### PR TITLE
feat: improve CLI runtime help and errors

### DIFF
--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -12,7 +12,7 @@ export const runReplCommand = async (baseArgs: CliArgs): Promise<void> => {
   const sessionId = `repl-${Date.now()}`;
 
   output.write(
-    `detoks repl started (adapter=${baseArgs.adapter}, verbose=${String(baseArgs.verbose)}). type "exit" to quit.\n`,
+    `detoks repl started (adapter=${baseArgs.adapter}, executionMode=${baseArgs.executionMode}, verbose=${String(baseArgs.verbose)}). type "exit" to quit.\n`,
   );
 
   try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 
 import { formatError, formatSuccess } from "./format.js";
-import { parseCliArgs, toNormalizedRequest } from "./parse.js";
+import { getCliUsage, parseCliArgs, toNormalizedRequest } from "./parse.js";
 import { runCommand } from "./commands/run.js";
 import { startRepl } from "./repl/index.js";
 
 const main = async (): Promise<void> => {
   const args = parseCliArgs(process.argv.slice(2));
+
+  if (args.showHelp) {
+    console.log(getCliUsage());
+    return;
+  }
 
   if (args.mode === "repl") {
     await startRepl(args);

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -9,6 +9,18 @@ import {
 
 const DEFAULT_ADAPTER = "codex";
 const DEFAULT_EXECUTION_MODE = "stub";
+const CLI_USAGE = [
+  "Usage:",
+  '  detoks "<prompt>" [--adapter codex|gemini] [--execution-mode stub|real] [--verbose]',
+  "  detoks repl [--adapter codex|gemini] [--execution-mode stub|real] [--verbose]",
+  "  detoks --help",
+  "",
+  "Options:",
+  "  --adapter codex|gemini        Target adapter (default: codex)",
+  "  --execution-mode stub|real    Runtime execution mode (default: stub)",
+  "  --verbose                     Show full JSON output and error stacks",
+  "  -h, --help                    Show this help message",
+].join("\n");
 
 const isAdapter = (value: string): value is (typeof AdapterValues)[number] =>
   AdapterValues.includes(value as (typeof AdapterValues)[number]);
@@ -20,7 +32,7 @@ const assertPrompt = (prompt: string | undefined): string => {
   const normalized = prompt?.trim();
   if (!normalized) {
     throw new Error(
-      "Missing prompt. Usage: detoks \"<prompt>\" [--adapter codex|gemini] [--execution-mode stub|real] [--verbose] or detoks repl",
+      "Missing prompt. Run `detoks --help` for usage.",
     );
   }
   return normalized;
@@ -43,13 +55,23 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
       continue;
     }
 
+    if (current === "-h" || current === "--help") {
+      return {
+        mode: "run",
+        adapter,
+        executionMode,
+        verbose,
+        showHelp: true,
+      };
+    }
+
     if (current === "--adapter") {
       const next = argv[i + 1];
       if (!next) {
-        throw new Error("--adapter requires a value: codex|gemini");
+        throw new Error("--adapter requires a value: codex|gemini. Run `detoks --help` for usage.");
       }
       if (!isAdapter(next)) {
-        throw new Error(`Unsupported adapter: ${next}`);
+        throw new Error(`Unsupported adapter: ${next}. Use codex or gemini.`);
       }
       adapter = next;
       i += 1;
@@ -59,7 +81,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     if (current.startsWith("--adapter=")) {
       const inline = current.split("=")[1] ?? "";
       if (!isAdapter(inline)) {
-        throw new Error(`Unsupported adapter: ${inline}`);
+        throw new Error(`Unsupported adapter: ${inline}. Use codex or gemini.`);
       }
       adapter = inline;
       continue;
@@ -68,10 +90,12 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     if (current === "--execution-mode") {
       const next = argv[i + 1];
       if (!next) {
-        throw new Error("--execution-mode requires a value: stub|real");
+        throw new Error(
+          "--execution-mode requires a value: stub|real. Run `detoks --help` for usage.",
+        );
       }
       if (!isExecutionMode(next)) {
-        throw new Error(`Unsupported execution mode: ${next}`);
+        throw new Error(`Unsupported execution mode: ${next}. Use stub or real.`);
       }
       executionMode = next;
       i += 1;
@@ -81,14 +105,14 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     if (current.startsWith("--execution-mode=")) {
       const inline = current.split("=")[1] ?? "";
       if (!isExecutionMode(inline)) {
-        throw new Error(`Unsupported execution mode: ${inline}`);
+        throw new Error(`Unsupported execution mode: ${inline}. Use stub or real.`);
       }
       executionMode = inline;
       continue;
     }
 
     if (current.startsWith("--")) {
-      throw new Error(`Unknown flag: ${current}`);
+      throw new Error(`Unknown flag: ${current}. Run \`detoks --help\` for usage.`);
     }
 
     positionals.push(current);
@@ -97,9 +121,11 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
   const first = positionals[0];
   if (first === "repl") {
     if (positionals.length > 1) {
-      throw new Error('REPL mode does not accept prompt arguments. Use: detoks repl');
+      throw new Error(
+        "REPL mode does not accept prompt arguments. Run `detoks repl --help` for usage.",
+      );
     }
-    return { mode: "repl", adapter, executionMode, verbose };
+    return { mode: "repl", adapter, executionMode, verbose, showHelp: false };
   }
 
   const prompt = assertPrompt(positionals.join(" "));
@@ -109,8 +135,11 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     adapter,
     executionMode,
     verbose,
+    showHelp: false,
   };
 };
+
+export const getCliUsage = (): string => CLI_USAGE;
 
 export const toNormalizedRequest = (
   args: CliArgs,

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -20,6 +20,7 @@ export interface CliArgs {
   adapter: Adapter;
   executionMode: ExecutionMode;
   verbose: boolean;
+  showHelp: boolean;
 }
 
 export type NormalizedCliRequest = PipelineExecutionRequest;

--- a/tests/ts/unit/cli/parse.test.ts
+++ b/tests/ts/unit/cli/parse.test.ts
@@ -10,6 +10,7 @@ describe("parseCliArgs", () => {
       adapter: "codex",
       executionMode: "stub",
       verbose: false,
+      showHelp: false,
     });
   });
 
@@ -27,6 +28,41 @@ describe("parseCliArgs", () => {
       adapter: "gemini",
       executionMode: "real",
       verbose: true,
+      showHelp: false,
     });
+  });
+
+  it("parses help flags without treating them as errors", () => {
+    const parsed = parseCliArgs(["--help"]);
+    expect(parsed).toMatchObject({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "stub",
+      verbose: false,
+      showHelp: true,
+    });
+  });
+
+  it("accepts -h as a help alias", () => {
+    const parsed = parseCliArgs(["-h"]);
+    expect(parsed).toMatchObject({
+      showHelp: true,
+    });
+  });
+
+  it("treats help as higher priority than normal parsing", () => {
+    const parsed = parseCliArgs(["hello detoks", "--help"]);
+    expect(parsed).toMatchObject({
+      showHelp: true,
+      adapter: "codex",
+      executionMode: "stub",
+    });
+  });
+
+  it("adds actionable guidance to parse errors", () => {
+    expect(() => parseCliArgs(["--execution-mode"])).toThrow(
+      /Run `detoks --help` for usage/,
+    );
+    expect(() => parseCliArgs(["--unknown"])).toThrow(/Run `detoks --help` for usage/);
   });
 });


### PR DESCRIPTION
## 요약
  - CLI runtime UX를 개선하여 사용자가 실행 모드와 사용법을 더 쉽게 이해할 수 있도록 정리
  했습니다.
  - `--help`, `-h`를 지원하고, 잘못된 입력 시 `detoks --help`를 안내하도록 에러 메시지를
  개선했습니다.
  - REPL 시작 시 adapter뿐 아니라 execution mode도 함께 표시되도록 정리했습니다.

  ## 관련 이슈
  - Closes #TODO
  - Related to #TODO

  ## 변경 유형
  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 리팩터링
  - [ ] 문서 수정
  - [x] 테스트 추가/수정

  ## 영향 범위
  - 영향받는 모듈:
    - `src/cli/index.ts`
    - `src/cli/parse.ts`
    - `src/cli/types.ts`
    - `src/cli/commands/repl.ts`
    - `tests/ts/unit/cli/parse.test.ts`
  - 영향받지 않는 모듈:
    - executor / subprocess / adapter 실제 실행 계층
    - Role 1 Python 영역
    - 문서 계층

  ## 테스트 방법
  1. `npm run typecheck`
  2. `npx vitest run tests/ts/unit/cli/parse.test.ts`
  3. `detoks --help`, `detoks -h`, 잘못된 플래그 입력 시 안내 메시지 확인

  ## 체크리스트
  - [x] 로컬에서 테스트했습니다
  - [x] 필요한 경우 테스트를 추가하거나 수정했습니다
  - [ ] 필요한 경우 문서를 수정했습니다
  - [x] 브레이킹 체인지 여부를 확인했습니다
  - [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

  ## 스크린샷 / 로그
  <!-- 필요한 경우 스크린샷, 터미널 출력, 로그 등을 첨부하세요 -->

  - `npm run typecheck` 통과
  - `tests/ts/unit/cli/parse.test.ts` 통과

  ## 리뷰어 참고사항
  <!-- 리뷰어가 특히 봐야 할 부분이나 참고해야 할 내용을 적어주세요 -->

  - 이번 변경은 CLI 사용자 경험 개선에 초점이 있습니다.
  - help 플래그 우선 처리, action-oriented parse error, execution mode 가시성을 중심으로
  봐주세요.

