### PR TITLE
feat: implement real subprocess runner path

### DIFF
--- a/src/core/executor/execute.ts
+++ b/src/core/executor/execute.ts
@@ -22,6 +22,7 @@ export const executeWithAdapter = async (request: ExecutorRequest): Promise<Exec
     ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
     ...(request.sessionId !== undefined ? { sessionId: request.sessionId } : {}),
   }, {
+    executionMode: "stub",
     subprocessRunner,
   });
 

--- a/src/integrations/adapters/codex/adapter.ts
+++ b/src/integrations/adapters/codex/adapter.ts
@@ -1,5 +1,6 @@
 import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../../core/executor/types.js";
 import type { AdapterExecutionContext, CliAdapter } from "../interface.js";
+import { executeAdapterViaSubprocess } from "../real.js";
 import { buildStubRawOutput } from "../stub.js";
 
 export class CodexStubAdapter implements CliAdapter {
@@ -16,8 +17,12 @@ export class CodexStubAdapter implements CliAdapter {
 
   async execute(
     request: AdapterExecutionRequest,
-    _context?: AdapterExecutionContext,
+    context?: AdapterExecutionContext,
   ): Promise<AdapterExecutionResult> {
+    if (context?.executionMode === "real") {
+      return executeAdapterViaSubprocess(this, request, context);
+    }
+
     return {
       success: true,
       rawOutput: buildStubRawOutput(this.target, request.prompt),

--- a/src/integrations/adapters/gemini/adapter.ts
+++ b/src/integrations/adapters/gemini/adapter.ts
@@ -1,5 +1,6 @@
 import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../../core/executor/types.js";
 import type { AdapterExecutionContext, CliAdapter } from "../interface.js";
+import { executeAdapterViaSubprocess } from "../real.js";
 import { buildStubRawOutput } from "../stub.js";
 
 export class GeminiStubAdapter implements CliAdapter {
@@ -16,8 +17,12 @@ export class GeminiStubAdapter implements CliAdapter {
 
   async execute(
     request: AdapterExecutionRequest,
-    _context?: AdapterExecutionContext,
+    context?: AdapterExecutionContext,
   ): Promise<AdapterExecutionResult> {
+    if (context?.executionMode === "real") {
+      return executeAdapterViaSubprocess(this, request, context);
+    }
+
     return {
       success: true,
       rawOutput: buildStubRawOutput(this.target, request.prompt),

--- a/src/integrations/adapters/interface.ts
+++ b/src/integrations/adapters/interface.ts
@@ -2,7 +2,10 @@ import type { Adapter } from "../../core/pipeline/types.js";
 import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../core/executor/types.js";
 import type { SubprocessRequest, SubprocessRunner } from "../subprocess/types.js";
 
+export type AdapterExecutionMode = "stub" | "real";
+
 export interface AdapterExecutionContext {
+  executionMode: AdapterExecutionMode;
   subprocessRunner: SubprocessRunner;
 }
 

--- a/src/integrations/adapters/real.ts
+++ b/src/integrations/adapters/real.ts
@@ -1,6 +1,9 @@
 import type { AdapterExecutionContext, CliAdapter } from "./interface.js";
 import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../core/executor/types.js";
 
+export const shouldUseRealExecution = (context?: AdapterExecutionContext): boolean =>
+  context?.executionMode === "real";
+
 export const executeAdapterViaSubprocess = async (
   adapter: CliAdapter,
   request: AdapterExecutionRequest,

--- a/src/integrations/subprocess/runner.ts
+++ b/src/integrations/subprocess/runner.ts
@@ -1,4 +1,5 @@
 import type { SubprocessRequest, SubprocessResult, SubprocessRunner } from "./types.js";
+import { spawn } from "node:child_process";
 
 const formatCommand = (request: SubprocessRequest): string => {
   const args = request.args.length > 0 ? ` ${request.args.join(" ")}` : "";
@@ -13,5 +14,65 @@ export const createStubSubprocessRunner = (): SubprocessRunner => ({
       exitCode: 0,
       timedOut: false,
     };
+  },
+});
+
+export const createRealSubprocessRunner = (): SubprocessRunner => ({
+  async run(request: SubprocessRequest): Promise<SubprocessResult> {
+    return await new Promise<SubprocessResult>((resolve) => {
+      const child = spawn(request.command, request.args, {
+        cwd: request.cwd,
+        env: request.env ? { ...process.env, ...request.env } : process.env,
+        shell: false,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      let settled = false;
+      let stdout = "";
+      let stderr = "";
+
+      const finish = (result: SubprocessResult): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolve(result);
+      };
+
+      child.stdout?.setEncoding("utf8");
+      child.stderr?.setEncoding("utf8");
+
+      child.stdout?.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+
+      child.stderr?.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+
+      child.on("error", (error) => {
+        finish({
+          stdout,
+          stderr: stderr.length > 0 ? `${stderr}\n${String(error)}` : String(error),
+          exitCode: 127,
+          timedOut: false,
+        });
+      });
+
+      child.on("close", (exitCode, signal) => {
+        finish({
+          stdout,
+          stderr,
+          exitCode: typeof exitCode === "number" ? exitCode : signal ? 128 : 1,
+          timedOut: false,
+        });
+      });
+
+      if (request.input !== undefined) {
+        child.stdin.write(request.input);
+      }
+
+      child.stdin.end();
+    });
   },
 });

--- a/tests/ts/unit/integrations/adapters/adapter-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/adapter-path.test.ts
@@ -47,6 +47,7 @@ describe("adapter subprocess path", () => {
         verbose: false,
       },
       {
+        executionMode: "real",
         subprocessRunner: createStubSubprocessRunner(),
       },
     );

--- a/tests/ts/unit/integrations/adapters/real-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/real-path.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { CodexStubAdapter } from "../../../../../src/integrations/adapters/codex/adapter.js";
+import { GeminiStubAdapter } from "../../../../../src/integrations/adapters/gemini/adapter.js";
+import type { SubprocessRunner } from "../../../../../src/integrations/subprocess/types.js";
+
+const fakeRunner: SubprocessRunner = {
+  async run(request) {
+    return {
+      stdout: `[fake:${request.command}] ${request.input ?? ""}`,
+      stderr: "",
+      exitCode: request.command === "codex" ? 0 : 3,
+      timedOut: false,
+    };
+  },
+};
+
+describe("adapter execution modes", () => {
+  it("keeps codex stub execution separate from real execution", async () => {
+    const adapter = new CodexStubAdapter();
+
+    const stubResult = await adapter.execute({
+      mode: "run",
+      prompt: "stub prompt",
+      verbose: false,
+    });
+
+    const realResult = await adapter.execute(
+      {
+        mode: "run",
+        prompt: "real prompt",
+        verbose: false,
+      },
+      {
+        executionMode: "real",
+        subprocessRunner: fakeRunner,
+      },
+    );
+
+    expect(stubResult.rawOutput).toBe("[stub:codex] stub prompt");
+    expect(stubResult.exitCode).toBe(0);
+    expect(realResult.rawOutput).toBe("[fake:codex] real prompt");
+    expect(realResult.exitCode).toBe(0);
+  });
+
+  it("keeps gemini stub execution separate from real execution", async () => {
+    const adapter = new GeminiStubAdapter();
+
+    const stubResult = await adapter.execute({
+      mode: "run",
+      prompt: "stub prompt",
+      verbose: true,
+    });
+
+    const realResult = await adapter.execute(
+      {
+        mode: "run",
+        prompt: "real prompt",
+        verbose: true,
+      },
+      {
+        executionMode: "real",
+        subprocessRunner: fakeRunner,
+      },
+    );
+
+    expect(stubResult.rawOutput).toBe("[stub:gemini] stub prompt");
+    expect(stubResult.exitCode).toBe(0);
+    expect(realResult.rawOutput).toBe("[fake:gemini] real prompt");
+    expect(realResult.exitCode).toBe(3);
+  });
+});

--- a/tests/ts/unit/integrations/subprocess/runner.test.ts
+++ b/tests/ts/unit/integrations/subprocess/runner.test.ts
@@ -1,17 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { createStubSubprocessRunner } from "../../../../../src/integrations/subprocess/runner.js";
+import { createRealSubprocessRunner } from "../../../../../src/integrations/subprocess/runner.js";
 
-describe("createStubSubprocessRunner", () => {
-  it("returns a stub subprocess result", async () => {
-    const runner = createStubSubprocessRunner();
+describe("createRealSubprocessRunner", () => {
+  it("captures stdout, stderr, and exit code from a real process", async () => {
+    const runner = createRealSubprocessRunner();
     const result = await runner.run({
-      command: "codex",
-      args: ["--help"],
+      command: process.execPath,
+      args: [
+        "-e",
+        "process.stdout.write('out'); process.stderr.write('err'); process.exit(7);",
+      ],
     });
 
-    expect(result.stdout).toBe("[stub:subprocess] codex --help");
-    expect(result.stderr).toBe("");
-    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("out");
+    expect(result.stderr).toBe("err");
+    expect(result.exitCode).toBe(7);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("reports a clear failure for missing commands", async () => {
+    const runner = createRealSubprocessRunner();
+    const result = await runner.run({
+      command: "__detoks_missing_binary__",
+      args: [],
+    });
+
+    expect(result.exitCode).toBe(127);
+    expect(result.stderr.length).toBeGreaterThan(0);
     expect(result.timedOut).toBe(false);
   });
 });


### PR DESCRIPTION
## 요약
  - real subprocess runner를 추가하고, adapter가 stub execution과 real execution을 분리해
  서 사용할 수 있도록 실행 모드를 확장했습니다.
  - codex/gemini adapter가 `executionMode`에 따라 subprocess boundary를 타는 real path를
  사용할 수 있게 정리했습니다.
  - 실제 프로세스 실행 결과(stdout, stderr, exitCode)를 다루는 real runner와 관련 테스트
  를 추가했습니다.

  ## 관련 이슈
  - Closes #TODO
  - Related to #TODO

  ## 변경 유형
  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 리팩터링
  - [ ] 문서 수정
  - [x] 테스트 추가/수정

  ## 영향 범위
  - 영향받는 모듈:
    - `src/core/executor/execute.ts`
    - `src/integrations/adapters/interface.ts`
    - `src/integrations/adapters/real.ts`
    - `src/integrations/adapters/codex/adapter.ts`
    - `src/integrations/adapters/gemini/adapter.ts`
    - `src/integrations/subprocess/runner.ts`
    - `tests/ts/unit/integrations/adapters/adapter-path.test.ts`
    - `tests/ts/unit/integrations/adapters/real-path.test.ts`
    - `tests/ts/unit/integrations/subprocess/runner.test.ts`
  - 영향받지 않는 모듈:
    - Role 1 Python 영역
    - 상태 관리 로직
    - Prompt Compiler / Request Analyzer / Task Graph / Context 내부 구현
    - 문서/README 계층

  ## 테스트 방법
  1. `npm run typecheck`
  2. `npx vitest run tests/ts/unit/integrations/subprocess/runner.test.ts tests/ts/unit/
  integrations/adapters/adapter-path.test.ts tests/ts/unit/integrations/adapters/real-
  path.test.ts tests/ts/unit/core/executor/execute.test.ts`
  3. real runner가 실제 프로세스 stdout/stderr/exitCode를 캡처하는지 확인
  4. adapter가 stub path와 real path를 분리해서 사용하는지 확인

  ## 체크리스트
  - [x] 로컬에서 테스트했습니다
  - [x] 필요한 경우 테스트를 추가하거나 수정했습니다
  - [ ] 필요한 경우 문서를 수정했습니다
  - [x] 브레이킹 체인지 여부를 확인했습니다
  - [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

  ## 스크린샷 / 로그
  <!-- 필요한 경우 스크린샷, 터미널 출력, 로그 등을 첨부하세요 -->

  - `npm run typecheck` 통과
  - 관련 subprocess / adapter / executor 테스트 통과

  ## 리뷰어 참고사항
  <!-- 리뷰어가 특히 봐야 할 부분이나 참고해야 할 내용을 적어주세요 -->

  - 이번 변경의 핵심은 real subprocess runner와 execution mode 분리입니다.
  - adapter interface에 `executionMode`가 추가되어 stub path와 real path가 분리됩니다.
  - codex/gemini adapter는 이제 real path를 지원하지만, 실제 외부 CLI 성공 여부를 테스트
  에 의존하지 않도록 구성했습니다.

