### PR TITLE
feat: add CLI execution mode control

### DIFF
--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -1,16 +1,26 @@
 import { UserRequestSchema } from "../schemas/pipeline.js";
-import { AdapterValues, type CliArgs, type CliMode, type NormalizedCliRequest } from "./types.js";
+import {
+  AdapterValues,
+  ExecutionModeValues,
+  type CliArgs,
+  type CliMode,
+  type NormalizedCliRequest,
+} from "./types.js";
 
 const DEFAULT_ADAPTER = "codex";
+const DEFAULT_EXECUTION_MODE = "stub";
 
 const isAdapter = (value: string): value is (typeof AdapterValues)[number] =>
   AdapterValues.includes(value as (typeof AdapterValues)[number]);
+
+const isExecutionMode = (value: string): value is (typeof ExecutionModeValues)[number] =>
+  ExecutionModeValues.includes(value as (typeof ExecutionModeValues)[number]);
 
 const assertPrompt = (prompt: string | undefined): string => {
   const normalized = prompt?.trim();
   if (!normalized) {
     throw new Error(
-      "Missing prompt. Usage: detoks \"<prompt>\" [--adapter codex|gemini] [--verbose] or detoks repl",
+      "Missing prompt. Usage: detoks \"<prompt>\" [--adapter codex|gemini] [--execution-mode stub|real] [--verbose] or detoks repl",
     );
   }
   return normalized;
@@ -19,6 +29,7 @@ const assertPrompt = (prompt: string | undefined): string => {
 export const parseCliArgs = (argv: string[]): CliArgs => {
   const positionals: string[] = [];
   let adapter: CliArgs["adapter"] = DEFAULT_ADAPTER;
+  let executionMode: CliArgs["executionMode"] = DEFAULT_EXECUTION_MODE;
   let verbose = false;
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -54,6 +65,28 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
       continue;
     }
 
+    if (current === "--execution-mode") {
+      const next = argv[i + 1];
+      if (!next) {
+        throw new Error("--execution-mode requires a value: stub|real");
+      }
+      if (!isExecutionMode(next)) {
+        throw new Error(`Unsupported execution mode: ${next}`);
+      }
+      executionMode = next;
+      i += 1;
+      continue;
+    }
+
+    if (current.startsWith("--execution-mode=")) {
+      const inline = current.split("=")[1] ?? "";
+      if (!isExecutionMode(inline)) {
+        throw new Error(`Unsupported execution mode: ${inline}`);
+      }
+      executionMode = inline;
+      continue;
+    }
+
     if (current.startsWith("--")) {
       throw new Error(`Unknown flag: ${current}`);
     }
@@ -66,7 +99,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     if (positionals.length > 1) {
       throw new Error('REPL mode does not accept prompt arguments. Use: detoks repl');
     }
-    return { mode: "repl", adapter, verbose };
+    return { mode: "repl", adapter, executionMode, verbose };
   }
 
   const prompt = assertPrompt(positionals.join(" "));
@@ -74,6 +107,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     mode: "run",
     prompt,
     adapter,
+    executionMode,
     verbose,
   };
 };
@@ -88,6 +122,7 @@ export const toNormalizedRequest = (
   return {
     mode,
     adapter: args.adapter,
+    executionMode: args.executionMode,
     verbose: args.verbose,
     userRequest: UserRequestSchema.parse({
       raw_input: prompt,

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,18 +1,24 @@
-import { AdapterValues as CoreAdapterValues } from "../core/pipeline/types.js";
+import {
+  AdapterValues as CoreAdapterValues,
+  ExecutionModeValues as CoreExecutionModeValues,
+} from "../core/pipeline/types.js";
 import type {
   Adapter,
   InteractionMode,
+  ExecutionMode,
   PipelineExecutionRequest,
   PipelineExecutionResult,
 } from "../core/pipeline/types.js";
 
 export const AdapterValues = CoreAdapterValues;
+export const ExecutionModeValues = CoreExecutionModeValues;
 export type CliMode = InteractionMode;
 
 export interface CliArgs {
   mode: CliMode;
   prompt?: string;
   adapter: Adapter;
+  executionMode: ExecutionMode;
   verbose: boolean;
 }
 

--- a/src/core/executor/execute.ts
+++ b/src/core/executor/execute.ts
@@ -22,7 +22,7 @@ export const executeWithAdapter = async (request: ExecutorRequest): Promise<Exec
     ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
     ...(request.sessionId !== undefined ? { sessionId: request.sessionId } : {}),
   }, {
-    executionMode: "stub",
+    executionMode: request.executionMode,
     subprocessRunner,
   });
 

--- a/src/core/executor/types.ts
+++ b/src/core/executor/types.ts
@@ -1,4 +1,4 @@
-import type { Adapter, InteractionMode } from "../pipeline/types.js";
+import type { Adapter, ExecutionMode, InteractionMode } from "../pipeline/types.js";
 
 export interface AdapterExecutionRequest {
   mode: InteractionMode;
@@ -17,6 +17,7 @@ export interface AdapterExecutionResult {
 
 export interface ExecutorRequest extends AdapterExecutionRequest {
   adapter: Adapter;
+  executionMode: ExecutionMode;
 }
 
 export interface ExecutorResult {

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -21,6 +21,7 @@ export const orchestratePipeline = async (
   const execution = await executeWithAdapter({
     adapter: request.adapter,
     mode: request.mode,
+    executionMode: request.executionMode,
     prompt,
     verbose: request.verbose,
     ...(request.userRequest.cwd !== undefined ? { cwd: request.userRequest.cwd } : {}),

--- a/src/core/pipeline/types.ts
+++ b/src/core/pipeline/types.ts
@@ -3,10 +3,13 @@ import type { UserRequest } from "../../schemas/pipeline.js";
 export const AdapterValues = ["codex", "gemini"] as const;
 export type Adapter = (typeof AdapterValues)[number];
 export type InteractionMode = "run" | "repl";
+export const ExecutionModeValues = ["stub", "real"] as const;
+export type ExecutionMode = (typeof ExecutionModeValues)[number];
 
 export interface PipelineExecutionRequest {
   mode: InteractionMode;
   adapter: Adapter;
+  executionMode: ExecutionMode;
   verbose: boolean;
   userRequest: UserRequest;
 }

--- a/src/integrations/adapters/interface.ts
+++ b/src/integrations/adapters/interface.ts
@@ -1,8 +1,8 @@
-import type { Adapter } from "../../core/pipeline/types.js";
+import type { Adapter, ExecutionMode } from "../../core/pipeline/types.js";
 import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../core/executor/types.js";
 import type { SubprocessRequest, SubprocessRunner } from "../subprocess/types.js";
 
-export type AdapterExecutionMode = "stub" | "real";
+export type AdapterExecutionMode = ExecutionMode;
 
 export interface AdapterExecutionContext {
   executionMode: AdapterExecutionMode;

--- a/tests/ts/unit/cli/parse.test.ts
+++ b/tests/ts/unit/cli/parse.test.ts
@@ -8,15 +8,24 @@ describe("parseCliArgs", () => {
       mode: "run",
       prompt: "hello detoks",
       adapter: "codex",
+      executionMode: "stub",
       verbose: false,
     });
   });
 
   it("parses repl mode with flags", () => {
-    const parsed = parseCliArgs(["repl", "--adapter", "gemini", "--verbose"]);
+    const parsed = parseCliArgs([
+      "repl",
+      "--adapter",
+      "gemini",
+      "--execution-mode",
+      "real",
+      "--verbose",
+    ]);
     expect(parsed).toEqual({
       mode: "repl",
       adapter: "gemini",
+      executionMode: "real",
       verbose: true,
     });
   });

--- a/tests/ts/unit/core/executor/execute.test.ts
+++ b/tests/ts/unit/core/executor/execute.test.ts
@@ -6,6 +6,7 @@ describe("executeWithAdapter", () => {
     const result = await executeWithAdapter({
       adapter: "codex",
       mode: "run",
+      executionMode: "stub",
       prompt: "hello codex",
       verbose: false,
     });
@@ -20,6 +21,7 @@ describe("executeWithAdapter", () => {
     const result = await executeWithAdapter({
       adapter: "gemini",
       mode: "run",
+      executionMode: "stub",
       prompt: "hello gemini",
       verbose: true,
     });
@@ -27,6 +29,20 @@ describe("executeWithAdapter", () => {
     expect(result.ok).toBe(true);
     expect(result.adapter).toBe("gemini");
     expect(result.rawOutput).toBe("[stub:gemini] hello gemini");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("uses the real execution path when requested", async () => {
+    const result = await executeWithAdapter({
+      adapter: "codex",
+      mode: "run",
+      executionMode: "real",
+      prompt: "hello real codex",
+      verbose: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.rawOutput).toBe("[stub:subprocess] codex");
     expect(result.exitCode).toBe(0);
   });
 });

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -6,6 +6,7 @@ describe("orchestratePipeline", () => {
     const result = await orchestratePipeline({
       mode: "run",
       adapter: "codex",
+      executionMode: "stub",
       verbose: false,
       userRequest: {
         raw_input: "hello detoks",
@@ -18,5 +19,20 @@ describe("orchestratePipeline", () => {
     expect(result.summary).toContain("stub executor accepted prompt");
     expect(result.stages).toHaveLength(6);
     expect(result.rawOutput).toBe("[stub:codex] hello detoks");
+  });
+
+  it("passes execution mode through to the executor boundary", async () => {
+    const result = await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "real",
+      verbose: false,
+      userRequest: {
+        raw_input: "hello detoks",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.rawOutput).toBe("[stub:subprocess] codex");
   });
 });


### PR DESCRIPTION
## 요약
  - CLI에서 execution mode(`stub` / `real`)를 선택할 수 있도록 runtime control을 추가했습
  니다.
  - parse/types 계층에서 execution mode를 전달하고, pipeline / executor / adapter
  boundary까지 일관되게 연결되도록 구조를 확장했습니다.
  - 기본 동작은 안전한 방향으로 유지하면서, 실제 실행 경로를 선택할 수 있는 기반을 마련했
  습니다.

  ## 관련 이슈
  - Closes #TODO
  - Related to #TODO

  ## 변경 유형
  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 리팩터링
  - [ ] 문서 수정
  - [x] 테스트 추가/수정

  ## 영향 범위
  - 영향받는 모듈:
    - `src/cli/parse.ts`
    - `src/cli/types.ts`
    - `src/core/executor/execute.ts`
    - `src/core/executor/types.ts`
    - `src/core/pipeline/orchestrator.ts`
    - `src/core/pipeline/types.ts`
    - `src/integrations/adapters/interface.ts`
    - `tests/ts/unit/cli/parse.test.ts`
    - `tests/ts/unit/core/executor/execute.test.ts`
    - `tests/ts/unit/core/pipeline/orchestrator.test.ts`
  - 영향받지 않는 모듈:
    - Role 1 Python 영역
    - 문서/README 계층
    - 실제 adapter 내부 구현 세부사항

  ## 테스트 방법
  1. `npm run typecheck`
  2. `npx vitest run tests/ts/unit/cli/parse.test.ts tests/ts/unit/core/executor/
  execute.test.ts tests/ts/unit/core/pipeline/orchestrator.test.ts`
  3. CLI parse에서 execution mode가 전달되고, executor/pipeline 경계까지 반영되는지 확인

  ## 체크리스트
  - [x] 로컬에서 테스트했습니다
  - [x] 필요한 경우 테스트를 추가하거나 수정했습니다
  - [ ] 필요한 경우 문서를 수정했습니다
  - [x] 브레이킹 체인지 여부를 확인했습니다
  - [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

  ## 스크린샷 / 로그
  <!-- 필요한 경우 스크린샷, 터미널 출력, 로그 등을 첨부하세요 -->

  - `npm run typecheck` 통과
  - 관련 CLI / executor / pipeline 테스트 통과

  ## 리뷰어 참고사항
  <!-- 리뷰어가 특히 봐야 할 부분이나 참고해야 할 내용을 적어주세요 -->

  - 이번 변경의 핵심은 execution mode가 CLI에서 시작되어 executor/adapter 경계까지 전달되
  는 점입니다.
  - 기본 동작이 안전하게 유지되는지와, mode 전달 경로가 일관적인지 중심으로 봐주세요.

