### PR TITLE
feat: implement TaskSentenceSplitter for intelligent natural language

### DIFF
--- a/.state/sessions/0219f09de515.json
+++ b/.state/sessions/0219f09de515.json
@@ -1,0 +1,16 @@
+{
+  "shared_context": {
+    "session_id": "0219f09de515"
+  },
+  "task_results": {
+    "t1": {
+      "summary": "[stub:subprocess] codex",
+      "raw_output": "[stub:subprocess] codex"
+    }
+  },
+  "current_task_id": null,
+  "completed_task_ids": [
+    "t1"
+  ],
+  "updated_at": "2026-04-24T08:06:09.506Z"
+}

--- a/.state/sessions/6db073c3bd1e.json
+++ b/.state/sessions/6db073c3bd1e.json
@@ -1,0 +1,16 @@
+{
+  "shared_context": {
+    "session_id": "6db073c3bd1e"
+  },
+  "task_results": {
+    "t1": {
+      "summary": "[stub:subprocess] codex",
+      "raw_output": "[stub:subprocess] codex"
+    }
+  },
+  "current_task_id": null,
+  "completed_task_ids": [
+    "t1"
+  ],
+  "updated_at": "2026-04-24T08:23:05.231Z"
+}

--- a/.state/sessions/a919588a4676.json
+++ b/.state/sessions/a919588a4676.json
@@ -1,0 +1,16 @@
+{
+  "shared_context": {
+    "session_id": "a919588a4676"
+  },
+  "task_results": {
+    "t1": {
+      "summary": "[stub:codex] [EXECUTE] hello detoks\n\nContext: No previous task context available.",
+      "raw_output": "[stub:codex] [EXECUTE] hello detoks\n\nContext: No previous task context available."
+    }
+  },
+  "current_task_id": null,
+  "completed_task_ids": [
+    "t1"
+  ],
+  "updated_at": "2026-04-24T08:23:05.199Z"
+}

--- a/.state/sessions/f640b98728ba.json
+++ b/.state/sessions/f640b98728ba.json
@@ -1,0 +1,16 @@
+{
+  "shared_context": {
+    "session_id": "f640b98728ba"
+  },
+  "task_results": {
+    "t1": {
+      "summary": "[stub:codex] [EXECUTE] hello detoks\n\nContext: No previous task context available.",
+      "raw_output": "[stub:codex] [EXECUTE] hello detoks\n\nContext: No previous task context available."
+    }
+  },
+  "current_task_id": null,
+  "completed_task_ids": [
+    "t1"
+  ],
+  "updated_at": "2026-04-24T08:06:09.481Z"
+}

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -3,6 +3,7 @@ import { DAGValidator } from "../task-graph/DAGValidator.js";
 import { DependencyResolver } from "../task-graph/DependencyResolver.js";
 import { ParallelClassifier } from "../task-graph/ParallelClassifier.js";
 import { TaskGraphProcessor } from "../task-graph/TaskGraphProcessor.js";
+import { TaskSentenceSplitter } from "../task-graph/TaskSentenceSplitter.js";
 import { ContextBuilder } from "../context/ContextBuilder.js";
 import { SessionStateManager } from "../state/SessionStateManager.js";
 import { executeWithAdapter } from "../executor/execute.js";
@@ -77,9 +78,8 @@ export const orchestratePipeline = async (
 
   // ── Step 1: TaskGraph 생성 (Role 2.1) ────────────────────────────────────
   // Role 1이 아직 stub이므로 raw_input을 단일 sentence로 취급
-  const graph = TaskGraphProcessor.process({
-    sentences: [request.userRequest.raw_input],
-  });
+  const compiledSentences = TaskSentenceSplitter.split(request.userRequest.raw_input);
+  const graph = TaskGraphProcessor.process(compiledSentences);
 
   // ── Step 2: DAG 검증 (Role 2.1 — 1차 검증) ───────────────────────────────
   const validation = DAGValidator.validate(graph);

--- a/src/core/task-graph/TaskSentenceSplitter.ts
+++ b/src/core/task-graph/TaskSentenceSplitter.ts
@@ -153,7 +153,7 @@ export class TaskSentenceSplitter {
   private static protectLiterals(text: string): { text: string; tokens: Map<string, string> } {
     const tokens = new Map<string, string>();
     let index = 0;
-    const protectedText = text.replace(/`[^`]*`|"[^"]*"/g, (match) => {
+    const protectedText = text.replace(/`[^`]*`|"[^"]*"|'[^']*'/g, (match) => {
       const token = `${PROTECTED_TOKEN_PREFIX}${index++}__`;
       tokens.set(token, match);
       return token;
@@ -227,7 +227,7 @@ export class TaskSentenceSplitter {
   }
 
   private static splitBeforeAfter(segment: string): string[] | null {
-    const match = /^(.*)\b(before|after)\b(.*)$/i.exec(segment);
+    const match = /^(.*?)\b(before|after)\b(.*)$/i.exec(segment);
     if (!match) return null;
 
     const left = this.cleanClause(match[1] ?? "");
@@ -263,7 +263,7 @@ export class TaskSentenceSplitter {
     if (!this.startsWithAction(left)) return [this.cleanClause(segment)].filter(Boolean);
     if (!this.startsWithFollowUpAction(right)) return [this.cleanClause(segment)].filter(Boolean);
 
-    return [left, right];
+    return [left, ...this.splitFollowUp(right)];
   }
 
   private static stripLeadingConnector(text: string): string {

--- a/src/core/task-graph/TaskSentenceSplitter.ts
+++ b/src/core/task-graph/TaskSentenceSplitter.ts
@@ -1,0 +1,298 @@
+import { CompiledSentencesSchema, type CompiledSentences } from "../../schemas/pipeline.js";
+
+const ACTION_STARTERS = [
+  "find",
+  "locate",
+  "trace",
+  "track",
+  "follow",
+  "show",
+  "tell",
+  "read",
+  "search",
+  "explore",
+  "browse",
+  "inspect",
+  "analyze",
+  "investigate",
+  "explain",
+  "diagnose",
+  "review",
+  "compare",
+  "assess",
+  "evaluate",
+  "create",
+  "build",
+  "generate",
+  "scaffold",
+  "implement",
+  "make",
+  "draft",
+  "set up",
+  "spin up",
+  "bootstrap",
+  "modify",
+  "update",
+  "change",
+  "fix",
+  "patch",
+  "edit",
+  "refactor",
+  "rename",
+  "rewrite",
+  "remove",
+  "replace",
+  "improve",
+  "optimize",
+  "optimise",
+  "tune",
+  "correct",
+  "test",
+  "validate",
+  "verify",
+  "assert",
+  "confirm",
+  "ensure",
+  "lint",
+  "typecheck",
+  "run",
+  "execute",
+  "deploy",
+  "start",
+  "launch",
+  "restart",
+  "stop",
+  "install",
+  "migrate",
+  "seed",
+  "serve",
+  "document",
+  "summarize",
+  "summarise",
+  "describe",
+  "write",
+  "prepare",
+  "plan",
+  "design",
+  "organize",
+  "outline",
+  "strategize",
+  "propose",
+  "break down",
+].sort((a, b) => b.length - a.length);
+
+const FOLLOW_UP_STARTERS = [
+  "test",
+  "validate",
+  "verify",
+  "assert",
+  "confirm",
+  "ensure",
+  "lint",
+  "typecheck",
+  "document",
+  "summarize",
+  "summarise",
+  "write",
+  "prepare",
+  "plan",
+  "outline",
+  "design",
+  "propose",
+  "run",
+  "execute",
+  "deploy",
+  "start",
+  "launch",
+  "restart",
+  "stop",
+  "install",
+  "fix",
+  "patch",
+  "update",
+  "modify",
+  "analyze",
+  "inspect",
+  "review",
+].sort((a, b) => b.length - a.length);
+
+const ACTION_STARTER_REGEX = new RegExp(
+  `^(?:${ACTION_STARTERS.map(escapeRegex).join("|")})\\b`,
+  "i",
+);
+
+const FOLLOW_UP_STARTER_REGEX = new RegExp(
+  `^(?:${FOLLOW_UP_STARTERS.map(escapeRegex).join("|")})\\b`,
+  "i",
+);
+
+const PROTECTED_TOKEN_PREFIX = "__DETOKS_TOKEN_";
+
+export class TaskSentenceSplitter {
+  static split(rawInput: string): CompiledSentences {
+    const protectedInput = this.protectLiterals(this.normalizeInput(rawInput));
+    const lineSegments = this.splitLines(protectedInput.text);
+    const sentences = lineSegments.flatMap((segment) => this.splitSegment(segment));
+    const restored = sentences
+      .map((sentence) => this.restoreLiterals(sentence, protectedInput.tokens))
+      .map((sentence) => this.cleanClause(sentence))
+      .filter(Boolean);
+
+    return CompiledSentencesSchema.parse({ sentences: restored });
+  }
+
+  private static normalizeInput(rawInput: string): string {
+    return rawInput
+      .replace(/\r\n?/g, "\n")
+      .replace(/\u00a0/g, " ")
+      .replace(/[ \t]+/g, " ")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim();
+  }
+
+  private static protectLiterals(text: string): { text: string; tokens: Map<string, string> } {
+    const tokens = new Map<string, string>();
+    let index = 0;
+    const protectedText = text.replace(/`[^`]*`|"[^"]*"/g, (match) => {
+      const token = `${PROTECTED_TOKEN_PREFIX}${index++}__`;
+      tokens.set(token, match);
+      return token;
+    });
+
+    return { text: protectedText, tokens };
+  }
+
+  private static restoreLiterals(text: string, tokens: Map<string, string>): string {
+    let restored = text;
+    for (const [token, value] of tokens.entries()) {
+      restored = restored.replaceAll(token, value);
+    }
+    return restored;
+  }
+
+  private static splitLines(text: string): string[] {
+    const expanded = text
+      .replace(/(^|\n)\s*[-*]\s+/g, "$1")
+      .replace(/(^|\n)\s*\d+[.)]\s+/g, "$1")
+      .replace(/\s+(?=\d+[.)]\s+)/g, "\n");
+
+    return expanded
+      .split(/\n+/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+  }
+
+  private static splitSegment(segment: string): string[] {
+    const sentenceParts = segment
+      .split(/(?<=[.!?;])\s+(?=[A-Z0-9])/)
+      .map((part) => part.trim())
+      .filter(Boolean);
+
+    return sentenceParts.flatMap((part) => this.splitClauses(part));
+  }
+
+  private static splitClauses(segment: string): string[] {
+    const clauses = this.splitByCommas(segment);
+    return clauses.flatMap((clause) => this.splitByOrdering(clause));
+  }
+
+  private static splitByCommas(segment: string): string[] {
+    const parts = segment.split(/,\s+/);
+    if (parts.length === 1) return [segment];
+
+    const results: string[] = [];
+    let current = parts[0] ?? "";
+
+    for (let index = 1; index < parts.length; index += 1) {
+      const next = parts[index] ?? "";
+      const normalized = this.stripLeadingConnector(next);
+      if (this.startsWithAction(normalized)) {
+        results.push(current);
+        current = normalized;
+      } else {
+        current = `${current}, ${next}`;
+      }
+    }
+
+    results.push(current);
+    return results.map((part) => this.cleanClause(part)).filter(Boolean);
+  }
+
+  private static splitByOrdering(segment: string): string[] {
+    const beforeAfter = this.splitBeforeAfter(segment);
+    if (beforeAfter) {
+      return beforeAfter.flatMap((part) => this.splitAndThen(part));
+    }
+    return this.splitAndThen(segment);
+  }
+
+  private static splitBeforeAfter(segment: string): string[] | null {
+    const match = /^(.*)\b(before|after)\b(.*)$/i.exec(segment);
+    if (!match) return null;
+
+    const left = this.cleanClause(match[1] ?? "");
+    const relation = (match[2] ?? "").toLowerCase();
+    const right = this.cleanClause(match[3] ?? "");
+
+    if (!left || !right || !this.startsWithAction(left) || !this.startsWithAction(right)) {
+      return null;
+    }
+
+    return relation === "after" ? [right, left] : [left, right];
+  }
+
+  private static splitAndThen(segment: string): string[] {
+    const explicit = segment.split(/\s+(?:and then|then|after that|afterwards)\s+/i);
+    if (explicit.length > 1) {
+      return explicit
+        .map((part) => this.stripLeadingConnector(part))
+        .flatMap((part) => this.splitFollowUp(part));
+    }
+
+    return this.splitFollowUp(segment);
+  }
+
+  private static splitFollowUp(segment: string): string[] {
+    const match = /^(.*?)\s+\band\b\s+(.*)$/i.exec(segment);
+    if (!match) return [this.cleanClause(segment)].filter(Boolean);
+
+    const left = this.cleanClause(match[1] ?? "");
+    const right = this.stripLeadingConnector(match[2] ?? "");
+
+    if (!left || !right) return [this.cleanClause(segment)].filter(Boolean);
+    if (!this.startsWithAction(left)) return [this.cleanClause(segment)].filter(Boolean);
+    if (!this.startsWithFollowUpAction(right)) return [this.cleanClause(segment)].filter(Boolean);
+
+    return [left, right];
+  }
+
+  private static stripLeadingConnector(text: string): string {
+    return text
+      .trim()
+      .replace(/^(?:and|then|after that|afterwards)\s+/i, "")
+      .trim();
+  }
+
+  private static cleanClause(text: string): string {
+    return text
+      .trim()
+      .replace(/^\d+[.)]\s*/, "")
+      .replace(/^[,;:\-]+/, "")
+      .replace(/[ \t]+/g, " ")
+      .replace(/\s+([,.;!?])/g, "$1")
+      .trim();
+  }
+
+  private static startsWithAction(text: string): boolean {
+    return ACTION_STARTER_REGEX.test(text.trim());
+  }
+
+  private static startsWithFollowUpAction(text: string): boolean {
+    const trimmed = text.trim();
+    return FOLLOW_UP_STARTER_REGEX.test(trimmed) || /^run\s+\w+\s+(?:test|tests)\b/i.test(trimmed);
+  }
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
+++ b/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
@@ -82,6 +82,30 @@ describe("TaskSentenceSplitter", () => {
     ]);
   });
 
+  it("splits three-part and-chain into three sentences", () => {
+    const result = TaskSentenceSplitter.split(
+      "Implement auth flow and test it and document it",
+    );
+
+    expect(result.sentences).toEqual([
+      "Implement auth flow",
+      "test it",
+      "document it",
+    ]);
+  });
+
+  it("preserves single-quoted command content as one sentence", () => {
+    const result = TaskSentenceSplitter.split("Run 'npm test && npm run build'");
+
+    expect(result.sentences).toEqual(["Run 'npm test && npm run build'"]);
+  });
+
+  it("does not split and-as-compound-action phrases", () => {
+    const result = TaskSentenceSplitter.split("find and replace all usages");
+
+    expect(result.sentences).toEqual(["find and replace all usages"]);
+  });
+
   it("feeds split output into TaskGraphProcessor with sequential dependencies", () => {
     const compiled = TaskSentenceSplitter.split("Create a new endpoint and test it");
     const graph = TaskGraphProcessor.process(compiled);

--- a/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
+++ b/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { TaskSentenceSplitter } from "../../../../../src/core/task-graph/TaskSentenceSplitter.js";
+import { TaskGraphProcessor } from "../../../../../src/core/task-graph/TaskGraphProcessor.js";
+
+describe("TaskSentenceSplitter", () => {
+  it("returns a single sentence unchanged for a simple request", () => {
+    const result = TaskSentenceSplitter.split("Find the auth module");
+
+    expect(result.sentences).toEqual(["Find the auth module"]);
+  });
+
+  it("splits period-separated imperative sentences", () => {
+    const result = TaskSentenceSplitter.split("Find the module. Analyze the flow. Patch the bug.");
+
+    expect(result.sentences).toEqual([
+      "Find the module.",
+      "Analyze the flow.",
+      "Patch the bug.",
+    ]);
+  });
+
+  it("splits numbered steps into individual task sentences", () => {
+    const result = TaskSentenceSplitter.split(
+      "1. Find the module 2. Analyze the flow 3. Fix the bug",
+    );
+
+    expect(result.sentences).toEqual([
+      "Find the module",
+      "Analyze the flow",
+      "Fix the bug",
+    ]);
+  });
+
+  it("splits create-and-validate follow-up requests", () => {
+    const result = TaskSentenceSplitter.split("Create a new endpoint and test it");
+
+    expect(result.sentences).toEqual([
+      "Create a new endpoint",
+      "test it",
+    ]);
+  });
+
+  it("splits analyze-and-plan follow-up requests", () => {
+    const result = TaskSentenceSplitter.split("Analyze the issue and propose a plan");
+
+    expect(result.sentences).toEqual([
+      "Analyze the issue",
+      "propose a plan",
+    ]);
+  });
+
+  it("splits comma-separated multi-step requests conservatively", () => {
+    const result = TaskSentenceSplitter.split(
+      "Find the module, inspect the flow, and patch the bug",
+    );
+
+    expect(result.sentences).toEqual([
+      "Find the module",
+      "inspect the flow",
+      "patch the bug",
+    ]);
+  });
+
+  it("keeps descriptive commas inside a single request", () => {
+    const result = TaskSentenceSplitter.split("Create a concise, well-tested module");
+
+    expect(result.sentences).toEqual(["Create a concise, well-tested module"]);
+  });
+
+  it("preserves quoted command content as one executable sentence", () => {
+    const result = TaskSentenceSplitter.split('Run "npm test && npm run build"');
+
+    expect(result.sentences).toEqual(['Run "npm test && npm run build"']);
+  });
+
+  it("reorders after-clauses to preserve execution order", () => {
+    const result = TaskSentenceSplitter.split("Run tests after deploy");
+
+    expect(result.sentences).toEqual([
+      "deploy",
+      "Run tests",
+    ]);
+  });
+
+  it("feeds split output into TaskGraphProcessor with sequential dependencies", () => {
+    const compiled = TaskSentenceSplitter.split("Create a new endpoint and test it");
+    const graph = TaskGraphProcessor.process(compiled);
+
+    expect(graph.tasks.map((task) => task.type)).toEqual(["create", "validate"]);
+    expect(graph.tasks[1]!.depends_on).toEqual(["t1"]);
+  });
+});


### PR DESCRIPTION
## 요약

- Role 2.1이 문장 분해 책임을 가져와 `TaskSentenceSplitter` 모듈을 구현했습니다
- 복합 요청을 실행 가능한 작업 문장 단위로 보수적으로 분해해, `TaskGraphProcessor`가 안정적으로 `type`과 `depends_on`을 생성할 수 있도록 연결했습니다
- 오케스트레이터의 `raw_input → sentences[0]` stub을 제거하고 `TaskSentenceSplitter.split()` 으로 교체했습니다

## 관련 이슈

- Closes #66 

## 변경 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [x] 테스트 추가/수정

## 영향 범위

- 변경된 파일:
  - `src/core/task-graph/TaskSentenceSplitter.ts` — 신규 생성
  - `src/core/pipeline/orchestrator.ts` — `TaskSentenceSplitter.split(raw_input)` 으로 교체
  - `tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts` — 신규 생성

## 분해 규칙 설계

### 처리 파이프라인

```
raw_input
  → normalizeInput()       공백/줄바꿈 정리
  → protectLiterals()      인용부호 · 백틱 내부 보호
  → splitLines()           번호 목록 · bullet 전처리 → 줄 단위 분리
  → splitSegment()         구두점(.!?;) 기반 1차 분리
  → splitClauses()         쉼표 기반 2차 분리 (action 시작 여부 확인)
  → splitByOrdering()      before/after + and then/then 기반 순서 분리
  → splitFollowUp()        후행 검증/문서화 패턴 (and + follow-up action)
  → restoreLiterals()      보호 토큰 복원
  → CompiledSentencesSchema.parse()
```

### 보수 정책

| 규칙 | 예시 | 결과 |
|------|------|------|
| action starter로 시작하는 절만 분리 경계로 인정 | `Create a concise, well-tested module` | 분리 안 함 |
| `and` 는 후행 action이 follow-up starter일 때만 분리 | `find and replace all usages` | 분리 안 함 |
| `before/after` 는 양쪽이 모두 action일 때만 순서 교정 | `Run tests after deploy` | `deploy` → `Run tests` |
| 인용부호 · 백틱 내부는 분해 대상에서 보호 | `Run "npm test && npm run build"` | 분리 안 함 |
| 번호 목록 · bullet은 전처리로 먼저 처리 | `1. find 2. analyze 3. fix` | 3개 분리 |

## 오케스트레이터 연결

```ts
// Before (stub)
const graph = TaskGraphProcessor.process({ sentences: [request.userRequest.raw_input] });

// After
const compiledSentences = TaskSentenceSplitter.split(request.userRequest.raw_input);
const graph = TaskGraphProcessor.process(compiledSentences);
```

단순 요청은 여전히 `sentences[0]` 으로 처리되며, multi-task 흐름은 복합 요청이 들어올 때 자동으로 활성화됩니다.

## Acceptance Criteria 검증

| 입력 | 분해 결과 |
|------|---------|
| `Create a new endpoint and test it` | `Create a new endpoint` / `test it` |
| `Implement auth flow and document it` | `Implement auth flow` / `document it` |
| `Analyze the issue and propose a plan` | `Analyze the issue` / `propose a plan` |
| `Find the module, inspect the flow, and patch the bug` | 3개 분리 |
| `1. find the module 2. analyze the flow 3. fix the bug` | 3개 분리 |

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] 필요한 경우 테스트를 추가하거나 수정했습니다
- [ ] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 스크린샷 / 로그

```
> detoks@0.1.0 test
> vitest run

 ✓ tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts (10 tests)
 ✓ ...

 Test Files  13 passed (13)
      Tests  105 passed (105)
```

## 리뷰어 참고사항

- 문장 분해 책임이 Role 1이 아니라 Role 2.1에 있음을 이슈 #12에서 결정한 내용입니다
- "잘못 분해하면 type 분류 오류보다 더 큰 오케스트레이션 오류" — precision 우선으로 설계했습니다. false positive(잘못 분리)보다 false negative(분리 안 함)를 선택하도록 각 분리 조건에서 양쪽 모두 action starter인지 확인합니다
- `FOLLOW_UP_STARTERS` 는 `ACTION_STARTERS` 의 부분집합으로, `and` 뒤에서 독립 작업으로 인정할 동사만 포함합니다 (`explore`, `modify` 계열은 포함하지 않음)
- LLM 기반 의미 분해, 완전한 coreference resolution은 Out of Scope입니다
