### PR TITLE
feat: add real adapter execution path contract

### DIFF
--- a/src/integrations/adapters/codex/adapter.ts
+++ b/src/integrations/adapters/codex/adapter.ts
@@ -5,6 +5,15 @@ import { buildStubRawOutput } from "../stub.js";
 export class CodexStubAdapter implements CliAdapter {
   readonly target = "codex" as const;
 
+  buildSubprocessRequest(request: AdapterExecutionRequest) {
+    return {
+      command: "codex",
+      args: [],
+      ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+      input: request.prompt,
+    };
+  }
+
   async execute(
     request: AdapterExecutionRequest,
     _context?: AdapterExecutionContext,

--- a/src/integrations/adapters/gemini/adapter.ts
+++ b/src/integrations/adapters/gemini/adapter.ts
@@ -5,6 +5,15 @@ import { buildStubRawOutput } from "../stub.js";
 export class GeminiStubAdapter implements CliAdapter {
   readonly target = "gemini" as const;
 
+  buildSubprocessRequest(request: AdapterExecutionRequest) {
+    return {
+      command: "gemini",
+      args: [],
+      ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+      input: request.prompt,
+    };
+  }
+
   async execute(
     request: AdapterExecutionRequest,
     _context?: AdapterExecutionContext,

--- a/src/integrations/adapters/interface.ts
+++ b/src/integrations/adapters/interface.ts
@@ -1,6 +1,6 @@
 import type { Adapter } from "../../core/pipeline/types.js";
 import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../core/executor/types.js";
-import type { SubprocessRunner } from "../subprocess/types.js";
+import type { SubprocessRequest, SubprocessRunner } from "../subprocess/types.js";
 
 export interface AdapterExecutionContext {
   subprocessRunner: SubprocessRunner;
@@ -8,6 +8,7 @@ export interface AdapterExecutionContext {
 
 export interface CliAdapter {
   readonly target: Adapter;
+  buildSubprocessRequest(request: AdapterExecutionRequest): SubprocessRequest;
   execute(
     request: AdapterExecutionRequest,
     context?: AdapterExecutionContext,

--- a/src/integrations/adapters/real.ts
+++ b/src/integrations/adapters/real.ts
@@ -1,0 +1,18 @@
+import type { AdapterExecutionContext, CliAdapter } from "./interface.js";
+import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../core/executor/types.js";
+
+export const executeAdapterViaSubprocess = async (
+  adapter: CliAdapter,
+  request: AdapterExecutionRequest,
+  context: AdapterExecutionContext,
+): Promise<AdapterExecutionResult> => {
+  const subprocessRequest = adapter.buildSubprocessRequest(request);
+  const result = await context.subprocessRunner.run(subprocessRequest);
+
+  return {
+    success: !result.timedOut && result.exitCode === 0,
+    rawOutput: result.stdout,
+    exitCode: result.exitCode,
+    ...(result.stderr.length > 0 ? { stderr: result.stderr } : {}),
+  };
+};

--- a/tests/ts/unit/integrations/adapters/adapter-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/adapter-path.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { CodexStubAdapter } from "../../../../../src/integrations/adapters/codex/adapter.js";
+import { GeminiStubAdapter } from "../../../../../src/integrations/adapters/gemini/adapter.js";
+import { executeAdapterViaSubprocess } from "../../../../../src/integrations/adapters/real.js";
+import { createStubSubprocessRunner } from "../../../../../src/integrations/subprocess/runner.js";
+
+describe("adapter subprocess path", () => {
+  it("builds codex subprocess requests explicitly", () => {
+    const adapter = new CodexStubAdapter();
+    expect(
+      adapter.buildSubprocessRequest({
+        mode: "run",
+        prompt: "hello codex",
+        verbose: false,
+      }),
+    ).toEqual({
+      command: "codex",
+      args: [],
+      input: "hello codex",
+    });
+  });
+
+  it("builds gemini subprocess requests explicitly", () => {
+    const adapter = new GeminiStubAdapter();
+    expect(
+      adapter.buildSubprocessRequest({
+        mode: "run",
+        prompt: "hello gemini",
+        verbose: true,
+        cwd: "/tmp",
+      }),
+    ).toEqual({
+      command: "gemini",
+      args: [],
+      cwd: "/tmp",
+      input: "hello gemini",
+    });
+  });
+
+  it("routes a codex request through the subprocess boundary", async () => {
+    const adapter = new CodexStubAdapter();
+    const result = await executeAdapterViaSubprocess(
+      adapter,
+      {
+        mode: "run",
+        prompt: "hello subprocess",
+        verbose: false,
+      },
+      {
+        subprocessRunner: createStubSubprocessRunner(),
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.rawOutput).toBe("[stub:subprocess] codex");
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## 요약
  - Codex와 Gemini adapter가 실제 실행 경로로 확장될 수 있도록 공통 execution contract를
  추가했습니다.
  - adapter interface에 subprocess request 생성 경로를 명시하고, 공통 helper를 통해
  subprocess boundary를 통과하는 실행 흐름을 정의했습니다.
  - 현재 stub 동작은 유지하면서도, 이후 real CLI execution으로 전환할 수 있는 구조를 마련
  했습니다.

  ## 관련 이슈
  - Closes #TODO
  - Related to #TODO

  ## 변경 유형
  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 리팩터링
  - [ ] 문서 수정
  - [x] 테스트 추가/수정

  ## 영향 범위
  - 영향받는 모듈:
    - `src/integrations/adapters/interface.ts`
    - `src/integrations/adapters/real.ts`
    - `src/integrations/adapters/codex/adapter.ts`
    - `src/integrations/adapters/gemini/adapter.ts`
    - `tests/ts/unit/integrations/adapters/adapter-path.test.ts`
  - 영향받지 않는 모듈:
    - Role 1 Python 영역
    - 상태 관리 로직
    - Prompt Compiler / Request Analyzer / Task Graph / Context 내부 구현
    - 실제 외부 CLI 실행 구현 자체

  ## 테스트 방법
  1. `npm run typecheck`
  2. `npx vitest run tests/ts/unit/integrations/adapters/adapter-path.test.ts tests/ts/
  unit/integrations/subprocess/runner.test.ts tests/ts/unit/core/executor/
  execute.test.ts`
  3. adapter가 subprocess request를 명시적으로 생성하고, subprocess boundary를 통해 실행
  경로를 통과하는지 확인

  ## 체크리스트
  - [x] 로컬에서 테스트했습니다
  - [x] 필요한 경우 테스트를 추가하거나 수정했습니다
  - [ ] 필요한 경우 문서를 수정했습니다
  - [x] 브레이킹 체인지 여부를 확인했습니다
  - [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

  ## 스크린샷 / 로그
  <!-- 필요한 경우 스크린샷, 터미널 출력, 로그 등을 첨부하세요 -->

  - `npm run typecheck` 통과
  - 관련 adapter / subprocess / executor 테스트 통과

  ## 리뷰어 참고사항
  <!-- 리뷰어가 특히 봐야 할 부분이나 참고해야 할 내용을 적어주세요 -->

  - 이번 변경의 핵심은 “real execution path를 위한 계약 추가”입니다.
  - adapter interface에 `buildSubprocessRequest(...)`가 추가되었고,
  `executeAdapterViaSubprocess(...)` helper를 통해 subprocess boundary를 지나는 공통 경로
  를 만들었습니다.
  - 현재 codex/gemini adapter는 여전히 stub 실행을 유지합니다. 즉, 이번 PR은 실제 외부 바
  이너리 실행이 아니라 그 전 단계인 구조/계약 정리에 해당합니다.

