### PR TITLE
ParallelClassifier

### DIFF
--- a/src/core/task-graph/ParallelClassifier.ts
+++ b/src/core/task-graph/ParallelClassifier.ts
@@ -1,0 +1,86 @@
+import type { Task } from "../../schemas/pipeline.js";
+import type { DependencyResolution } from "./DependencyResolver.js";
+
+/**
+ * 동시에 실행 가능한 Task 묶음 하나를 나타냅니다.
+ *
+ * - stage : 실행 단계 번호 (0부터 시작)
+ *   - stage 0 : 아무것도 기다리지 않아도 되는 task들 — 가장 먼저 실행
+ *   - stage 1 : stage 0이 모두 완료된 후 실행 가능한 task들
+ *   - stage N : stage 0~(N-1)이 모두 완료된 후 실행 가능한 task들
+ *
+ * - tasks : 이 stage에 속한 Task 배열
+ *   - 같은 stage 안의 task들은 서로 의존하지 않으므로 병렬 실행 가능
+ *
+ * 예) t1→t2, t1→t3, t4(독립) 구조:
+ *   stage 0: [t1, t4]   ← 둘 다 depends_on 없음, 동시 실행 가능
+ *   stage 1: [t2, t3]   ← 둘 다 t1에만 의존, t1 완료 후 동시 실행 가능
+ */
+export type ExecutionStage = {
+  stage: number;
+  tasks: Task[];
+};
+
+/**
+ * ParallelClassifier.classify()의 반환값입니다.
+ *
+ * - stages : 실행 단계 배열 (stage 번호 오름차순 정렬)
+ *   - 앞 stage가 완전히 끝나야 다음 stage를 시작할 수 있음
+ *   - 같은 stage 내 task들은 병렬 실행 가능
+ *
+ * 이 구조를 실제 실행기(executor)에 넘기면
+ * "stage 단위로 await + 내부는 Promise.all" 패턴으로 실행 가능
+ */
+export type ParallelClassification = {
+  stages: ExecutionStage[];
+};
+
+/**
+ * DependencyResolver 결과를 받아 병렬 실행 가능한 stage 단위로 그룹화합니다.
+ *
+ * ─── 역할 분담 ─────────────────────────────────────────────────────
+ *   DependencyResolver  : topological 순서로 정렬된 ResolvedTask[] 제공
+ *   ParallelClassifier  : ResolvedTask[]를 stage 단위로 그룹화  ← 여기
+ *   (실행기)            : stages[]를 순서대로 실행 (stage 내부는 병렬)
+ * ──────────────────────────────────────────────────────────────────
+ *
+ * stage 배정 규칙:
+ *   - deps가 없으면 → stage 0
+ *   - deps가 있으면 → max(deps의 stage) + 1
+ *
+ * orderedTasks는 이미 topological 순서이므로,
+ * 각 task를 순서대로 처리할 때 deps의 stage가 항상 먼저 결정되어 있음이 보장됩니다.
+ */
+export class ParallelClassifier {
+  static classify(resolution: DependencyResolution): ParallelClassification {
+    // task id → 배정된 stage 번호
+    const stageMap = new Map<string, number>();
+
+    for (const { task, deps } of resolution.orderedTasks) {
+      if (deps.length === 0) {
+        // 선행 task가 없으면 가장 첫 번째 단계
+        stageMap.set(task.id, 0);
+      } else {
+        // 내 모든 deps 중 가장 늦은 stage + 1 = 내 stage
+        // 예) deps가 stage 0짜리와 stage 2짜리라면 → 내 stage = 2 + 1 = 3
+        const maxDepStage = Math.max(...deps.map((dep) => stageMap.get(dep.id) ?? 0));
+        stageMap.set(task.id, maxDepStage + 1);
+      }
+    }
+
+    // stage 번호 → Task[] 로 그룹화
+    const stageGroups = new Map<number, Task[]>();
+    for (const { task } of resolution.orderedTasks) {
+      const stage = stageMap.get(task.id)!;
+      if (!stageGroups.has(stage)) stageGroups.set(stage, []);
+      stageGroups.get(stage)!.push(task);
+    }
+
+    // stage 번호 오름차순으로 정렬하여 반환
+    const stages: ExecutionStage[] = Array.from(stageGroups.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([stage, tasks]) => ({ stage, tasks }));
+
+    return { stages };
+  }
+}


### PR DESCRIPTION
## 요약

- `ParallelClassifier` 구현 — DependencyResolver 결과를 stage 단위 병렬 실행 그룹으로 변환
- `ExecutionStage`, `ParallelClassification` 타입 정의
- stage 배정 규칙: deps 없으면 stage 0, deps 있으면 `max(deps의 stage) + 1`
- 같은 stage 내 task들은 서로 의존하지 않으므로 병렬 실행 가능

## 관련 이슈

- Closes #31 

## 변경 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [ ] 테스트 추가/수정

## 영향 범위

- 영향받는 모듈:
  - `src/core/task-graph/ParallelClassifier.ts` — 신규 생성
- 영향받지 않는 모듈:
  - `src/core/task-graph/DependencyResolver.ts`
  - `src/core/task-graph/DAGValidator.ts`
  - `src/core/task-graph/TaskGraphProcessor.ts`
  - `src/schemas/pipeline.ts`

## 설계

```
DependencyResolver.resolve(graph, validation)
  → { orderedTasks: ResolvedTask[] }

ParallelClassifier.classify(resolution)
  → { stages: ExecutionStage[] }
```

| stage | 조건 | 실행 방식 |
|---|---|---|
| 0 | depends_on 없음 | 즉시 병렬 실행 |
| N | 모든 deps가 stage N-1 이하 | 이전 stage 완료 후 병렬 실행 |

## 테스트 방법

1. `npm run typecheck` — 타입 에러 없음 확인
2. 순차 구조 (`t1→t2→t3`):
```ts
// stages: [ {stage:0,[t1]}, {stage:1,[t2]}, {stage:2,[t3]} ]
```
3. 병렬 포함 구조 (`t1→t2`, `t1→t3`):
```ts
// stages: [ {stage:0,[t1]}, {stage:1,[t2,t3]} ]  // t2, t3 동시 실행 가능
```
4. 전부 독립 (`t1`, `t2`, `t3` 모두 depends_on:[]):
```ts
// stages: [ {stage:0,[t1,t2,t3]} ]  // 전부 동시 실행 가능
```

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [ ] 필요한 경우 테스트를 추가하거나 수정했습니다
- [ ] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 스크린샷 / 로그

```
> detoks@0.1.0 typecheck
> tsc --noEmit -p tsconfig.json

(0 errors)
```

## 리뷰어 참고사항

- `orderedTasks`가 이미 topological 순서이므로 각 task 처리 시 deps의 stage가 항상 먼저 결정됨이 보장됨
- 실행기(executor)는 `stages[]`를 순서대로 순회하며 각 stage를 `Promise.all()` 패턴으로 실행 가능
- 실제 병렬 실행 및 리소스 할당은 Out of Scope — 이 클래스는 그룹화만 담당
