### PR TITLE
feat: add adapter execution boundary

### DIFF
--- a/src/core/executor/execute.ts
+++ b/src/core/executor/execute.ts
@@ -1,0 +1,31 @@
+import type { Adapter } from "../pipeline/types.js";
+import type { ExecutorRequest, ExecutorResult } from "./types.js";
+import type { CliAdapter } from "../../integrations/adapters/interface.js";
+import { CodexStubAdapter } from "../../integrations/adapters/codex/adapter.js";
+import { GeminiStubAdapter } from "../../integrations/adapters/gemini/adapter.js";
+
+const adapterRegistry: Record<Adapter, CliAdapter> = {
+  codex: new CodexStubAdapter(),
+  gemini: new GeminiStubAdapter(),
+};
+
+export const getAdapter = (adapter: Adapter): CliAdapter => adapterRegistry[adapter];
+
+export const executeWithAdapter = async (request: ExecutorRequest): Promise<ExecutorResult> => {
+  const adapter = getAdapter(request.adapter);
+  const result = await adapter.execute({
+    mode: request.mode,
+    prompt: request.prompt,
+    verbose: request.verbose,
+    ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+    ...(request.sessionId !== undefined ? { sessionId: request.sessionId } : {}),
+  });
+
+  return {
+    ok: result.success,
+    adapter: request.adapter,
+    rawOutput: result.rawOutput,
+    exitCode: result.exitCode,
+    ...(result.stderr !== undefined ? { stderr: result.stderr } : {}),
+  };
+};

--- a/src/core/executor/types.ts
+++ b/src/core/executor/types.ts
@@ -1,0 +1,28 @@
+import type { Adapter, InteractionMode } from "../pipeline/types.js";
+
+export interface AdapterExecutionRequest {
+  mode: InteractionMode;
+  prompt: string;
+  verbose: boolean;
+  cwd?: string;
+  sessionId?: string;
+}
+
+export interface AdapterExecutionResult {
+  success: boolean;
+  rawOutput: string;
+  exitCode: number;
+  stderr?: string;
+}
+
+export interface ExecutorRequest extends AdapterExecutionRequest {
+  adapter: Adapter;
+}
+
+export interface ExecutorResult {
+  ok: boolean;
+  adapter: Adapter;
+  rawOutput: string;
+  exitCode: number;
+  stderr?: string;
+}

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1,3 +1,4 @@
+import { executeWithAdapter } from "../executor/execute.js";
 import type { PipelineExecutionRequest, PipelineExecutionResult } from "./types.js";
 
 const buildStages = (): PipelineExecutionResult["stages"] => [
@@ -17,15 +18,24 @@ export const orchestratePipeline = async (
   request: PipelineExecutionRequest,
 ): Promise<PipelineExecutionResult> => {
   const prompt = request.userRequest.raw_input;
-  const shortPrompt = prompt.length > 96 ? `${prompt.slice(0, 93)}...` : prompt;
+  const execution = await executeWithAdapter({
+    adapter: request.adapter,
+    mode: request.mode,
+    prompt,
+    verbose: request.verbose,
+    ...(request.userRequest.cwd !== undefined ? { cwd: request.userRequest.cwd } : {}),
+    ...(request.userRequest.session_id !== undefined
+      ? { sessionId: request.userRequest.session_id }
+      : {}),
+  });
 
   return {
-    ok: true,
+    ok: execution.ok,
     mode: request.mode,
     adapter: request.adapter,
     summary: `stub executor accepted prompt (${prompt.length} chars)`,
     nextAction: "connect core pipeline modules behind this boundary",
     stages: buildStages(),
-    rawOutput: `[stub:${request.adapter}] ${shortPrompt}`,
+    rawOutput: execution.rawOutput,
   };
 };

--- a/src/integrations/adapters/codex/adapter.ts
+++ b/src/integrations/adapters/codex/adapter.ts
@@ -1,0 +1,15 @@
+import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../../core/executor/types.js";
+import type { CliAdapter } from "../interface.js";
+import { buildStubRawOutput } from "../stub.js";
+
+export class CodexStubAdapter implements CliAdapter {
+  readonly target = "codex" as const;
+
+  async execute(request: AdapterExecutionRequest): Promise<AdapterExecutionResult> {
+    return {
+      success: true,
+      rawOutput: buildStubRawOutput(this.target, request.prompt),
+      exitCode: 0,
+    };
+  }
+}

--- a/src/integrations/adapters/gemini/adapter.ts
+++ b/src/integrations/adapters/gemini/adapter.ts
@@ -1,0 +1,15 @@
+import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../../core/executor/types.js";
+import type { CliAdapter } from "../interface.js";
+import { buildStubRawOutput } from "../stub.js";
+
+export class GeminiStubAdapter implements CliAdapter {
+  readonly target = "gemini" as const;
+
+  async execute(request: AdapterExecutionRequest): Promise<AdapterExecutionResult> {
+    return {
+      success: true,
+      rawOutput: buildStubRawOutput(this.target, request.prompt),
+      exitCode: 0,
+    };
+  }
+}

--- a/src/integrations/adapters/interface.ts
+++ b/src/integrations/adapters/interface.ts
@@ -1,0 +1,7 @@
+import type { Adapter } from "../../core/pipeline/types.js";
+import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../core/executor/types.js";
+
+export interface CliAdapter {
+  readonly target: Adapter;
+  execute(request: AdapterExecutionRequest): Promise<AdapterExecutionResult>;
+}

--- a/src/integrations/adapters/stub.ts
+++ b/src/integrations/adapters/stub.ts
@@ -1,0 +1,7 @@
+import type { Adapter } from "../../core/pipeline/types.js";
+
+const truncatePrompt = (prompt: string): string =>
+  prompt.length > 96 ? `${prompt.slice(0, 93)}...` : prompt;
+
+export const buildStubRawOutput = (adapter: Adapter, prompt: string): string =>
+  `[stub:${adapter}] ${truncatePrompt(prompt)}`;

--- a/tests/ts/unit/core/executor/execute.test.ts
+++ b/tests/ts/unit/core/executor/execute.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { executeWithAdapter } from "../../../../../src/core/executor/execute.js";
+
+describe("executeWithAdapter", () => {
+  it("routes to the codex stub adapter", async () => {
+    const result = await executeWithAdapter({
+      adapter: "codex",
+      mode: "run",
+      prompt: "hello codex",
+      verbose: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.adapter).toBe("codex");
+    expect(result.rawOutput).toBe("[stub:codex] hello codex");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("routes to the gemini stub adapter", async () => {
+    const result = await executeWithAdapter({
+      adapter: "gemini",
+      mode: "run",
+      prompt: "hello gemini",
+      verbose: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.adapter).toBe("gemini");
+    expect(result.rawOutput).toBe("[stub:gemini] hello gemini");
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## 요약
  - Codex / Gemini 통합을 위한 adapter execution boundary를 추가했습니다.
  - executor 계층과 adapter 계층의 request/response 계약을 정의하고, 각 target CLI에 대한
  stub adapter를 추가했습니다.
  - 기존 pipeline orchestration은 새로운 executor boundary를 통해 adapter를 호출하도록 연
  결했습니다.

  ## 관련 이슈
  - Closes #TODO
  - Related to #TODO

  ## 변경 유형
  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 리팩터링
  - [ ] 문서 수정
  - [x] 테스트 추가/수정

  ## 영향 범위
  - 영향받는 모듈:
    - `src/core/executor/execute.ts`
    - `src/core/executor/types.ts`
    - `src/integrations/adapters/interface.ts`
    - `src/integrations/adapters/stub.ts`
    - `src/integrations/adapters/codex/adapter.ts`
    - `src/integrations/adapters/gemini/adapter.ts`
    - `src/core/pipeline/orchestrator.ts`
    - `tests/ts/unit/core/executor/execute.test.ts`
  - 영향받지 않는 모듈:
    - Role 1 Python 영역
    - 실제 subprocess 실행 구현
    - 실제 Prompt Compiler / Request Analyzer / Task Graph / Context / State 내부 로직

  ## 테스트 방법
  1. `npm run typecheck`
  2. `npx vitest run tests/ts/unit/core/pipeline/orchestrator.test.ts tests/ts/unit/core/
  executor/execute.test.ts tests/ts/unit/cli/parse.test.ts`
  3. stub adapter를 통해 pipeline → executor → adapter 흐름이 유지되는지 확인

  ## 체크리스트
  - [x] 로컬에서 테스트했습니다
  - [x] 필요한 경우 테스트를 추가하거나 수정했습니다
  - [ ] 필요한 경우 문서를 수정했습니다
  - [x] 브레이킹 체인지 여부를 확인했습니다
  - [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

  ## 스크린샷 / 로그
  <!-- 필요한 경우 스크린샷, 터미널 출력, 로그 등을 첨부하세요 -->

  - `npm run typecheck` 통과
  - 관련 vitest 테스트 3개 파일 통과

  ## 리뷰어 참고사항
  <!-- 리뷰어가 특히 봐야 할 부분이나 참고해야 할 내용을 적어주세요 -->

  - 이번 변경은 실제 외부 CLI 실행이 아니라 adapter contract와 executor boundary를 추가하
  는 작업입니다.
  - pipeline이 executor를 통해 adapter를 호출하도록 경로가 바뀌었는지 확인해주세요.
  - codex/gemini adapter는 현재 stub 구현입니다.

  ———

