### PR TITLE
Cli runtime ux

### DIFF
--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -12,7 +12,7 @@ export const runReplCommand = async (baseArgs: CliArgs): Promise<void> => {
   const sessionId = `repl-${Date.now()}`;
 
   output.write(
-    `detoks repl started (adapter=${baseArgs.adapter}, verbose=${String(baseArgs.verbose)}). type "exit" to quit.\n`,
+    `detoks repl started (adapter=${baseArgs.adapter}, executionMode=${baseArgs.executionMode}, verbose=${String(baseArgs.verbose)}). type "exit" to quit.\n`,
   );
 
   try {

--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -12,7 +12,7 @@ export const runReplCommand = async (baseArgs: CliArgs): Promise<void> => {
   const sessionId = `repl-${Date.now()}`;
 
   output.write(
-    `detoks repl started (adapter=${baseArgs.adapter}, executionMode=${baseArgs.executionMode}, verbose=${String(baseArgs.verbose)}). type "exit" to quit.\n`,
+    `detoks repl started (adapter=${baseArgs.adapter}, executionMode=${baseArgs.executionMode}, verbose=${String(baseArgs.verbose)}). stub = simulated output; real = adapter's real execution path. type "exit" to quit.\n`,
   );
 
   try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,7 +9,7 @@ const main = async (): Promise<void> => {
   const args = parseCliArgs(process.argv.slice(2));
 
   if (args.showHelp) {
-    console.log(getCliUsage());
+    console.log(getCliUsage(args.helpTopic ?? "main"));
     return;
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 
 import { formatError, formatSuccess } from "./format.js";
-import { parseCliArgs, toNormalizedRequest } from "./parse.js";
+import { getCliUsage, parseCliArgs, toNormalizedRequest } from "./parse.js";
 import { runCommand } from "./commands/run.js";
 import { startRepl } from "./repl/index.js";
 
 const main = async (): Promise<void> => {
   const args = parseCliArgs(process.argv.slice(2));
+
+  if (args.showHelp) {
+    console.log(getCliUsage());
+    return;
+  }
 
   if (args.mode === "repl") {
     await startRepl(args);

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -9,6 +9,18 @@ import {
 
 const DEFAULT_ADAPTER = "codex";
 const DEFAULT_EXECUTION_MODE = "stub";
+const CLI_USAGE = [
+  "Usage:",
+  '  detoks "<prompt>" [--adapter codex|gemini] [--execution-mode stub|real] [--verbose]',
+  "  detoks repl [--adapter codex|gemini] [--execution-mode stub|real] [--verbose]",
+  "  detoks --help",
+  "",
+  "Options:",
+  "  --adapter codex|gemini        Target adapter (default: codex)",
+  "  --execution-mode stub|real    Runtime execution mode (default: stub)",
+  "  --verbose                     Show full JSON output and error stacks",
+  "  -h, --help                    Show this help message",
+].join("\n");
 
 const isAdapter = (value: string): value is (typeof AdapterValues)[number] =>
   AdapterValues.includes(value as (typeof AdapterValues)[number]);
@@ -20,7 +32,7 @@ const assertPrompt = (prompt: string | undefined): string => {
   const normalized = prompt?.trim();
   if (!normalized) {
     throw new Error(
-      "Missing prompt. Usage: detoks \"<prompt>\" [--adapter codex|gemini] [--execution-mode stub|real] [--verbose] or detoks repl",
+      "Missing prompt. Run `detoks --help` for usage.",
     );
   }
   return normalized;
@@ -43,13 +55,23 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
       continue;
     }
 
+    if (current === "-h" || current === "--help") {
+      return {
+        mode: "run",
+        adapter,
+        executionMode,
+        verbose,
+        showHelp: true,
+      };
+    }
+
     if (current === "--adapter") {
       const next = argv[i + 1];
       if (!next) {
-        throw new Error("--adapter requires a value: codex|gemini");
+        throw new Error("--adapter requires a value: codex|gemini. Run `detoks --help` for usage.");
       }
       if (!isAdapter(next)) {
-        throw new Error(`Unsupported adapter: ${next}`);
+        throw new Error(`Unsupported adapter: ${next}. Use codex or gemini.`);
       }
       adapter = next;
       i += 1;
@@ -59,7 +81,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     if (current.startsWith("--adapter=")) {
       const inline = current.split("=")[1] ?? "";
       if (!isAdapter(inline)) {
-        throw new Error(`Unsupported adapter: ${inline}`);
+        throw new Error(`Unsupported adapter: ${inline}. Use codex or gemini.`);
       }
       adapter = inline;
       continue;
@@ -68,10 +90,12 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     if (current === "--execution-mode") {
       const next = argv[i + 1];
       if (!next) {
-        throw new Error("--execution-mode requires a value: stub|real");
+        throw new Error(
+          "--execution-mode requires a value: stub|real. Run `detoks --help` for usage.",
+        );
       }
       if (!isExecutionMode(next)) {
-        throw new Error(`Unsupported execution mode: ${next}`);
+        throw new Error(`Unsupported execution mode: ${next}. Use stub or real.`);
       }
       executionMode = next;
       i += 1;
@@ -81,14 +105,14 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     if (current.startsWith("--execution-mode=")) {
       const inline = current.split("=")[1] ?? "";
       if (!isExecutionMode(inline)) {
-        throw new Error(`Unsupported execution mode: ${inline}`);
+        throw new Error(`Unsupported execution mode: ${inline}. Use stub or real.`);
       }
       executionMode = inline;
       continue;
     }
 
     if (current.startsWith("--")) {
-      throw new Error(`Unknown flag: ${current}`);
+      throw new Error(`Unknown flag: ${current}. Run \`detoks --help\` for usage.`);
     }
 
     positionals.push(current);
@@ -97,9 +121,11 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
   const first = positionals[0];
   if (first === "repl") {
     if (positionals.length > 1) {
-      throw new Error('REPL mode does not accept prompt arguments. Use: detoks repl');
+      throw new Error(
+        "REPL mode does not accept prompt arguments. Run `detoks repl --help` for usage.",
+      );
     }
-    return { mode: "repl", adapter, executionMode, verbose };
+    return { mode: "repl", adapter, executionMode, verbose, showHelp: false };
   }
 
   const prompt = assertPrompt(positionals.join(" "));
@@ -109,8 +135,11 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     adapter,
     executionMode,
     verbose,
+    showHelp: false,
   };
 };
+
+export const getCliUsage = (): string => CLI_USAGE;
 
 export const toNormalizedRequest = (
   args: CliArgs,

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -9,15 +9,41 @@ import {
 
 const DEFAULT_ADAPTER = "codex";
 const DEFAULT_EXECUTION_MODE = "stub";
-const CLI_USAGE = [
+const EXECUTION_MODE_HELP = [
+  "Execution mode:",
+  "    stub = simulated output for fast, safe CLI testing",
+  "    real = runs the adapter's real execution path",
+].join("\n");
+const CLI_USAGE_MAIN = [
   "Usage:",
   '  detoks "<prompt>" [--adapter codex|gemini] [--execution-mode stub|real] [--verbose]',
   "  detoks repl [--adapter codex|gemini] [--execution-mode stub|real] [--verbose]",
+  "  detoks repl --help",
   "  detoks --help",
   "",
   "Options:",
   "  --adapter codex|gemini        Target adapter (default: codex)",
   "  --execution-mode stub|real    Runtime execution mode (default: stub)",
+  EXECUTION_MODE_HELP,
+  "  --verbose                     Show full JSON output and error stacks",
+  "  -h, --help                    Show this help message",
+].join("\n");
+
+const CLI_USAGE_REPL = [
+  "Usage:",
+  "  detoks repl [--adapter codex|gemini] [--execution-mode stub|real] [--verbose]",
+  "  detoks repl --help",
+  "",
+  "REPL notes:",
+  "  - type a prompt and press Enter to run it",
+  "  - type exit, quit, or .exit to leave the REPL",
+  "  - each prompt is executed as a separate work unit",
+  "  - execution-mode controls whether prompts use simulated or real execution",
+  "",
+  "Options:",
+  "  --adapter codex|gemini        Target adapter (default: codex)",
+  "  --execution-mode stub|real    Runtime execution mode (default: stub)",
+  EXECUTION_MODE_HELP,
   "  --verbose                     Show full JSON output and error stacks",
   "  -h, --help                    Show this help message",
 ].join("\n");
@@ -56,12 +82,14 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     }
 
     if (current === "-h" || current === "--help") {
+      const helpTopic = positionals[0] === "repl" ? "repl" : "main";
       return {
         mode: "run",
         adapter,
         executionMode,
         verbose,
         showHelp: true,
+        helpTopic,
       };
     }
 
@@ -125,7 +153,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
         "REPL mode does not accept prompt arguments. Run `detoks repl --help` for usage.",
       );
     }
-    return { mode: "repl", adapter, executionMode, verbose, showHelp: false };
+    return { mode: "repl", adapter, executionMode, verbose, showHelp: false, helpTopic: "repl" };
   }
 
   const prompt = assertPrompt(positionals.join(" "));
@@ -136,10 +164,12 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     executionMode,
     verbose,
     showHelp: false,
+    helpTopic: "main",
   };
 };
 
-export const getCliUsage = (): string => CLI_USAGE;
+export const getCliUsage = (topic: "main" | "repl" = "main"): string =>
+  topic === "repl" ? CLI_USAGE_REPL : CLI_USAGE_MAIN;
 
 export const toNormalizedRequest = (
   args: CliArgs,

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -20,6 +20,7 @@ export interface CliArgs {
   adapter: Adapter;
   executionMode: ExecutionMode;
   verbose: boolean;
+  showHelp: boolean;
 }
 
 export type NormalizedCliRequest = PipelineExecutionRequest;

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -21,6 +21,7 @@ export interface CliArgs {
   executionMode: ExecutionMode;
   verbose: boolean;
   showHelp: boolean;
+  helpTopic?: "main" | "repl";
 }
 
 export type NormalizedCliRequest = PipelineExecutionRequest;

--- a/tests/ts/unit/cli/parse.test.ts
+++ b/tests/ts/unit/cli/parse.test.ts
@@ -10,6 +10,7 @@ describe("parseCliArgs", () => {
       adapter: "codex",
       executionMode: "stub",
       verbose: false,
+      showHelp: false,
     });
   });
 
@@ -27,6 +28,41 @@ describe("parseCliArgs", () => {
       adapter: "gemini",
       executionMode: "real",
       verbose: true,
+      showHelp: false,
     });
+  });
+
+  it("parses help flags without treating them as errors", () => {
+    const parsed = parseCliArgs(["--help"]);
+    expect(parsed).toMatchObject({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "stub",
+      verbose: false,
+      showHelp: true,
+    });
+  });
+
+  it("accepts -h as a help alias", () => {
+    const parsed = parseCliArgs(["-h"]);
+    expect(parsed).toMatchObject({
+      showHelp: true,
+    });
+  });
+
+  it("treats help as higher priority than normal parsing", () => {
+    const parsed = parseCliArgs(["hello detoks", "--help"]);
+    expect(parsed).toMatchObject({
+      showHelp: true,
+      adapter: "codex",
+      executionMode: "stub",
+    });
+  });
+
+  it("adds actionable guidance to parse errors", () => {
+    expect(() => parseCliArgs(["--execution-mode"])).toThrow(
+      /Run `detoks --help` for usage/,
+    );
+    expect(() => parseCliArgs(["--unknown"])).toThrow(/Run `detoks --help` for usage/);
   });
 });

--- a/tests/ts/unit/cli/parse.test.ts
+++ b/tests/ts/unit/cli/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseCliArgs } from "../../../../src/cli/parse.js";
+import { getCliUsage, parseCliArgs } from "../../../../src/cli/parse.js";
 
 describe("parseCliArgs", () => {
   it("parses one-shot mode with defaults", () => {
@@ -11,6 +11,7 @@ describe("parseCliArgs", () => {
       executionMode: "stub",
       verbose: false,
       showHelp: false,
+      helpTopic: "main",
     });
   });
 
@@ -29,6 +30,7 @@ describe("parseCliArgs", () => {
       executionMode: "real",
       verbose: true,
       showHelp: false,
+      helpTopic: "repl",
     });
   });
 
@@ -40,6 +42,7 @@ describe("parseCliArgs", () => {
       executionMode: "stub",
       verbose: false,
       showHelp: true,
+      helpTopic: "main",
     });
   });
 
@@ -47,6 +50,7 @@ describe("parseCliArgs", () => {
     const parsed = parseCliArgs(["-h"]);
     expect(parsed).toMatchObject({
       showHelp: true,
+      helpTopic: "main",
     });
   });
 
@@ -56,7 +60,31 @@ describe("parseCliArgs", () => {
       showHelp: true,
       adapter: "codex",
       executionMode: "stub",
+      helpTopic: "main",
     });
+  });
+
+  it("parses repl help as a topic-specific help request", () => {
+    const parsed = parseCliArgs(["repl", "--help"]);
+    expect(parsed).toMatchObject({
+      mode: "run",
+      showHelp: true,
+      helpTopic: "repl",
+    });
+  });
+
+  it("documents execution mode differences in main help", () => {
+    const usage = getCliUsage("main");
+    expect(usage).toContain("Execution mode:");
+    expect(usage).toContain("stub = simulated output for fast, safe CLI testing");
+    expect(usage).toContain("real = runs the adapter's real execution path");
+  });
+
+  it("documents execution mode differences in repl help", () => {
+    const usage = getCliUsage("repl");
+    expect(usage).toContain("execution-mode controls whether prompts use simulated or real execution");
+    expect(usage).toContain("stub = simulated output for fast, safe CLI testing");
+    expect(usage).toContain("real = runs the adapter's real execution path");
   });
 
   it("adds actionable guidance to parse errors", () => {


### PR DESCRIPTION
## 요약
  - detoks CLI help와 REPL 안내 문구에서 execution-mode의 `stub` / `real` 차이를 더 명확히
  설명했습니다.
  - 사용자가 help와 REPL 시작 메시지만 보고도 현재 모드 의미를 이해할 수 있도록 UX를 보강
  했습니다.

  ## 관련 이슈
  - Closes #
  - Related to #

  ## 변경 유형p
  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 리팩터링
  - [ ] 문서 수정
  - [x] 테스트 추가/수정

  ## 영향 범위
  - 영향받는 모듈:
    - `src/cli/parse.ts`
    - `src/cli/index.ts`
    - `src/cli/types.ts`
    - `src/cli/commands/repl.ts`
    - `tests/ts/unit/cli/parse.test.ts`
  - 영향받지 않는 모듈:
    - core pipeline
    - integrations
    - subprocess/runtime execution behavior

  ## 테스트 방법
  1. `rtk npm test -- tests/ts/unit/cli/parse.test.ts`
  2. `rtk npm run typecheck`
  3. 필요 시 `detoks --help`, `detoks repl --help` 출력 확인

  ## 체크리스트
  - [x] 로컬에서 테스트했습니다
  - [x] 필요한 경우 테스트를 추가하거나 수정했습니다
  - [ ] 필요한 경우 문서를 수정했습니다
  - [x] 브레이킹 체인지 여부를 확인했습니다
  - [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

  ## 스크린샷 / 로그
  - parse test 통과
  - typecheck 통과

  ## 리뷰어 참고사항
  - execution-mode의 실제 동작은 변경하지 않았고, help/안내 문구와 테스트만 보강했습니다.

