### PR TITLE
fix: ExecutionResultNormalizer - 빈 raw_output에 기본값 제공

### DIFF
--- a/src/core/state/ExecutionResultNormalizer.ts
+++ b/src/core/state/ExecutionResultNormalizer.ts
@@ -23,11 +23,16 @@ export class ExecutionResultNormalizer {
       };
 
       // 0. Summary 자동 추출 (없을 경우)
-      if (!normalized.summary && normalized.raw_output) {
-        // 첫 번째 줄 전체를 요약으로 활용 (너무 길지 않게 제한)
-        const lines = normalized.raw_output.split('\n');
-        const firstLine = lines[0]?.trim() || '';
-        normalized.summary = firstLine.length > 100 ? firstLine.substring(0, 97) + '...' : firstLine;
+      if (!normalized.summary) {
+        if (normalized.raw_output) {
+          // 첫 번째 줄 전체를 요약으로 활용 (너무 길지 않게 제한)
+          const lines = normalized.raw_output.split('\n');
+          const firstLine = lines[0]?.trim() || '';
+          normalized.summary = firstLine.length > 100 ? firstLine.substring(0, 97) + '...' : firstLine;
+        } else {
+          // raw_output가 없으면 상태 기반 기본 요약 제공
+          normalized.summary = normalized.success ? 'Task completed successfully' : 'Task execution failed';
+        }
       }
 
       // 1. 에러 정보 정규화 (exitCode나 stderr가 있을 경우)


### PR DESCRIPTION
## 설명

ExecutionResultNormalizer가 raw_output이 없거나 빈 경우에도 항상 유효한 summary를 생성하도록 개선했습니다.

## 문제

- raw_output이 undefined 또는 ''일 때 summary가 undefined가 될 수 있음
- 일부 에러 케이스에서 요약 정보가 누락되는 현상

## 해결

- raw_output이 없을 때 작업 성공/실패 상태 기반 기본값 제공
- 'Task completed successfully' 또는 'Task execution failed' 제공
- 모든 상황에서 유효한 summary 보장

## 변경사항

**src/core/state/ExecutionResultNormalizer.ts**

```typescript
// Before
if (!normalized.summary && normalized.raw_output) {
  // raw_output이 ''이면 summary 생성 안됨
}

// After  
if (!normalized.summary) {
  if (normalized.raw_output) {
    // 첫 줄 추출
  } else {
    // 상태 기반 기본값
    normalized.summary = normalized.success 
      ? 'Task completed successfully' 
      : 'Task execution failed';
  }
}
```

## 테스트

- ExecutionResultNormalizer 엣지 케이스 테스트로 검증
- null/undefined 입력, 다양한 에러 형식 처리 확인
- 12/12 테스트 통과

## 영향 범위

- Role 2.2: SessionState 저장 시 자동 정규화 과정
- State persistence layer (SessionStateManager)