### PR TITLE
Test/validation

### DIFF
--- a/tests/ts/unit/core/task-graph/DAGValidator.test.ts
+++ b/tests/ts/unit/core/task-graph/DAGValidator.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { DAGValidator } from "../../../../../src/core/task-graph/DAGValidator.js";
+import { makeGraph, makeTask } from "../../helpers/task.js";
+
+describe("DAGValidator", () => {
+  describe("정상 케이스", () => {
+    it("단일 task는 유효한 DAG다", () => {
+      const graph = makeGraph(makeTask({ id: "t1" }));
+      const result = DAGValidator.validate(graph);
+
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.topologicalOrder).toEqual(["t1"]);
+      }
+    });
+
+    it("선형 의존 (t1 → t2 → t3) topological order를 반환한다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+        makeTask({ id: "t3", depends_on: ["t2"] }),
+      );
+      const result = DAGValidator.validate(graph);
+
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.topologicalOrder).toEqual(["t1", "t2", "t3"]);
+      }
+    });
+
+    it("fan-out (t1 → t2, t1 → t3) 구조는 유효하다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+        makeTask({ id: "t3", depends_on: ["t1"] }),
+      );
+      const result = DAGValidator.validate(graph);
+
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.topologicalOrder[0]).toBe("t1");
+        expect(result.topologicalOrder).toContain("t2");
+        expect(result.topologicalOrder).toContain("t3");
+      }
+    });
+
+    it("fan-in (t1, t2 → t3) 구조는 유효하다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2" }),
+        makeTask({ id: "t3", depends_on: ["t1", "t2"] }),
+      );
+      const result = DAGValidator.validate(graph);
+
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.topologicalOrder.indexOf("t1")).toBeLessThan(
+          result.topologicalOrder.indexOf("t3"),
+        );
+        expect(result.topologicalOrder.indexOf("t2")).toBeLessThan(
+          result.topologicalOrder.indexOf("t3"),
+        );
+      }
+    });
+
+    it("모든 task가 depends_on: [] 이면 고립 노드가 아니다 (의도적 병렬)", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2" }),
+        makeTask({ id: "t3" }),
+      );
+      const result = DAGValidator.validate(graph);
+
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("UNKNOWN_DEPENDENCY", () => {
+    it("존재하지 않는 id를 depends_on에 참조하면 실패한다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2", depends_on: ["t99"] }),
+      );
+      const result = DAGValidator.validate(graph);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.reason).toBe("UNKNOWN_DEPENDENCY");
+        expect(result.detail).toContain("t99");
+      }
+    });
+  });
+
+  describe("CYCLE_DETECTED", () => {
+    it("자기 자신을 depends_on에 참조하면 사이클로 감지된다", () => {
+      const graph = makeGraph(makeTask({ id: "t1", depends_on: ["t1"] }));
+      const result = DAGValidator.validate(graph);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.reason).toBe("CYCLE_DETECTED");
+      }
+    });
+
+    it("t1 → t2 → t1 사이클을 감지한다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1", depends_on: ["t2"] }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+      );
+      const result = DAGValidator.validate(graph);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.reason).toBe("CYCLE_DETECTED");
+        expect(result.detail).toContain("t1");
+        expect(result.detail).toContain("t2");
+      }
+    });
+
+    it("t1 → t2 → t3 → t1 긴 사이클을 감지한다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1", depends_on: ["t3"] }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+        makeTask({ id: "t3", depends_on: ["t2"] }),
+      );
+      const result = DAGValidator.validate(graph);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.reason).toBe("CYCLE_DETECTED");
+      }
+    });
+  });
+
+  describe("DISCONNECTED_NODE", () => {
+    it("엣지가 있는 그래프에서 고립된 노드를 감지한다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+        makeTask({ id: "t3" }), // t1-t2 연결과 무관
+      );
+      const result = DAGValidator.validate(graph);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.reason).toBe("DISCONNECTED_NODE");
+        expect(result.detail).toContain("t3");
+      }
+    });
+
+    it("diamond 구조 (t1→t2, t1→t3, t2→t4, t3→t4)는 고립 노드 없이 유효하다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+        makeTask({ id: "t3", depends_on: ["t1"] }),
+        makeTask({ id: "t4", depends_on: ["t2", "t3"] }),
+      );
+      const result = DAGValidator.validate(graph);
+
+      expect(result.valid).toBe(true);
+    });
+  });
+});

--- a/tests/ts/unit/core/task-graph/DependencyResolver.test.ts
+++ b/tests/ts/unit/core/task-graph/DependencyResolver.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { DAGValidator } from "../../../../../src/core/task-graph/DAGValidator.js";
+import { DependencyResolver } from "../../../../../src/core/task-graph/DependencyResolver.js";
+import type { TaskGraph } from "../../../../../src/schemas/pipeline.js";
+import { makeGraph, makeTask } from "../../helpers/task.js";
+
+function resolve(graph: TaskGraph) {
+  const validation = DAGValidator.validate(graph);
+  if (!validation.valid) throw new Error(`Invalid graph: ${validation.reason}`);
+  return DependencyResolver.resolve(graph, validation);
+}
+
+describe("DependencyResolver", () => {
+  describe("단순 선형 의존성", () => {
+    it("단일 task는 deps가 빈 배열이다", () => {
+      const graph = makeGraph(makeTask({ id: "t1" }));
+      const { orderedTasks } = resolve(graph);
+
+      expect(orderedTasks).toHaveLength(1);
+      expect(orderedTasks[0]!.task.id).toBe("t1");
+      expect(orderedTasks[0]!.deps).toEqual([]);
+    });
+
+    it("t1 → t2 → t3 순서로 orderedTasks를 반환한다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+        makeTask({ id: "t3", depends_on: ["t2"] }),
+      );
+      const { orderedTasks } = resolve(graph);
+
+      expect(orderedTasks.map((r) => r.task.id)).toEqual(["t1", "t2", "t3"]);
+    });
+
+    it("deps는 id 문자열이 아닌 실제 Task 객체다", () => {
+      const t1 = makeTask({ id: "t1" });
+      const t2 = makeTask({ id: "t2", depends_on: ["t1"] });
+      const graph = makeGraph(t1, t2);
+      const { orderedTasks } = resolve(graph);
+
+      const resolved_t2 = orderedTasks.find((r) => r.task.id === "t2")!;
+      expect(resolved_t2.deps).toHaveLength(1);
+      expect(resolved_t2.deps[0]!.id).toBe("t1");
+      expect(resolved_t2.deps[0]!.type).toBe(t1.type);
+    });
+
+    it("선행 task의 deps는 비어 있고, 후행 task의 deps는 채워져 있다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+        makeTask({ id: "t3", depends_on: ["t2"] }),
+      );
+      const { orderedTasks } = resolve(graph);
+
+      expect(orderedTasks[0]!.deps).toEqual([]);           // t1: 선행 없음
+      expect(orderedTasks[1]!.deps.map((d) => d.id)).toEqual(["t1"]);
+      expect(orderedTasks[2]!.deps.map((d) => d.id)).toEqual(["t2"]);
+    });
+  });
+
+  describe("복수 의존성 (fan-in)", () => {
+    it("t1, t2 → t3 구조에서 t3의 deps가 [t1, t2]다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2" }),
+        makeTask({ id: "t3", depends_on: ["t1", "t2"] }),
+      );
+      const { orderedTasks } = resolve(graph);
+
+      const resolved_t3 = orderedTasks.find((r) => r.task.id === "t3")!;
+      expect(resolved_t3.deps.map((d) => d.id)).toEqual(["t1", "t2"]);
+    });
+
+    it("t3는 orderedTasks에서 t1, t2보다 뒤에 위치한다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2" }),
+        makeTask({ id: "t3", depends_on: ["t1", "t2"] }),
+      );
+      const { orderedTasks } = resolve(graph);
+      const ids = orderedTasks.map((r) => r.task.id);
+
+      expect(ids.indexOf("t1")).toBeLessThan(ids.indexOf("t3"));
+      expect(ids.indexOf("t2")).toBeLessThan(ids.indexOf("t3"));
+    });
+  });
+
+  describe("deterministic 결과 보장", () => {
+    it("같은 입력에 대해 항상 동일한 orderedTasks를 반환한다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+        makeTask({ id: "t3", depends_on: ["t1"] }),
+        makeTask({ id: "t4", depends_on: ["t2", "t3"] }),
+      );
+
+      const result1 = resolve(graph).orderedTasks.map((r) => r.task.id);
+      const result2 = resolve(graph).orderedTasks.map((r) => r.task.id);
+
+      expect(result1).toEqual(result2);
+    });
+  });
+});

--- a/tests/ts/unit/core/task-graph/ParallelClassifier.test.ts
+++ b/tests/ts/unit/core/task-graph/ParallelClassifier.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { DAGValidator } from "../../../../../src/core/task-graph/DAGValidator.js";
+import { DependencyResolver } from "../../../../../src/core/task-graph/DependencyResolver.js";
+import { ParallelClassifier } from "../../../../../src/core/task-graph/ParallelClassifier.js";
+import type { TaskGraph } from "../../../../../src/schemas/pipeline.js";
+import { makeGraph, makeTask } from "../../helpers/task.js";
+
+function classify(graph: TaskGraph) {
+  const validation = DAGValidator.validate(graph);
+  if (!validation.valid) throw new Error(`Invalid graph: ${validation.reason}`);
+  const resolution = DependencyResolver.resolve(graph, validation);
+  return ParallelClassifier.classify(resolution);
+}
+
+describe("ParallelClassifier", () => {
+  describe("독립 Task 병렬 그룹화", () => {
+    it("단일 task는 stage 0 하나만 생성된다", () => {
+      const graph = makeGraph(makeTask({ id: "t1" }));
+      const { stages } = classify(graph);
+
+      expect(stages).toHaveLength(1);
+      expect(stages[0]!.stage).toBe(0);
+      expect(stages[0]!.tasks.map((t) => t.id)).toEqual(["t1"]);
+    });
+
+    it("모든 독립 task는 stage 0에 함께 배치된다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2" }),
+        makeTask({ id: "t3" }),
+      );
+      const { stages } = classify(graph);
+
+      expect(stages).toHaveLength(1);
+      expect(stages[0]!.stage).toBe(0);
+      expect(stages[0]!.tasks.map((t) => t.id)).toEqual(["t1", "t2", "t3"]);
+    });
+
+    it("fan-out (t1→t2, t1→t3) 구조에서 t2, t3는 같은 stage에 배치된다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+        makeTask({ id: "t3", depends_on: ["t1"] }),
+      );
+      const { stages } = classify(graph);
+
+      expect(stages).toHaveLength(2);
+
+      const stage0Ids = stages[0]!.tasks.map((t) => t.id);
+      const stage1Ids = stages[1]!.tasks.map((t) => t.id);
+
+      expect(stage0Ids).toEqual(["t1"]);
+      expect(stage1Ids).toContain("t2");
+      expect(stage1Ids).toContain("t3");
+    });
+  });
+
+  describe("순차 실행 Task 분리", () => {
+    it("t1 → t2 → t3 선형 구조는 각각 별도 stage에 배치된다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+        makeTask({ id: "t3", depends_on: ["t2"] }),
+      );
+      const { stages } = classify(graph);
+
+      expect(stages).toHaveLength(3);
+      expect(stages[0]!.tasks.map((t) => t.id)).toEqual(["t1"]);
+      expect(stages[1]!.tasks.map((t) => t.id)).toEqual(["t2"]);
+      expect(stages[2]!.tasks.map((t) => t.id)).toEqual(["t3"]);
+    });
+
+    it("fan-in (t1, t2 → t3) 구조에서 t1, t2는 stage 0이고 t3는 stage 1이다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2" }),
+        makeTask({ id: "t3", depends_on: ["t1", "t2"] }),
+      );
+      const { stages } = classify(graph);
+
+      expect(stages).toHaveLength(2);
+
+      const stage0Ids = stages[0]!.tasks.map((t) => t.id);
+      expect(stage0Ids).toContain("t1");
+      expect(stage0Ids).toContain("t2");
+      expect(stages[1]!.tasks.map((t) => t.id)).toEqual(["t3"]);
+    });
+  });
+
+  describe("stage 단위 구조 생성", () => {
+    it("stages 배열은 stage 번호 오름차순으로 정렬된다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+        makeTask({ id: "t3", depends_on: ["t2"] }),
+      );
+      const { stages } = classify(graph);
+
+      for (let i = 0; i < stages.length - 1; i++) {
+        expect(stages[i]!.stage).toBeLessThan(stages[i + 1]!.stage);
+      }
+    });
+
+    it("diamond (t1→t2,t3, t2,t3→t4) 구조는 3단계로 분류된다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+        makeTask({ id: "t3", depends_on: ["t1"] }),
+        makeTask({ id: "t4", depends_on: ["t2", "t3"] }),
+      );
+      const { stages } = classify(graph);
+
+      expect(stages).toHaveLength(3);
+      expect(stages[0]!.tasks.map((t) => t.id)).toEqual(["t1"]);
+      expect(stages[1]!.tasks.map((t) => t.id)).toContain("t2");
+      expect(stages[1]!.tasks.map((t) => t.id)).toContain("t3");
+      expect(stages[2]!.tasks.map((t) => t.id)).toEqual(["t4"]);
+    });
+
+    it("각 stage의 stage 번호는 배열 인덱스와 일치한다", () => {
+      const graph = makeGraph(
+        makeTask({ id: "t1" }),
+        makeTask({ id: "t2", depends_on: ["t1"] }),
+      );
+      const { stages } = classify(graph);
+
+      stages.forEach((s, i) => {
+        expect(s.stage).toBe(i);
+      });
+    });
+  });
+});

--- a/tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts
+++ b/tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { TaskGraphProcessor } from "../../../../../src/core/task-graph/TaskGraphProcessor.js";
+
+describe("TaskGraphProcessor", () => {
+  describe("single 요청 (문장 1개)", () => {
+    it("문장 1개는 task 1개로 변환된다", () => {
+      const result = TaskGraphProcessor.process({
+        sentences: ["Find all files in src"],
+      });
+
+      expect(result.tasks).toHaveLength(1);
+    });
+
+    it("단일 task의 id는 t1이고 depends_on은 비어 있다", () => {
+      const result = TaskGraphProcessor.process({
+        sentences: ["Find all files in src"],
+      });
+      const task = result.tasks[0]!;
+
+      expect(task.id).toBe("t1");
+      expect(task.depends_on).toEqual([]);
+    });
+
+    it("단일 task의 title은 입력 문장과 동일하다", () => {
+      const sentence = "Find all files in src";
+      const result = TaskGraphProcessor.process({ sentences: [sentence] });
+
+      expect(result.tasks[0]!.title).toBe(sentence);
+    });
+
+    it("단일 task의 status는 pending이다", () => {
+      const result = TaskGraphProcessor.process({
+        sentences: ["Find all files in src"],
+      });
+
+      expect(result.tasks[0]!.status).toBe("pending");
+    });
+
+    it("input_hash는 16자리 hex 문자열이다", () => {
+      const result = TaskGraphProcessor.process({
+        sentences: ["Find all files in src"],
+      });
+
+      expect(result.tasks[0]!.input_hash).toMatch(/^[a-f0-9]{16}$/);
+    });
+  });
+
+  describe("type 분류", () => {
+    const cases: [string, string, string][] = [
+      ["Find the structure",         "explore",  "find"],
+      ["Create a new module",        "create",   "create"],
+      ["Modify the config file",     "modify",   "modify"],
+      ["Analyze the dependencies",   "analyze",  "analyze"],
+      ["Validate the output",        "validate", "validate"],
+      ["Execute the deployment",       "execute",  "execute"],
+      ["Document the API",           "document", "document"],
+      ["Plan the architecture",      "plan",     "plan"],
+    ];
+
+    it.each(cases)('"%s" → type: "%s" (%s 키워드)', (sentence, expectedType) => {
+      const result = TaskGraphProcessor.process({ sentences: [sentence] });
+
+      expect(result.tasks[0]!.type).toBe(expectedType);
+    });
+  });
+
+  describe("multi 요청 — sequential 흐름", () => {
+    it("explore → analyze → modify 흐름은 순차 의존을 생성한다", () => {
+      const result = TaskGraphProcessor.process({
+        sentences: [
+          "Find the project structure",   // explore
+          "Analyze the dependencies",     // analyze
+          "Modify the config file",       // modify
+        ],
+      });
+
+      expect(result.tasks).toHaveLength(3);
+      expect(result.tasks[0]!.depends_on).toEqual([]);
+      expect(result.tasks[1]!.depends_on).toEqual(["t1"]);
+      expect(result.tasks[2]!.depends_on).toEqual(["t2"]);
+    });
+
+    it("task id는 t1, t2, t3 순서로 생성된다", () => {
+      const result = TaskGraphProcessor.process({
+        sentences: [
+          "Find the project structure",
+          "Analyze the dependencies",
+          "Modify the config file",
+        ],
+      });
+
+      expect(result.tasks.map((t) => t.id)).toEqual(["t1", "t2", "t3"]);
+    });
+
+    it("create → validate 흐름은 sequential이다", () => {
+      const result = TaskGraphProcessor.process({
+        sentences: [
+          "Create a new component",  // create
+          "Validate the output",     // validate
+        ],
+      });
+
+      expect(result.tasks[1]!.depends_on).toEqual(["t1"]);
+    });
+  });
+
+  describe("multi 요청 — parallel (독립)", () => {
+    it("FLOWS_TO에 없는 흐름은 depends_on: []로 독립 처리된다", () => {
+      // FLOWS_TO["create"] = ["validate", "modify", "document", "execute"] — explore 없음
+      const result = TaskGraphProcessor.process({
+        sentences: [
+          "Create a new component",  // create
+          "Find all references",     // explore
+        ],
+      });
+
+      expect(result.tasks[0]!.depends_on).toEqual([]);
+      expect(result.tasks[1]!.depends_on).toEqual([]);
+    });
+
+    it("document → 어떤 type이든 독립 처리된다 (FLOWS_TO[document] = [])", () => {
+      const result = TaskGraphProcessor.process({
+        sentences: [
+          "Document the API",        // document
+          "Validate the output",     // validate
+        ],
+      });
+
+      expect(result.tasks[1]!.depends_on).toEqual([]);
+    });
+  });
+});

--- a/tests/ts/unit/helpers/task.ts
+++ b/tests/ts/unit/helpers/task.ts
@@ -1,0 +1,16 @@
+import type { Task, TaskGraph } from "../../../../src/schemas/pipeline.js";
+
+export function makeTask(overrides: Partial<Task> & Pick<Task, "id">): Task {
+  return {
+    type: "explore",
+    status: "pending",
+    title: overrides.id,
+    input_hash: "test",
+    depends_on: [],
+    ...overrides,
+  };
+}
+
+export function makeGraph(...tasks: Task[]): TaskGraph {
+  return { tasks };
+}


### PR DESCRIPTION
## 요약

- Task Graph & Workflow Engine 4개 모듈 단위 테스트 작성 (44개 테스트)
  - `DAGValidator` — 유효 DAG 검증, 사이클/고립 노드/미존재 의존 탐지
  - `DependencyResolver` — topological 순서 변환, deps 객체 resolve
  - `ParallelClassifier` — stage 단위 그룹화, 병렬/순차 분류
  - `TaskGraphProcessor` — type 분류, sequential/parallel 흐름 결정
- 테스트 헬퍼 `makeTask` / `makeGraph` 추가 — 필수 필드 기본값 처리로 테스트 코드 간결화

## 관련 이슈

- Closes #32 

## 변경 유형

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [x] 테스트 추가/수정

## 영향 범위

- 추가된 파일:
  - `tests/ts/unit/helpers/task.ts` — `makeTask`, `makeGraph` 헬퍼
  - `tests/ts/unit/core/task-graph/DAGValidator.test.ts`
  - `tests/ts/unit/core/task-graph/DependencyResolver.test.ts`
  - `tests/ts/unit/core/task-graph/ParallelClassifier.test.ts`
  - `tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts`
- 변경된 파일: 없음 (프로덕션 코드 수정 없음)

## 테스트 커버리지

| 모듈 | 테스트 수 | 커버 항목 |
|------|---------|-----------|
| DAGValidator | 11 | 정상 DAG 5종, UNKNOWN_DEPENDENCY, CYCLE_DETECTED 3종, DISCONNECTED_NODE 2종 |
| DependencyResolver | 7 | 선형 4종, fan-in 2종, deterministic |
| ParallelClassifier | 8 | 병렬 그룹화 3종, 순차 분리 2종, stage 구조 3종 |
| TaskGraphProcessor | 18 | single 5종, type 분류 8종, sequential 3종, parallel 2종 |
| **합계** | **44** | |

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] 필요한 경우 테스트를 추가하거나 수정했습니다
- [ ] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 스크린샷 / 로그

```
> detoks@0.1.0 test
> vitest run tests/ts/unit/core/task-graph/

 ✓ tests/ts/unit/core/task-graph/DAGValidator.test.ts (11 tests) 8ms
 ✓ tests/ts/unit/core/task-graph/DependencyResolver.test.ts (7 tests) 10ms
 ✓ tests/ts/unit/core/task-graph/ParallelClassifier.test.ts (8 tests) 9ms
 ✓ tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts (18 tests) 15ms

 Test Files  4 passed (4)
      Tests  44 passed (44)
   Duration  733ms
```

## 리뷰어 참고사항

- `DependencyResolver`, `ParallelClassifier` 테스트는 DAGValidator → DependencyResolver → ParallelClassifier 전체 파이프라인을 헬퍼로 묶어 실제 사용 흐름과 동일하게 테스트
- `"Run the build script"`처럼 키워드가 중복된 문장은 `classifyType` 우선순위상 의도와 다른 type으로 분류될 수 있음 — TaskGraphProcessor 테스트에서 확인
- fan-out + fan-in 조합(diamond 구조)은 DAGValidator, ParallelClassifier 양쪽에서 핵심 케이스로 검증
