### PR TITLE
fix: redefining role of role1 and role 2.1

### DIFF
--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -33,21 +33,16 @@ type CompiledPrompt = {
 
 ---
 
-## 3. AnalyzedRequest
+## 3. CompiledSentences
 
 ```ts
-type AnalyzedRequest = {
-  category: string;
-  keywords: string[];
-  tasks: Array<{
-    id: string;
-    type: string;
-  }>;
+type CompiledSentences = {
+  sentences: string[];
 };
 ```
 
 **책임:** Role 1 (AI Prompt Engineer)  
-**설명:** 요청을 분류하고 Task 후보를 추출
+**설명:** 한국어 입력을 영어로 변환한 뒤 문장 단위로 분리한 결과. task 분해 / id / depends_on 생성은 Role 2.1 담당.
 
 ---
 

--- a/docs/SCHEMA_FLOW.md
+++ b/docs/SCHEMA_FLOW.md
@@ -13,7 +13,7 @@ detoks의 7단계 데이터 변환 흐름과 역할별 책임을 정의합니다
   ↓ (Role 1)
 CompiledPrompt
   ↓ (Role 1)
-AnalyzedRequest
+CompiledSentences
   ↓ (Role 2.1)
 TaskGraph
   ↓ (Role 2.2)
@@ -31,9 +31,9 @@ SessionState
 ### Role 1: AI Prompt Engineer
 
 **책임:**
-- 자연어 입력 정규화
-- 요청 분류 및 키워드 추출
-- Task 후보 추출
+- 한국어 → 영어 변환
+- 문장 단위 분리
+- 불필요한 정보 제거 (압축)
 
 **생성 데이터:**
 
@@ -48,17 +48,15 @@ type CompiledPrompt = {
 };
 ```
 
-#### 2. AnalyzedRequest
+#### 2. CompiledSentences
 
 ```ts
-type AnalyzedRequest = {
-  category: string;
-  keywords: string[];
-  tasks: Task[];
+type CompiledSentences = {
+  sentences: string[];
 };
 ```
 
-**의미:** 단순 문자열이 아닌 구조화된 요청으로 변환
+**의미:** task 분해 / id / depends_on 생성은 Role 2.1 전담. Role 1은 전처리만 담당.
 
 ---
 
@@ -177,7 +175,7 @@ type ExecutionResult = {
 |--------|------|------|
 | UserRequest | User | 입력 |
 | CompiledPrompt | Role 1 | 생성 |
-| AnalyzedRequest | Role 1 | 생성 |
+| CompiledSentences | Role 1 | 생성 |
 | TaskGraph | Role 2.1 | 생성 |
 | ExecutionContext | Role 2.2 | 생성 |
 | ExecutionRequest | Role 3 | 생성 |
@@ -218,7 +216,7 @@ type ExecutionResult = {
 ```ts
 UserRequestSchema
 CompiledPromptSchema
-AnalyzedRequestSchema
+CompiledSentencesSchema
 TaskSchema
 TaskGraphSchema
 ExecutionContextSchema

--- a/docs/SHARED_DATA_FLOW.md
+++ b/docs/SHARED_DATA_FLOW.md
@@ -9,7 +9,7 @@ The recommended flow is:
 ```text
 UserRequest
 → CompiledPrompt
-→ AnalyzedRequest
+→ CompiledSentences
 → TaskGraph
 → ExecutionContext
 → ExecutionResult
@@ -24,7 +24,7 @@ UserRequest
 
 ### Role 1: AI Prompt Engineer
 - produces `CompiledPrompt`
-- produces `AnalyzedRequest`
+- produces `CompiledSentences`
 
 ### Role 2.1: Task Graph Engineer
 - produces `TaskGraph`
@@ -49,19 +49,9 @@ Raw user input entering the system.
 ### 2. CompiledPrompt
 Compressed and normalized prompt output from the Prompt Compiler.
 
-### 3. AnalyzedRequest
-Classified request with extracted keywords and task candidates.
-
-Top-level category values should use the shared intent set below:
-
-- `explore`
-- `create`
-- `modify`
-- `analyze`
-- `validate`
-- `execute`
-- `document`
-- `plan`
+### 3. CompiledSentences
+Korean input translated to English and split into individual sentences.
+Task decomposition, id generation, and depends_on assignment are handled by Role 2.1.
 
 ### 4. TaskGraph
 Executable task structure with dependency order.
@@ -111,7 +101,7 @@ This file contains the shared Zod schemas for:
 - `UserRequest`
 - `RequestCategory`
 - `CompiledPrompt`
-- `AnalyzedRequest`
+- `CompiledSentences`
 - `Task`
 - `TaskGraph`
 - `ExecutionContext`

--- a/src/core/task-graph/TaskGraphProcessor.ts
+++ b/src/core/task-graph/TaskGraphProcessor.ts
@@ -1,69 +1,98 @@
 import { createHash } from "node:crypto";
 import {
-  RawAnalyzedRequestSchema,
+  CompiledSentencesSchema,
   TaskGraphSchema,
 } from "../../schemas/pipeline.js";
-import type { RawTask, Task, TaskGraph } from "../../schemas/pipeline.js";
+import type { Task, TaskGraph, RequestCategory } from "../../schemas/pipeline.js";
 
 /**
- * Role 1의 최소 output을 받아 실행 가능한 TaskGraph로 변환합니다.
+ * Role 1의 sentences[]를 받아 실행 가능한 TaskGraph로 변환합니다.
  *
- * 책임:
- * - Role 1 output 파싱 및 스키마 검증
- * - intent 폐기 (TaskGraph에 포함하지 않음)
- * - 누락 필드 보강: title, status, input_hash
+ * Role 1 담당: 한국어 → 영어 변환, 문장 단위 분리
+ * Role 2.1 담당:
+ *   - single / multi 요청 구분
+ *   - 각 문장 type 분류
+ *   - id 생성
+ *   - type 흐름 기반 depends_on 결정 (sequential vs parallel)
  */
 export class TaskGraphProcessor {
+  // type A → type B 가 "자연스러운 흐름"인 관계 정의
+  // 이 관계에 해당하면 sequential(의존), 해당하지 않으면 parallel(독립)
+  private static readonly FLOWS_TO: Partial<Record<RequestCategory, RequestCategory[]>> = {
+    explore:  ["analyze", "modify", "create", "validate"],
+    plan:     ["explore", "create", "execute"],
+    analyze:  ["modify", "validate", "document", "create"],
+    create:   ["validate", "modify", "document", "execute"],
+    modify:   ["validate", "document", "execute"],
+    validate: ["document", "execute", "modify"],
+    execute:  ["validate", "document"],
+    document: [],
+  };
+
   static process(rawInput: unknown): TaskGraph {
-    // ① Role 1 output을 RawAnalyzedRequestSchema로 파싱
-    //    → { intent: "...", tasks: [{ id, type, depends_on }] } 구조 검증
-    //    → 스키마에 맞지 않으면 여기서 ZodError 발생
-    const analyzed = RawAnalyzedRequestSchema.parse(rawInput);
+    const { sentences } = CompiledSentencesSchema.parse(rawInput);
 
-    // ② intent 폐기
-    //    analyzed에는 intent와 tasks 두 필드가 있지만,
-    //    analyzed.tasks 만 꺼냄 → intent는 이 줄 이후로 사용되지 않음
-    //    (TaskGraph 스키마에 intent 필드가 없으므로 포함시키지 않음)
-    const tasks: Task[] = analyzed.tasks.map((raw) => this.enrichTask(raw));
+    // single 요청: 문장 1개 → task 1개, depends_on 없음
+    if (sentences.length === 1) {
+      const sentence = sentences[0]!;
+      const type = this.classifyType(sentence);
+      const tasks = [this.buildTask(sentence, 0, type, [])];
+      return TaskGraphSchema.parse({ tasks });
+    }
 
-    // ③ TaskGraph로 변환
-    //    TaskGraphSchema는 { tasks: Task[] } 구조
-    //    enrichTask로 보강된 tasks 배열을 넣어 최종 TaskGraph 완성
-    //    → 여기서도 Zod 검증이 한 번 더 실행되어 완전한 구조 보장
+    // multi 요청: 먼저 모든 type을 분류한 뒤 흐름 기반으로 depends_on 결정
+    const types: RequestCategory[] = sentences.map((s) => this.classifyType(s));
+    const tasks: Task[] = sentences.map((sentence, index) => {
+      const type = types[index]!;
+      const dependsOn = this.resolveDependsOn(index, types);
+      return this.buildTask(sentence, index, type, dependsOn);
+    });
+
     return TaskGraphSchema.parse({ tasks });
   }
 
-  private static enrichTask(raw: RawTask): Task {
-    // Role 1이 준 최소 필드(id, type, depends_on)에
-    // Role 2.1이 나머지 필수 필드를 채워 완전한 Task로 만듦
+  // type 흐름이 자연스러우면 이전 task에 의존(sequential)
+  // 흐름이 끊기면 독립(parallel, depends_on: [])
+  private static resolveDependsOn(index: number, types: RequestCategory[]): string[] {
+    if (index === 0) return [];
+    const prev = types[index - 1] as RequestCategory;
+    const curr = types[index] as RequestCategory;
+    return this.FLOWS_TO[prev]?.includes(curr) ? [`t${index}`] : [];
+  }
+
+  private static buildTask(
+    sentence: string,
+    index: number,
+    type: RequestCategory,
+    dependsOn: string[]
+  ): Task {
+    const id = `t${index + 1}`;
     return {
-      id: raw.id,
-      type: raw.type,
-      // Role 1이 title을 줬으면 그대로, 없으면 자동 생성
-      title: raw.title ?? this.deriveTitle(raw),
-      description: raw.description,
-      // 모든 task는 처음엔 항상 대기 상태로 시작
+      id,
+      type,
+      title: sentence,
       status: "pending",
-      // task 내용 기반 고유 해시 (변경 감지 및 캐싱용)
-      input_hash: this.computeInputHash(raw),
-      depends_on: raw.depends_on,
+      input_hash: this.computeInputHash(id, type, sentence),
+      depends_on: dependsOn,
     };
   }
 
-  private static deriveTitle(raw: RawTask): string {
-    // "create" → "Create (t1)" 형태로 읽기 쉬운 제목 생성
-    const type = raw.type.charAt(0).toUpperCase() + raw.type.slice(1);
-    return `${type} (${raw.id})`;
+  // 영어 문장 키워드 기반 type 분류
+  private static classifyType(sentence: string): RequestCategory {
+    const s = sentence.toLowerCase();
+    if (/read|find|look|search|explore|browse|check/.test(s)) return "explore";
+    if (/create|implement|build|write|add|generate/.test(s))  return "create";
+    if (/modify|update|change|fix|edit|refactor/.test(s))     return "modify";
+    if (/analyze|review|inspect|investigate/.test(s))          return "analyze";
+    if (/test|validate|verify|assert/.test(s))                 return "validate";
+    if (/run|execute|deploy|start|launch/.test(s))             return "execute";
+    if (/document|docs|summarize|describe/.test(s))            return "document";
+    if (/plan|design|organize|structure|outline/.test(s))      return "plan";
+    return "execute";
   }
 
-  // id + type + depends_on 기반으로 task 고유 해시 생성
-  // depends_on을 sort()하는 이유: 순서가 달라도 같은 의존성이면 동일 해시가 나와야 하기 때문
-  private static computeInputHash(raw: RawTask): string {
-    const content = JSON.stringify({
-      id: raw.id,
-      type: raw.type,
-      depends_on: [...raw.depends_on].sort(),
-    });
+  private static computeInputHash(id: string, type: string, sentence: string): string {
+    const content = JSON.stringify({ id, type, sentence });
     return createHash("sha256").update(content).digest("hex").slice(0, 16);
   }
 }

--- a/src/schemas/pipeline.ts
+++ b/src/schemas/pipeline.ts
@@ -142,22 +142,12 @@ export const SessionStateSchema = z.object({
   updated_at: z.string().datetime().optional(),
 });
 
-// Role 1이 실제로 보내는 최소 구조 (TaskGraphProcessor 입력용)
-export const RawTaskSchema = z.object({
-  id: z.string().min(1),
-  type: RequestCategorySchema,
-  depends_on: z.array(z.string()).default([]),
-  title: z.string().optional(),
-  description: z.string().optional(),
+// Role 1 output: 한국어 → 영어 변환 후 문장 단위로 분리한 결과
+export const CompiledSentencesSchema = z.object({
+  sentences: z.array(z.string().min(1)),
 });
 
-export const RawAnalyzedRequestSchema = z.object({
-  intent: z.string(),
-  tasks: z.array(RawTaskSchema).default([]),
-});
-
-export type RawTask = z.infer<typeof RawTaskSchema>;
-export type RawAnalyzedRequest = z.infer<typeof RawAnalyzedRequestSchema>;
+export type CompiledSentences = z.infer<typeof CompiledSentencesSchema>;
 
 export type UserRequest = z.infer<typeof UserRequestSchema>;
 export type RequestCategory = z.infer<typeof RequestCategorySchema>;


### PR DESCRIPTION
## 요약

- Role 1 / Role 2.1 책임 경계 재정의 및 TaskGraphProcessor 전면 재작성
- Role 1은 전처리(한국어 → 영어 변환 + 문장 단위 분리)만 담당, `{ sentences: string[] }` 출력
- Role 2.1이 `sentences[]`를 받아 type 분류 / id 생성 / single·multi 구분 / depends_on 결정 / TaskGraph 구성 전담
- TaskDecomposer를 별도 모듈에서 TaskGraphProcessor 내부로 흡수 (단순화)

## 관련 이슈

- 없음

## 변경 유형

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩터링
- [x] 문서 수정
- [ ] 테스트 추가/수정

## 영향 범위

- 영향받는 모듈:
  - `src/schemas/pipeline.ts`
    - `RawTaskSchema`, `RawAnalyzedRequestSchema` 제거
    - `CompiledSentencesSchema` (`{ sentences: string[] }`) 추가
  - `src/core/task-graph/TaskGraphProcessor.ts`
    - 입력: `{ intent, tasks[] }` → `{ sentences: string[] }`
    - single(문장 1개) / multi(문장 2개 이상) 분기 추가
    - type 흐름 기반 `depends_on` 자동 결정 (`FLOWS_TO` 매핑)
  - `docs/SCHEMAS.md`, `docs/SCHEMA_FLOW.md`, `docs/SHARED_DATA_FLOW.md`
    - `AnalyzedRequest` → `CompiledSentences` 로 교체
    - Role 1 / Role 2.1 책임 기술 업데이트
- 영향받지 않는 모듈:
  - `src/core/state/` (Role 2.2 모듈)
  - `src/core/context/` (Role 2.2 모듈)
  - `src/core/executor/`, `src/integrations/` (Role 3 모듈)

## 테스트 방법

1. `npm run typecheck` — 타입 에러 없음 확인
2. `npm run test` — 12/12 통과 확인
3. single 요청 정상 동작 확인:
```json
{ "sentences": ["Read the auth module"] }
→ TaskGraph { tasks: [{ id: "t1", type: "explore", depends_on: [] }] }
```
4. multi sequential 정상 동작 확인:
```json
{ "sentences": ["Read the auth module", "Analyze the bug", "Fix the issue"] }
→ t1(explore) → t2(analyze) → t3(modify) 순차 실행
```
5. multi parallel 정상 동작 확인:
```json
{ "sentences": ["Fix the auth bug", "Update the README"] }
→ t1(modify), t2(document) 각각 depends_on: [] (독립 실행)
```

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [ ] 필요한 경우 테스트를 추가하거나 수정했습니다
- [x] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 스크린샷 / 로그

```
> detoks@0.1.0 typecheck
> tsc --noEmit -p tsconfig.json
(0 errors)

> detoks@0.1.0 test
> vitest run
Test Files  6 passed (6)
      Tests  12 passed (12)
```

## 리뷰어 참고사항

- `AnalyzedRequestSchema` / `AnalyzedRequest` 타입은 `pipeline.ts`에 잔존 — 현재 참조 코드 없음, Role 1 구현 시 정리 예정
- `FLOWS_TO` 매핑이 sequential/parallel 판단의 핵심 — 추후 type 쌍 추가 가능
- Role 1 담당자는 output을 `{ sentences: string[] }` 형식에 맞춰야 함 (`CompiledSentencesSchema` 기준)
