### PR TITLE
Feat: dependency resolver

### DIFF
--- a/src/core/task-graph/DAGValidator.ts
+++ b/src/core/task-graph/DAGValidator.ts
@@ -1,32 +1,70 @@
 import type { Task, TaskGraph } from "../../schemas/pipeline.js";
 
+/**
+ * DAG 검증 성공 결과입니다.
+ *
+ * topologicalOrder: 실행 가능한 순서로 정렬된 task id 배열
+ *   - 앞에 있는 task일수록 먼저 실행 가능
+ *   - Kahn's algorithm으로 계산 (in-degree 기반)
+ *   - 이 배열을 DependencyResolver에 그대로 전달하면 됩니다
+ *
+ * 예: t1 → t2 → t3 구조라면 topologicalOrder = ["t1", "t2", "t3"]
+ */
 export type DAGValidationSuccess = {
   valid: true;
   topologicalOrder: string[];
 };
 
+/**
+ * DAG 검증 실패 결과입니다.
+ *
+ * reason: 실패 원인 코드
+ *   - "UNKNOWN_DEPENDENCY" : depends_on에 존재하지 않는 task id를 참조
+ *   - "CYCLE_DETECTED"     : 순환 의존성 존재 (A→B→A 같은 구조)
+ *   - "DISCONNECTED_NODE"  : 그래프의 나머지와 연결되지 않은 고립 task
+ *
+ * detail: 어떤 task에서 문제가 발생했는지 설명하는 사람이 읽을 수 있는 메시지
+ */
 export type DAGValidationFailure = {
   valid: false;
   reason: "CYCLE_DETECTED" | "UNKNOWN_DEPENDENCY" | "DISCONNECTED_NODE";
   detail: string;
 };
 
+/**
+ * validate()의 반환 타입입니다.
+ *
+ * TypeScript discriminated union: valid 필드를 기준으로 분기 가능
+ *   if (result.valid) {
+ *     result.topologicalOrder  // ← 여기서만 접근 가능
+ *   } else {
+ *     result.reason            // ← 여기서만 접근 가능
+ *   }
+ */
 export type DAGValidationResult = DAGValidationSuccess | DAGValidationFailure;
 
 /**
- * TaskGraph가 유효한 DAG인지 검증합니다.
+ * TaskGraph가 유효한 DAG(Directed Acyclic Graph)인지 3단계로 검증합니다.
  *
- * 검증 순서:
- * 1. UNKNOWN_DEPENDENCY — depends_on에 존재하지 않는 ID 참조 여부
- * 2. CYCLE_DETECTED     — 순환 의존성 여부 (DFS)
- * 3. DISCONNECTED_NODE  — 연결된 그래프 안의 고립 노드 여부
- * 4. 정상이면 topological order 반환
+ * DAG 조건 = 방향이 있고(Directed) + 순환이 없는(Acyclic) 그래프
+ * TaskGraph가 DAG여야 topological sort가 가능하고, 실행 순서를 결정할 수 있습니다.
+ *
+ * 검증 순서 (빠른 실패 우선):
+ *   1. UNKNOWN_DEPENDENCY — 참조된 id가 존재하는지 (O(n²) 전에 빠르게 차단)
+ *   2. CYCLE_DETECTED     — 순환 의존성 여부 (DFS)
+ *   3. DISCONNECTED_NODE  — 그래프 일부가 완전히 고립되었는지
+ *   4. 성공 → topological order 계산 후 반환
  */
 export class DAGValidator {
   static validate(graph: TaskGraph): DAGValidationResult {
+    // 전체 task id 집합 — 존재 여부를 O(1)로 확인하기 위해 Set 사용
     const ids = new Set(graph.tasks.map((t) => t.id));
 
-    // 1. 존재하지 않는 ID 참조 검사
+    // ─── Step 1: UNKNOWN_DEPENDENCY ─────────────────────────────
+    // 각 task의 depends_on에 적힌 id가 실제로 존재하는지 확인
+    //
+    // 예) t2.depends_on = ["t99"] 인데 t99가 없으면
+    //     → t2는 영원히 시작할 수 없는 task가 됨 → 즉시 실패 반환
     for (const task of graph.tasks) {
       for (const dep of task.depends_on) {
         if (!ids.has(dep)) {
@@ -39,17 +77,30 @@ export class DAGValidator {
       }
     }
 
-    // 2. 사이클 탐지 (DFS white/gray/black 컬러링)
+    // ─── Step 2: CYCLE_DETECTED ──────────────────────────────────
+    // DFS로 순환 의존성 탐지
+    // 순환이 있으면 실행 순서를 결정할 수 없음 (어떤 task도 먼저 시작할 수 없게 됨)
+    //
+    // 예) t1.depends_on=["t2"], t2.depends_on=["t1"]
+    //     → t1은 t2가 끝나야 실행, t2는 t1이 끝나야 실행 → 영원히 기다림
     const cycleResult = this.detectCycle(graph.tasks);
     if (cycleResult) return cycleResult;
 
-    // 3. 고립 노드 탐지
-    // 그래프 안에 depends_on이 있는 task가 하나라도 있는데(= 연결된 부분이 있는데)
-    // 어떤 task가 depends_on도 없고 다른 task가 의존하지도 않으면 고립 노드로 판단
+    // ─── Step 3: DISCONNECTED_NODE ───────────────────────────────
+    // 그래프에 엣지(의존 관계)가 하나라도 있는데, 어떤 task가 완전히 고립되어 있는지 확인
+    //
+    // "고립 노드"의 정의:
+    //   - 본인은 아무것도 의존하지 않음 (depends_on: [])
+    //   - 다른 task도 본인을 의존하지 않음 (아무도 depends_on에 이 id를 포함하지 않음)
+    //
+    // 예) t1→t2 연결은 있는데 t3는 완전히 혼자 → t3는 고립 노드
+    //     단, 모든 task가 병렬(depends_on: [])이면 고립이 아님 — 의도적 병렬 실행
     const hasAnyEdge = graph.tasks.some((t) => t.depends_on.length > 0);
     if (hasAnyEdge) {
+      // 어떤 task의 depends_on에라도 언급된 id 전체 집합
       const referencedIds = new Set(graph.tasks.flatMap((t) => t.depends_on));
       for (const task of graph.tasks) {
+        // depends_on도 없고, 다른 task가 나를 의존하지도 않으면 → 고립
         if (task.depends_on.length === 0 && !referencedIds.has(task.id)) {
           return {
             valid: false,
@@ -60,33 +111,58 @@ export class DAGValidator {
       }
     }
 
-    // 4. Topological sort (Kahn's algorithm)
+    // ─── Step 4: 성공 → topological order 계산 ───────────────────
     const order = this.topologicalSort(graph.tasks);
     return { valid: true, topologicalOrder: order };
   }
 
-  // DFS: white(미방문)=0 / gray(방문중)=1 / black(완료)=2
+  /**
+   * DFS white/gray/black 컬러링으로 순환 의존성을 탐지합니다.
+   *
+   * 컬러 의미:
+   *   white(0) : 아직 방문하지 않은 노드
+   *   gray(1)  : 현재 DFS 경로 위에 있는 노드 (방문 중, 아직 완료되지 않음)
+   *   black(2) : DFS가 완전히 끝난 노드 (이 노드에서 시작하는 경로에 사이클 없음)
+   *
+   * 사이클 탐지 원리:
+   *   gray 노드를 다시 만났다 = 현재 탐색 경로에서 이미 방문한 노드로 돌아왔다 = 사이클!
+   *
+   * 예) t1 → t2 → t1 탐색 중:
+   *   dfs(t1): color[t1]=gray, 이웃 t2 탐색
+   *   dfs(t2): color[t2]=gray, 이웃 t1 탐색
+   *   t1이 gray → 사이클 발견! path = ["t1", "t2", "t1"]
+   *
+   * @returns 사이클이 있으면 DAGValidationFailure, 없으면 null
+   */
   private static detectCycle(tasks: Task[]): DAGValidationFailure | null {
     const color = new Map<string, 0 | 1 | 2>(tasks.map((t) => [t.id, 0]));
+    // adjList: 각 task에서 의존하는 task id 목록 (방향: "나 → 내가 의존하는 것")
     const adjList = new Map<string, string[]>(
       tasks.map((t) => [t.id, t.depends_on])
     );
 
+    // path: 현재 DFS 경로 (사이클 발견 시 경로 문자열 구성에 사용)
     const dfs = (id: string, path: string[]): string[] | null => {
-      color.set(id, 1);
+      color.set(id, 1); // 방문 시작 → gray
       for (const dep of adjList.get(id) ?? []) {
-        if (color.get(dep) === 1) return [...path, id, dep];
-        if (color.get(dep) === 0) {
-          const cycle = dfs(dep, [...path, id]);
-          if (cycle) return cycle;
+        if (color.get(dep) === 1) {
+          // gray 노드를 다시 만남 → 사이클! 경로 배열 반환
+          return [...path, id, dep];
         }
+        if (color.get(dep) === 0) {
+          // white 노드 → 아직 미방문, 재귀 탐색
+          const cycle = dfs(dep, [...path, id]);
+          if (cycle) return cycle; // 하위에서 사이클이 발견되면 그대로 전파
+        }
+        // black 노드(=2) → 이미 완료된 노드, 이 방향엔 사이클 없음 → 무시
       }
-      color.set(id, 2);
+      color.set(id, 2); // 이 노드의 모든 이웃 탐색 완료 → black
       return null;
     };
 
     for (const task of tasks) {
       if (color.get(task.id) === 0) {
+        // white 노드만 DFS 시작점으로 사용 (gray/black은 이미 처리됨)
         const cycle = dfs(task.id, []);
         if (cycle) {
           return {
@@ -100,28 +176,64 @@ export class DAGValidator {
     return null;
   }
 
-  // Kahn's algorithm: in-degree 기반 topological sort
+  /**
+   * Kahn's algorithm으로 topological sort를 수행합니다.
+   *
+   * 핵심 개념:
+   *   in-degree  : 이 task를 의존하는 다른 task의 수 (= 나보다 먼저 끝나야 하는 task 수)
+   *   dependents : 내가 완료됐을 때 "대기 해제"해줘야 하는 task 목록 (역방향 엣지)
+   *
+   * 알고리즘 순서:
+   *   1. 모든 task의 in-degree를 계산
+   *   2. in-degree가 0인 task(= 아무것도 기다리지 않아도 되는 task)를 큐에 넣음
+   *   3. 큐에서 하나씩 꺼내어 result에 추가
+   *   4. 꺼낸 task를 의존하던 task들의 in-degree를 1씩 감소
+   *   5. in-degree가 0이 된 task를 큐에 추가
+   *   6. 큐가 빌 때까지 반복
+   *
+   * 예) t1 → t2 → t3 구조:
+   *   in-degree: { t1:0, t2:1, t3:1 }
+   *   초기 큐: [t1]
+   *   t1 처리 → t2의 in-degree: 0 → 큐: [t2]
+   *   t2 처리 → t3의 in-degree: 0 → 큐: [t3]
+   *   t3 처리 → result: ["t1", "t2", "t3"]
+   *
+   * 병렬 예) t1, t2 모두 depends_on:[]:
+   *   in-degree: { t1:0, t2:0 }
+   *   초기 큐: [t1, t2]
+   *   result: ["t1", "t2"] (순서는 tasks 배열 순서 따름)
+   */
   private static topologicalSort(tasks: Task[]): string[] {
+    // in-degree: 각 task를 의존하는 task의 수 (초기값 0, 아래에서 갱신)
     const inDegree = new Map<string, number>(tasks.map((t) => [t.id, 0]));
+    // dependents: "내가 완료되면 이 task들의 in-degree를 줄여줘야 한다"는 역방향 맵
     const dependents = new Map<string, string[]>(tasks.map((t) => [t.id, []]));
 
     for (const task of tasks) {
+      // 이 task는 depends_on 수만큼 기다려야 함
       inDegree.set(task.id, task.depends_on.length);
       for (const dep of task.depends_on) {
+        // dep가 완료되면 task의 in-degree를 줄여줘야 한다
         dependents.get(dep)!.push(task.id);
       }
     }
 
+    // 초기 큐: 지금 당장 실행 가능한 task들 (아무것도 기다리지 않아도 되는 task)
     const queue = tasks.filter((t) => t.depends_on.length === 0).map((t) => t.id);
     const result: string[] = [];
 
     while (queue.length > 0) {
-      const id = queue.shift()!;
+      const id = queue.shift()!; // 큐 앞에서 하나 꺼냄 (FIFO → BFS 순서)
       result.push(id);
+
+      // 이 task가 완료됐으므로, 이 task를 기다리던 task들의 in-degree를 1씩 감소
       for (const dependent of dependents.get(id) ?? []) {
         const deg = (inDegree.get(dependent) ?? 1) - 1;
         inDegree.set(dependent, deg);
-        if (deg === 0) queue.push(dependent);
+        if (deg === 0) {
+          // 이제 이 task도 모든 선행 task가 완료됨 → 실행 가능 → 큐에 추가
+          queue.push(dependent);
+        }
       }
     }
 

--- a/src/core/task-graph/DependencyResolver.ts
+++ b/src/core/task-graph/DependencyResolver.ts
@@ -1,0 +1,71 @@
+import type { Task, TaskGraph } from "../../schemas/pipeline.js";
+import type { DAGValidationSuccess } from "./DAGValidator.js";
+
+/**
+ * 실행 순서가 결정된 Task 하나를 나타냅니다.
+ *
+ * - task : 이번에 실행할 Task 객체
+ * - deps : 이 Task가 실행되기 전에 반드시 완료되어야 하는 Task 객체 목록
+ *          (task.depends_on의 ID 배열을 실제 Task 객체로 변환한 것)
+ *
+ * 예) t2.depends_on = ["t1"] 이면
+ *     → deps = [ Task(t1) ]   ← "t1이 끝나야 t2를 시작할 수 있다"
+ */
+export type ResolvedTask = {
+  task: Task;
+  deps: Task[];
+};
+
+/**
+ * DependencyResolver.resolve()의 반환값입니다.
+ *
+ * - orderedTasks : topological 순서로 정렬된 ResolvedTask 배열
+ *   - 앞에 있는 항목일수록 먼저 실행 가능
+ *   - 같은 위치에 있더라도 deps가 비어 있으면 바로 실행 가능 (병렬 후보)
+ *   - ParallelClassifier는 이 배열을 받아 stage 단위로 그룹화함
+ */
+export type DependencyResolution = {
+  orderedTasks: ResolvedTask[];
+};
+
+/**
+ * DAGValidator의 topologicalOrder(string[])를
+ * 실제 실행에 필요한 Task 객체 순서(ResolvedTask[])로 변환합니다.
+ *
+ * ─────────────────────────────────────────────────────
+ * 역할 분담
+ *   DAGValidator    : 그래프가 유효한 DAG인지 검증 + topological 순서(ID 배열) 계산
+ *   DependencyResolver : ID 배열 → Task 객체 배열로 변환 + 각 Task의 deps(선행 Task) resolve
+ *   ParallelClassifier : ResolvedTask 배열을 받아 병렬 실행 가능한 stage로 그룹화
+ * ─────────────────────────────────────────────────────
+ *
+ * 선행 조건: DAGValidator.validate()가 { valid: true }를 반환한 그래프여야 합니다.
+ *            (사이클 없음, 존재하지 않는 ID 참조 없음이 보장된 상태)
+ */
+export class DependencyResolver {
+  static resolve(
+    graph: TaskGraph,
+    validation: DAGValidationSuccess
+  ): DependencyResolution {
+    // id → Task 객체 빠른 조회를 위한 Map 생성
+    // 예: { "t1" → Task, "t2" → Task, ... }
+    const taskMap = new Map<string, Task>(graph.tasks.map((t) => [t.id, t]));
+
+    // topologicalOrder는 DAGValidator(Kahn's algorithm)가 계산한 실행 가능 순서
+    // 예: ["t1", "t3", "t2"] → t1 먼저, 그 다음 t3, 마지막 t2
+    const orderedTasks: ResolvedTask[] = validation.topologicalOrder.map(
+      (id) => {
+        const task = taskMap.get(id)!;
+
+        // depends_on의 ID 문자열들을 실제 Task 객체로 변환
+        // 예: task.depends_on = ["t1"] → deps = [ Task(t1) ]
+        // deps가 빈 배열이면 이 Task는 아무것도 기다릴 필요 없음 (즉시 실행 가능)
+        const deps = task.depends_on.map((depId) => taskMap.get(depId)!);
+
+        return { task, deps };
+      }
+    );
+
+    return { orderedTasks };
+  }
+}

--- a/src/core/task-graph/TaskGraphProcessor.ts
+++ b/src/core/task-graph/TaskGraphProcessor.ts
@@ -8,16 +8,37 @@ import type { Task, TaskGraph, RequestCategory } from "../../schemas/pipeline.js
 /**
  * Role 1의 sentences[]를 받아 실행 가능한 TaskGraph로 변환합니다.
  *
- * Role 1 담당: 한국어 → 영어 변환, 문장 단위 분리
- * Role 2.1 담당:
- *   - single / multi 요청 구분
- *   - 각 문장 type 분류
- *   - id 생성
- *   - type 흐름 기반 depends_on 결정 (sequential vs parallel)
+ * ─── 역할 분담 ──────────────────────────────────────────────────
+ * Role 1 담당 : 한국어 → 영어 변환, 한 문장 = 하나의 실행 단위로 분리
+ * Role 2.1 담당 (이 클래스):
+ *   1. single(문장 1개) / multi(문장 여러 개) 요청 구분
+ *   2. 각 문장의 type 분류 (explore / create / modify / ...)
+ *   3. task id 자동 생성 (t1, t2, t3, ...)
+ *   4. depends_on 결정 — 이전 type → 현재 type이 자연스러운 흐름이면 sequential(의존),
+ *                        흐름이 끊기면 parallel(독립, depends_on: [])
+ * ────────────────────────────────────────────────────────────────
+ *
+ * 전체 파이프라인에서의 위치:
+ *   Role 1 output (sentences[])
+ *     → TaskGraphProcessor.process()   ← 여기
+ *     → DAGValidator.validate()
+ *     → DependencyResolver.resolve()
+ *     → ParallelClassifier.classify()
  */
 export class TaskGraphProcessor {
-  // type A → type B 가 "자연스러운 흐름"인 관계 정의
-  // 이 관계에 해당하면 sequential(의존), 해당하지 않으면 parallel(독립)
+  /**
+   * type A → type B 전환이 "자연스러운 실행 흐름"인 조합을 정의한 테이블입니다.
+   *
+   * 이 테이블에 해당하면 → sequential (t_prev 완료 후 t_curr 실행, depends_on: ["t_prev"])
+   * 해당하지 않으면   → parallel  (서로 독립 실행, depends_on: [])
+   *
+   * 예시:
+   *   "explore" 다음 "analyze" → 자연스러운 흐름 (탐색 후 분석)    → sequential
+   *   "explore" 다음 "document"→ 테이블에 없음 (탐색 후 바로 문서화는 비약) → parallel
+   *   "create"  다음 "validate"→ 자연스러운 흐름 (생성 후 검증)    → sequential
+   *
+   * document는 보통 마지막 단계이므로 어떤 type도 뒤따르지 않음 → 빈 배열
+   */
   private static readonly FLOWS_TO: Partial<Record<RequestCategory, RequestCategory[]>> = {
     explore:  ["analyze", "modify", "create", "validate"],
     plan:     ["explore", "create", "execute"],
@@ -29,10 +50,27 @@ export class TaskGraphProcessor {
     document: [],
   };
 
+  /**
+   * Role 1의 raw output을 파싱하여 TaskGraph를 반환합니다.
+   *
+   * @param rawInput - Role 1이 넘겨준 값. 내부적으로 CompiledSentencesSchema로 검증.
+   *                   형식: { sentences: string[] }
+   * @returns 유효성 검증된 TaskGraph 객체 (Zod parse 통과)
+   *
+   * single 예시 (문장 1개):
+   *   input : { sentences: ["Explore the src directory"] }
+   *   output: { tasks: [{ id:"t1", type:"explore", depends_on:[], ... }] }
+   *
+   * multi 예시 (문장 여러 개):
+   *   input : { sentences: ["Explore src", "Analyze structure", "Create module"] }
+   *   types : ["explore", "analyze", "create"]
+   *   흐름  : explore→analyze (O, sequential), analyze→create (O, sequential)
+   *   output: t1(depends_on:[]), t2(depends_on:["t1"]), t3(depends_on:["t2"])
+   */
   static process(rawInput: unknown): TaskGraph {
     const { sentences } = CompiledSentencesSchema.parse(rawInput);
 
-    // single 요청: 문장 1개 → task 1개, depends_on 없음
+    // single 요청: 문장이 1개면 의존 관계가 성립하지 않으므로 바로 반환
     if (sentences.length === 1) {
       const sentence = sentences[0]!;
       const type = this.classifyType(sentence);
@@ -40,8 +78,11 @@ export class TaskGraphProcessor {
       return TaskGraphSchema.parse({ tasks });
     }
 
-    // multi 요청: 먼저 모든 type을 분류한 뒤 흐름 기반으로 depends_on 결정
+    // multi 요청
+    // ① 먼저 모든 문장의 type을 한 번에 분류 — resolveDependsOn에서 이전 type을 참조하기 때문
     const types: RequestCategory[] = sentences.map((s) => this.classifyType(s));
+
+    // ② 각 문장을 Task로 변환하면서 depends_on 결정
     const tasks: Task[] = sentences.map((sentence, index) => {
       const type = types[index]!;
       const dependsOn = this.resolveDependsOn(index, types);
@@ -51,15 +92,36 @@ export class TaskGraphProcessor {
     return TaskGraphSchema.parse({ tasks });
   }
 
-  // type 흐름이 자연스러우면 이전 task에 의존(sequential)
-  // 흐름이 끊기면 독립(parallel, depends_on: [])
+  /**
+   * index번째 task의 depends_on을 결정합니다.
+   *
+   * 판단 기준: FLOWS_TO[이전 type]에 현재 type이 포함되어 있으면 sequential
+   *
+   * 예시:
+   *   types = ["explore", "analyze", "document"]
+   *   index=1: FLOWS_TO["explore"].includes("analyze") → true  → depends_on: ["t1"]
+   *   index=2: FLOWS_TO["analyze"].includes("document")→ true  → depends_on: ["t2"]
+   *
+   *   types = ["create", "explore"]
+   *   index=1: FLOWS_TO["create"].includes("explore")  → false → depends_on: []  (병렬)
+   */
   private static resolveDependsOn(index: number, types: RequestCategory[]): string[] {
+    // 첫 번째 task는 항상 아무것도 기다리지 않음
     if (index === 0) return [];
     const prev = types[index - 1] as RequestCategory;
     const curr = types[index] as RequestCategory;
+    // t1, t2, t3... — index는 0-based이므로 이전 task id는 `t${index}` (1-based 기준)
     return this.FLOWS_TO[prev]?.includes(curr) ? [`t${index}`] : [];
   }
 
+  /**
+   * 하나의 문장으로부터 Task 객체를 생성합니다.
+   *
+   * @param sentence  - Role 1이 분리한 영어 문장 (title로 그대로 사용)
+   * @param index     - 0-based 인덱스 → id는 `t${index+1}` 형태
+   * @param type      - classifyType()이 결정한 RequestCategory
+   * @param dependsOn - resolveDependsOn()이 결정한 선행 task id 배열
+   */
   private static buildTask(
     sentence: string,
     index: number,
@@ -70,14 +132,24 @@ export class TaskGraphProcessor {
     return {
       id,
       type,
-      title: sentence,
-      status: "pending",
+      title: sentence,         // Role 1이 이미 영어로 변환한 문장을 그대로 사용
+      status: "pending",       // 모든 task는 생성 시점에 pending 상태로 초기화
       input_hash: this.computeInputHash(id, type, sentence),
       depends_on: dependsOn,
     };
   }
 
-  // 영어 문장 키워드 기반 type 분류
+  /**
+   * 영어 문장에서 키워드를 찾아 RequestCategory를 결정합니다.
+   *
+   * 매칭 우선순위: 위에서 아래 순서로 첫 번째 매칭된 type 반환
+   * 아무 키워드도 매칭되지 않으면 "execute"를 기본값으로 사용
+   *
+   * 예시:
+   *   "Find all usages of X"    → "read|find|..." 매칭  → "explore"
+   *   "Create a new component"  → "create|implement|..." 매칭 → "create"
+   *   "Run the tests"           → "run|execute|..." 매칭 → "execute"
+   */
   private static classifyType(sentence: string): RequestCategory {
     const s = sentence.toLowerCase();
     if (/read|find|look|search|explore|browse|check/.test(s)) return "explore";
@@ -88,9 +160,16 @@ export class TaskGraphProcessor {
     if (/run|execute|deploy|start|launch/.test(s))             return "execute";
     if (/document|docs|summarize|describe/.test(s))            return "document";
     if (/plan|design|organize|structure|outline/.test(s))      return "plan";
-    return "execute";
+    return "execute"; // 기본값: 어떤 키워드도 매칭되지 않으면 일반 실행 작업으로 분류
   }
 
+  /**
+   * task의 고유 식별 해시를 생성합니다. (SHA-256 앞 16자리)
+   *
+   * id + type + sentence 세 값을 조합해서 해시화하므로
+   * 같은 문장이라도 id나 type이 다르면 다른 hash가 생성됩니다.
+   * 이후 캐싱, 중복 실행 방지, 상태 추적 등에 활용할 수 있습니다.
+   */
   private static computeInputHash(id: string, type: string, sentence: string): string {
     const content = JSON.stringify({ id, type, sentence });
     return createHash("sha256").update(content).digest("hex").slice(0, 16);


### PR DESCRIPTION
## 요약

- `DependencyResolver` 구현 — DAGValidator 결과를 실제 실행 가능한 Task 순서로 변환
- `DAGValidationSuccess.topologicalOrder`를 입력받아 전체 Task 객체 + resolved deps 배열 반환
- `ResolvedTask`, `DependencyResolution` 타입 정의 — ParallelClassifier가 바로 사용 가능한 구조

## 관련 이슈

- Closes #30 

## 변경 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [ ] 테스트 추가/수정

## 영향 범위

- 영향받는 모듈:
  - `src/core/task-graph/DependencyResolver.ts` — 신규 생성
- 영향받지 않는 모듈:
  - `src/core/task-graph/DAGValidator.ts`
  - `src/core/task-graph/TaskGraphProcessor.ts`
  - `src/schemas/pipeline.ts` (스키마 변경 없음)

## 설계

```
DAGValidator.validate(graph)
  → { valid: true, topologicalOrder: string[] }

DependencyResolver.resolve(graph, validation)
  → { orderedTasks: ResolvedTask[] }
```

| 타입 | 설명 |
|---|---|
| `ResolvedTask` | `task: Task` + `deps: Task[]` (depends_on ID → 실제 객체) |
| `DependencyResolution` | `orderedTasks: ResolvedTask[]` — topological 순서 보장 |

## 테스트 방법

1. `npm run typecheck` — 타입 에러 없음 확인
2. 정상 케이스:
```ts
const graph = TaskGraphProcessor.process({ sentences: ["explore X", "create Y"] });
const validation = DAGValidator.validate(graph);
// validation.valid === true

const resolution = DependencyResolver.resolve(graph, validation as DAGValidationSuccess);
// resolution.orderedTasks[0].task.id === "t1"
// resolution.orderedTasks[1].task.id === "t2"
// resolution.orderedTasks[1].deps[0].id === "t1"
```
3. 병렬 케이스 (depends_on 없음):
```ts
// 모든 task.depends_on === [] → 각 ResolvedTask.deps === []
```

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [ ] 필요한 경우 테스트를 추가하거나 수정했습니다
- [ ] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 스크린샷 / 로그

```
> detoks@0.1.0 typecheck
> tsc --noEmit -p tsconfig.json

(0 errors)
```

## 리뷰어 참고사항

- DAGValidator가 이미 topological sort를 완료하므로 DependencyResolver는 ID → 객체 변환만 담당
- `deps` 배열은 `depends_on` 순서를 그대로 따름 (DAGValidator에서 순환 없음 보장)
- ParallelClassifier는 `orderedTasks`를 받아 `deps`가 모두 이전 stage에 있는지 기준으로 stage 분류 예정
