### PR TITLE
Feature/task graph processor

### DIFF
--- a/src/core/task-graph/TaskGraphProcessor.ts
+++ b/src/core/task-graph/TaskGraphProcessor.ts
@@ -1,0 +1,49 @@
+import { createHash } from "node:crypto";
+import {
+  RawAnalyzedRequestSchema,
+  TaskGraphSchema,
+} from "../../schemas/pipeline.js";
+import type { RawTask, Task, TaskGraph } from "../../schemas/pipeline.js";
+
+/**
+ * Role 1의 최소 output을 받아 실행 가능한 TaskGraph로 변환합니다.
+ *
+ * 책임:
+ * - Role 1 output 파싱 및 스키마 검증
+ * - intent 폐기 (TaskGraph에 포함하지 않음)
+ * - 누락 필드 보강: title, status, input_hash
+ */
+export class TaskGraphProcessor {
+  static process(rawInput: unknown): TaskGraph {
+    const analyzed = RawAnalyzedRequestSchema.parse(rawInput);
+    const tasks: Task[] = analyzed.tasks.map((raw) => this.enrichTask(raw));
+    return TaskGraphSchema.parse({ tasks });
+  }
+
+  private static enrichTask(raw: RawTask): Task {
+    return {
+      id: raw.id,
+      type: raw.type,
+      title: raw.title ?? this.deriveTitle(raw),
+      description: raw.description,
+      status: "pending",
+      input_hash: this.computeInputHash(raw),
+      depends_on: raw.depends_on,
+    };
+  }
+
+  private static deriveTitle(raw: RawTask): string {
+    const type = raw.type.charAt(0).toUpperCase() + raw.type.slice(1);
+    return `${type} (${raw.id})`;
+  }
+
+  // id + type + depends_on 기반으로 task 고유 해시 생성
+  private static computeInputHash(raw: RawTask): string {
+    const content = JSON.stringify({
+      id: raw.id,
+      type: raw.type,
+      depends_on: [...raw.depends_on].sort(),
+    });
+    return createHash("sha256").update(content).digest("hex").slice(0, 16);
+  }
+}

--- a/src/core/task-graph/TaskGraphProcessor.ts
+++ b/src/core/task-graph/TaskGraphProcessor.ts
@@ -15,29 +15,49 @@ import type { RawTask, Task, TaskGraph } from "../../schemas/pipeline.js";
  */
 export class TaskGraphProcessor {
   static process(rawInput: unknown): TaskGraph {
+    // ① Role 1 output을 RawAnalyzedRequestSchema로 파싱
+    //    → { intent: "...", tasks: [{ id, type, depends_on }] } 구조 검증
+    //    → 스키마에 맞지 않으면 여기서 ZodError 발생
     const analyzed = RawAnalyzedRequestSchema.parse(rawInput);
+
+    // ② intent 폐기
+    //    analyzed에는 intent와 tasks 두 필드가 있지만,
+    //    analyzed.tasks 만 꺼냄 → intent는 이 줄 이후로 사용되지 않음
+    //    (TaskGraph 스키마에 intent 필드가 없으므로 포함시키지 않음)
     const tasks: Task[] = analyzed.tasks.map((raw) => this.enrichTask(raw));
+
+    // ③ TaskGraph로 변환
+    //    TaskGraphSchema는 { tasks: Task[] } 구조
+    //    enrichTask로 보강된 tasks 배열을 넣어 최종 TaskGraph 완성
+    //    → 여기서도 Zod 검증이 한 번 더 실행되어 완전한 구조 보장
     return TaskGraphSchema.parse({ tasks });
   }
 
   private static enrichTask(raw: RawTask): Task {
+    // Role 1이 준 최소 필드(id, type, depends_on)에
+    // Role 2.1이 나머지 필수 필드를 채워 완전한 Task로 만듦
     return {
       id: raw.id,
       type: raw.type,
+      // Role 1이 title을 줬으면 그대로, 없으면 자동 생성
       title: raw.title ?? this.deriveTitle(raw),
       description: raw.description,
+      // 모든 task는 처음엔 항상 대기 상태로 시작
       status: "pending",
+      // task 내용 기반 고유 해시 (변경 감지 및 캐싱용)
       input_hash: this.computeInputHash(raw),
       depends_on: raw.depends_on,
     };
   }
 
   private static deriveTitle(raw: RawTask): string {
+    // "create" → "Create (t1)" 형태로 읽기 쉬운 제목 생성
     const type = raw.type.charAt(0).toUpperCase() + raw.type.slice(1);
     return `${type} (${raw.id})`;
   }
 
   // id + type + depends_on 기반으로 task 고유 해시 생성
+  // depends_on을 sort()하는 이유: 순서가 달라도 같은 의존성이면 동일 해시가 나와야 하기 때문
   private static computeInputHash(raw: RawTask): string {
     const content = JSON.stringify({
       id: raw.id,

--- a/src/schemas/pipeline.ts
+++ b/src/schemas/pipeline.ts
@@ -142,6 +142,23 @@ export const SessionStateSchema = z.object({
   updated_at: z.string().datetime().optional(),
 });
 
+// Role 1이 실제로 보내는 최소 구조 (TaskGraphProcessor 입력용)
+export const RawTaskSchema = z.object({
+  id: z.string().min(1),
+  type: RequestCategorySchema,
+  depends_on: z.array(z.string()).default([]),
+  title: z.string().optional(),
+  description: z.string().optional(),
+});
+
+export const RawAnalyzedRequestSchema = z.object({
+  intent: z.string(),
+  tasks: z.array(RawTaskSchema).default([]),
+});
+
+export type RawTask = z.infer<typeof RawTaskSchema>;
+export type RawAnalyzedRequest = z.infer<typeof RawAnalyzedRequestSchema>;
+
 export type UserRequest = z.infer<typeof UserRequestSchema>;
 export type RequestCategory = z.infer<typeof RequestCategorySchema>;
 export type CompiledPrompt = z.infer<typeof CompiledPromptSchema>;


### PR DESCRIPTION
## 요약

- Role 1의 output(`intent`, `tasks[]`)을 받아 실행 가능한 `TaskGraph`로 변환하는 `TaskGraphProcessor` 구현
- `intent`는 파싱 후 폐기 — `TaskGraph` 스키마에 포함하지 않음
- 누락 필드(`status`, `title`, `input_hash`)를 Role 2.1에서 자동 보강하여 이후 DAGValidator에서 바로 사용 가능한 구조 생성

## 관련 이슈

- Closes #23 

## 변경 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [ ] 테스트 추가/수정

## 영향 범위

- 영향받는 모듈:
  - `src/schemas/pipeline.ts` — `RawTaskSchema`, `RawAnalyzedRequestSchema` 추가
  - `src/core/task-graph/TaskGraphProcessor.ts` — 신규 생성
- 영향받지 않는 모듈:
  - `src/core/state/` (Role 2.2 모듈)
  - `src/core/context/` (Role 2.2 모듈)

## 테스트 방법

1. `npm run typecheck` — 타입 에러 없음 확인
2. 아래 입력으로 `TaskGraphProcessor.process()` 호출 시 정상 변환 확인:
```json
{
  "intent": "multi_step_dev_request",
  "tasks": [
    { "id": "t1", "type": "create", "depends_on": [] },
    { "id": "t2", "type": "validate", "depends_on": ["t1"] }
  ]
}
```
3. 반환된 `TaskGraph`에 `intent` 미포함 확인
4. 각 Task에 `status: "pending"`, `title`, `input_hash` 자동 보강 확인
5. 스키마 불일치 입력 시 ZodError 발생 확인

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [ ] 필요한 경우 테스트를 추가하거나 수정했습니다
- [ ] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 스크린샷 / 로그

```
> detoks@0.1.0 typecheck
> tsc --noEmit -p tsconfig.json

(0 errors)
```

## 리뷰어 참고사항

- `RawTaskSchema`는 Role 1 실제 output 구조(최소 필드)를 반영한 것으로 기존 `TaskSchema`와 별도 분리
- `priority`, `owner_role`은 optional이므로 현재 미보강 — 이후 필요 시 추가 예정
