### PR TITLE
feat: add subprocess execution boundary

### DIFF
--- a/src/core/executor/execute.ts
+++ b/src/core/executor/execute.ts
@@ -3,6 +3,7 @@ import type { ExecutorRequest, ExecutorResult } from "./types.js";
 import type { CliAdapter } from "../../integrations/adapters/interface.js";
 import { CodexStubAdapter } from "../../integrations/adapters/codex/adapter.js";
 import { GeminiStubAdapter } from "../../integrations/adapters/gemini/adapter.js";
+import { createStubSubprocessRunner } from "../../integrations/subprocess/runner.js";
 
 const adapterRegistry: Record<Adapter, CliAdapter> = {
   codex: new CodexStubAdapter(),
@@ -13,12 +14,15 @@ export const getAdapter = (adapter: Adapter): CliAdapter => adapterRegistry[adap
 
 export const executeWithAdapter = async (request: ExecutorRequest): Promise<ExecutorResult> => {
   const adapter = getAdapter(request.adapter);
+  const subprocessRunner = createStubSubprocessRunner();
   const result = await adapter.execute({
     mode: request.mode,
     prompt: request.prompt,
     verbose: request.verbose,
     ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
     ...(request.sessionId !== undefined ? { sessionId: request.sessionId } : {}),
+  }, {
+    subprocessRunner,
   });
 
   return {

--- a/src/integrations/adapters/codex/adapter.ts
+++ b/src/integrations/adapters/codex/adapter.ts
@@ -1,11 +1,14 @@
 import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../../core/executor/types.js";
-import type { CliAdapter } from "../interface.js";
+import type { AdapterExecutionContext, CliAdapter } from "../interface.js";
 import { buildStubRawOutput } from "../stub.js";
 
 export class CodexStubAdapter implements CliAdapter {
   readonly target = "codex" as const;
 
-  async execute(request: AdapterExecutionRequest): Promise<AdapterExecutionResult> {
+  async execute(
+    request: AdapterExecutionRequest,
+    _context?: AdapterExecutionContext,
+  ): Promise<AdapterExecutionResult> {
     return {
       success: true,
       rawOutput: buildStubRawOutput(this.target, request.prompt),

--- a/src/integrations/adapters/gemini/adapter.ts
+++ b/src/integrations/adapters/gemini/adapter.ts
@@ -1,11 +1,14 @@
 import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../../core/executor/types.js";
-import type { CliAdapter } from "../interface.js";
+import type { AdapterExecutionContext, CliAdapter } from "../interface.js";
 import { buildStubRawOutput } from "../stub.js";
 
 export class GeminiStubAdapter implements CliAdapter {
   readonly target = "gemini" as const;
 
-  async execute(request: AdapterExecutionRequest): Promise<AdapterExecutionResult> {
+  async execute(
+    request: AdapterExecutionRequest,
+    _context?: AdapterExecutionContext,
+  ): Promise<AdapterExecutionResult> {
     return {
       success: true,
       rawOutput: buildStubRawOutput(this.target, request.prompt),

--- a/src/integrations/adapters/interface.ts
+++ b/src/integrations/adapters/interface.ts
@@ -1,7 +1,15 @@
 import type { Adapter } from "../../core/pipeline/types.js";
 import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../core/executor/types.js";
+import type { SubprocessRunner } from "../subprocess/types.js";
+
+export interface AdapterExecutionContext {
+  subprocessRunner: SubprocessRunner;
+}
 
 export interface CliAdapter {
   readonly target: Adapter;
-  execute(request: AdapterExecutionRequest): Promise<AdapterExecutionResult>;
+  execute(
+    request: AdapterExecutionRequest,
+    context?: AdapterExecutionContext,
+  ): Promise<AdapterExecutionResult>;
 }

--- a/src/integrations/subprocess/index.ts
+++ b/src/integrations/subprocess/index.ts
@@ -1,0 +1,2 @@
+export * from "./runner.js";
+export * from "./types.js";

--- a/src/integrations/subprocess/runner.ts
+++ b/src/integrations/subprocess/runner.ts
@@ -1,0 +1,17 @@
+import type { SubprocessRequest, SubprocessResult, SubprocessRunner } from "./types.js";
+
+const formatCommand = (request: SubprocessRequest): string => {
+  const args = request.args.length > 0 ? ` ${request.args.join(" ")}` : "";
+  return `${request.command}${args}`;
+};
+
+export const createStubSubprocessRunner = (): SubprocessRunner => ({
+  async run(request: SubprocessRequest): Promise<SubprocessResult> {
+    return {
+      stdout: `[stub:subprocess] ${formatCommand(request)}`,
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+    };
+  },
+});

--- a/src/integrations/subprocess/types.ts
+++ b/src/integrations/subprocess/types.ts
@@ -1,0 +1,18 @@
+export interface SubprocessRequest {
+  command: string;
+  args: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  input?: string;
+}
+
+export interface SubprocessResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  timedOut: boolean;
+}
+
+export interface SubprocessRunner {
+  run(request: SubprocessRequest): Promise<SubprocessResult>;
+}

--- a/tests/ts/unit/integrations/subprocess/runner.test.ts
+++ b/tests/ts/unit/integrations/subprocess/runner.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { createStubSubprocessRunner } from "../../../../../src/integrations/subprocess/runner.js";
+
+describe("createStubSubprocessRunner", () => {
+  it("returns a stub subprocess result", async () => {
+    const runner = createStubSubprocessRunner();
+    const result = await runner.run({
+      command: "codex",
+      args: ["--help"],
+    });
+
+    expect(result.stdout).toBe("[stub:subprocess] codex --help");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+  });
+});


### PR DESCRIPTION
## 요약
  - adapter 계층 뒤에 subprocess execution boundary를 추가했습니다.
  - executor가 adapter 실행 시 subprocess runner context를 전달할 수 있도록 인터페이스를
  확장했습니다.
  - 향후 real codex/gemini 실행으로 전환할 수 있도록 subprocess request/result 계약과
  stub runner를 추가했습니다.

  ## 관련 이슈
  - Closes #TODO
  - Related to #TODO

  ## 변경 유형
  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 리팩터링
  - [ ] 문서 수정
  - [x] 테스트 추가/수정

  ## 영향 범위
  - 영향받는 모듈:
    - `src/core/executor/execute.ts`
    - `src/integrations/adapters/interface.ts`
    - `src/integrations/adapters/codex/adapter.ts`
    - `src/integrations/adapters/gemini/adapter.ts`
    - `src/integrations/subprocess/index.ts`
    - `src/integrations/subprocess/runner.ts`
    - `src/integrations/subprocess/types.ts`
    - `tests/ts/unit/integrations/subprocess/runner.test.ts`
  - 영향받지 않는 모듈:
    - Role 1 Python 영역
    - 실제 LLM 분석 단계
    - 상태 관리 로직
    - 실제 외부 CLI 실행 구현

  ## 테스트 방법
  1. `npm run typecheck`
  2. `npx vitest run tests/ts/unit/core/pipeline/orchestrator.test.ts tests/ts/unit/core/
  executor/execute.test.ts tests/ts/unit/cli/parse.test.ts`
  3. `npx vitest run tests/ts/unit/integrations/subprocess/runner.test.ts`

  ## 체크리스트
  - [x] 로컬에서 테스트했습니다
  - [x] 필요한 경우 테스트를 추가하거나 수정했습니다
  - [ ] 필요한 경우 문서를 수정했습니다
  - [x] 브레이킹 체인지 여부를 확인했습니다
  - [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

  ## 스크린샷 / 로그
  <!-- 필요한 경우 스크린샷, 터미널 출력, 로그 등을 첨부하세요 -->

  - subprocess runner stub test added
  - typecheck passed
  - related unit tests passed

  ## 리뷰어 참고사항
  <!-- 리뷰어가 특히 봐야 할 부분이나 참고해야 할 내용을 적어주세요 -->

  - 이번 변경은 real subprocess 실행이 아니라 그 경계 계약을 추가하는 작업입니다.
  - adapter가 execution context로 subprocess runner를 받도록 인터페이스가 바뀌었습니다.
  - codex/gemini adapter는 아직 stub 동작을 유지합니다.

  ———

