### PR TITLE
refactor: move CLI orchestration into core pipeline

### DIFF
--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -1,29 +1,9 @@
+import { orchestratePipeline } from "../../core/pipeline/orchestrator.js";
 import type { CliExecutionResult, NormalizedCliRequest } from "../types.js";
 
-const buildStages = (): CliExecutionResult["stages"] => [
-  { name: "Prompt Compiler", owner: "role1", status: "stubbed" },
-  { name: "Request Analyzer", owner: "role1", status: "stubbed" },
-  { name: "Task Graph Builder", owner: "role2.1", status: "stubbed" },
-  { name: "Context Optimizer", owner: "role2.2", status: "stubbed" },
-  { name: "Executor", owner: "role3", status: "ready" },
-  { name: "State Manager", owner: "role2.2", status: "stubbed" },
-];
-
 /**
- * Thin orchestration boundary for one-shot execution.
- * Real stage implementations are intentionally delegated to their owners.
+ * CLI boundary function.
+ * Execution orchestration lives in core/pipeline.
  */
-export const runCommand = async (request: NormalizedCliRequest): Promise<CliExecutionResult> => {
-  const prompt = request.userRequest.raw_input;
-  const shortPrompt = prompt.length > 96 ? `${prompt.slice(0, 93)}...` : prompt;
-
-  return {
-    ok: true,
-    mode: request.mode,
-    adapter: request.adapter,
-    summary: `stub executor accepted prompt (${prompt.length} chars)`,
-    nextAction: "connect core pipeline modules behind this boundary",
-    stages: buildStages(),
-    rawOutput: `[stub:${request.adapter}] ${shortPrompt}`,
-  };
-};
+export const runCommand = async (request: NormalizedCliRequest): Promise<CliExecutionResult> =>
+  orchestratePipeline(request);

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,9 +1,13 @@
-import type { UserRequest } from "../schemas/pipeline.js";
+import { AdapterValues as CoreAdapterValues } from "../core/pipeline/types.js";
+import type {
+  Adapter,
+  InteractionMode,
+  PipelineExecutionRequest,
+  PipelineExecutionResult,
+} from "../core/pipeline/types.js";
 
-export const AdapterValues = ["codex", "gemini"] as const;
-export type Adapter = (typeof AdapterValues)[number];
-
-export type CliMode = "run" | "repl";
+export const AdapterValues = CoreAdapterValues;
+export type CliMode = InteractionMode;
 
 export interface CliArgs {
   mode: CliMode;
@@ -12,25 +16,5 @@ export interface CliArgs {
   verbose: boolean;
 }
 
-export interface NormalizedCliRequest {
-  mode: CliMode;
-  adapter: Adapter;
-  verbose: boolean;
-  userRequest: UserRequest;
-}
-
-export interface PipelineStageStatus {
-  name: string;
-  owner: "role1" | "role2.1" | "role2.2" | "role3";
-  status: "ready" | "stubbed";
-}
-
-export interface CliExecutionResult {
-  ok: boolean;
-  mode: CliMode;
-  adapter: Adapter;
-  summary: string;
-  nextAction: string;
-  stages: PipelineStageStatus[];
-  rawOutput: string;
-}
+export type NormalizedCliRequest = PipelineExecutionRequest;
+export type CliExecutionResult = PipelineExecutionResult;

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1,0 +1,31 @@
+import type { PipelineExecutionRequest, PipelineExecutionResult } from "./types.js";
+
+const buildStages = (): PipelineExecutionResult["stages"] => [
+  { name: "Prompt Compiler", owner: "role1", status: "stubbed" },
+  { name: "Request Analyzer", owner: "role1", status: "stubbed" },
+  { name: "Task Graph Builder", owner: "role2.1", status: "stubbed" },
+  { name: "Context Optimizer", owner: "role2.2", status: "stubbed" },
+  { name: "Executor", owner: "role3", status: "ready" },
+  { name: "State Manager", owner: "role2.2", status: "stubbed" },
+];
+
+/**
+ * Core pipeline orchestration boundary (stub).
+ * Stage internals remain owned by each role and are intentionally not implemented here.
+ */
+export const orchestratePipeline = async (
+  request: PipelineExecutionRequest,
+): Promise<PipelineExecutionResult> => {
+  const prompt = request.userRequest.raw_input;
+  const shortPrompt = prompt.length > 96 ? `${prompt.slice(0, 93)}...` : prompt;
+
+  return {
+    ok: true,
+    mode: request.mode,
+    adapter: request.adapter,
+    summary: `stub executor accepted prompt (${prompt.length} chars)`,
+    nextAction: "connect core pipeline modules behind this boundary",
+    stages: buildStages(),
+    rawOutput: `[stub:${request.adapter}] ${shortPrompt}`,
+  };
+};

--- a/src/core/pipeline/types.ts
+++ b/src/core/pipeline/types.ts
@@ -1,0 +1,28 @@
+import type { UserRequest } from "../../schemas/pipeline.js";
+
+export const AdapterValues = ["codex", "gemini"] as const;
+export type Adapter = (typeof AdapterValues)[number];
+export type InteractionMode = "run" | "repl";
+
+export interface PipelineExecutionRequest {
+  mode: InteractionMode;
+  adapter: Adapter;
+  verbose: boolean;
+  userRequest: UserRequest;
+}
+
+export interface PipelineStageStatus {
+  name: string;
+  owner: "role1" | "role2.1" | "role2.2" | "role3";
+  status: "ready" | "stubbed";
+}
+
+export interface PipelineExecutionResult {
+  ok: boolean;
+  mode: InteractionMode;
+  adapter: Adapter;
+  summary: string;
+  nextAction: string;
+  stages: PipelineStageStatus[];
+  rawOutput: string;
+}

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { orchestratePipeline } from "../../../../../src/core/pipeline/orchestrator.js";
+
+describe("orchestratePipeline", () => {
+  it("returns the current stubbed pipeline result shape", async () => {
+    const result = await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      verbose: false,
+      userRequest: {
+        raw_input: "hello detoks",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.mode).toBe("run");
+    expect(result.adapter).toBe("codex");
+    expect(result.summary).toContain("stub executor accepted prompt");
+    expect(result.stages).toHaveLength(6);
+    expect(result.rawOutput).toBe("[stub:codex] hello detoks");
+  });
+});


### PR DESCRIPTION
## 요약
  - CLI 계층에 있던 stub 실행 orchestration을 `src/core/pipeline` 경계 뒤로 이동했습니다.
  - `src/cli`는 입력 파싱/모드 분기/출력 라우팅에 더 집중하고, 실행 흐름은 core pipeline
  계층에서 담당하도록 구조를 정리했습니다.
  - 현재 stub 동작은 유지하면서 이후 Prompt Compiler / Request Analyzer / Task Graph /
  Context / State 연결이 쉬운 형태로 리팩터링했습니다.

  ## 관련 이슈
  - Closes #TODO
  - Related to #TODO

  ## 변경 유형
  - [ ] 기능 추가
  - [ ] 버그 수정
  - [x] 리팩터링
  - [ ] 문서 수정
  - [x] 테스트 추가/수정

  ## 영향 범위
  - 영향받는 모듈:
    - `src/cli/commands/run.ts`
    - `src/cli/types.ts`
    - `src/core/pipeline/orchestrator.ts`
    - `src/core/pipeline/types.ts`
    - `tests/ts/unit/core/pipeline/orchestrator.test.ts`
  - 영향받지 않는 모듈:
    - Role 1 Python 영역
    - adapter 실제 구현 계층
    - session/state 실제 영속화 로직

  ## 테스트 방법
  1. `npm run typecheck`
  2. `npx vitest run tests/ts/unit/cli/parse.test.ts tests/ts/unit/core/pipeline/
  orchestrator.test.ts`
  3. one-shot / stub orchestration 흐름이 기존과 동일한지 확인

  ## 체크리스트
  - [x] 로컬에서 테스트했습니다
  - [x] 필요한 경우 테스트를 추가하거나 수정했습니다
  - [ ] 필요한 경우 문서를 수정했습니다
  - [x] 브레이킹 체인지 여부를 확인했습니다
  - [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

  ## 스크린샷 / 로그
  <!-- 필요한 경우 스크린샷, 터미널 출력, 로그 등을 첨부하세요 -->

  - `npm run typecheck` 통과
  - `npx vitest run tests/ts/unit/cli/parse.test.ts tests/ts/unit/core/pipeline/
  orchestrator.test.ts` 통과

  ## 리뷰어 참고사항
  <!-- 리뷰어가 특히 봐야 할 부분이나 참고해야 할 내용을 적어주세요 -->

  - 이번 변경은 “실행 흐름의 위치 이동”이 핵심입니다.
  - CLI가 얇아졌는지, orchestration 책임이 `src/core/pipeline`으로 분리됐는지 중심으로 봐
  주세요.
  - 실제 adapter 실행/Prompt Compiler 연결은 아직 stub 상태입니다.

  ———

