### PR TITLE
test: add gemini real smoke coverage

### DIFF
--- a/docs/my docs/CLI_PIPELINE_STATUS.md
+++ b/docs/my docs/CLI_PIPELINE_STATUS.md
@@ -141,6 +141,7 @@ CLI Input
 
 - codex / gemini adapter boundary 존재
 - `executionMode=stub|real` 분기 존재
+- smoke에서 codex/gemini real 경로의 `rawOutput` 계약을 fake binary로 고정함
 
 현재 특징:
 - adapter 구조는 있음
@@ -158,6 +159,7 @@ CLI Input
 
 - stub subprocess runner 존재
 - real subprocess runner 존재
+- CLI smoke에서 codex/gemini real 실행 시 stdout/rawOutput 일치 계약을 검증함
 
 한계:
 - real runner는 존재하지만, 실제 CLI binary 유무에 따라 runtime 결과가 달라질 수 있음

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -1,5 +1,6 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -19,6 +20,72 @@ const runCliWithInput = (args: string[], input: string) =>
     encoding: "utf8",
     input,
   });
+
+const runCliWithEnv = (args: string[], env: NodeJS.ProcessEnv) =>
+  spawnSync(process.execPath, ["--import", "tsx", cliEntry, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+
+const createFakeBinary = (dir: string, command: "codex" | "gemini") => {
+  const binaryPath = join(dir, command);
+  writeFileSync(
+    binaryPath,
+    `#!/usr/bin/env node
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+});
+process.stdin.on("end", () => {
+  process.stdout.write(\`[fake:${command}] \${input}\`);
+});
+`,
+    "utf8",
+  );
+  chmodSync(binaryPath, 0o755);
+  return binaryPath;
+};
+
+const runAdapterRawOutputSmoke = (adapter: "codex" | "gemini", prompt: string) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "detoks-cli-real-"));
+  createFakeBinary(tempDir, adapter);
+
+  const stubRun = runCli([prompt, "--adapter", adapter, "--verbose"]);
+  const realRun = runCliWithEnv(
+    [prompt, "--adapter", adapter, "--execution-mode", "real", "--verbose"],
+    {
+      PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+    },
+  );
+
+  expect(stubRun.error).toBeUndefined();
+  expect(realRun.error).toBeUndefined();
+  expect(stubRun.status).toBe(0);
+  expect(realRun.status).toBe(0);
+  expect(stubRun.stderr).toBe("");
+  expect(realRun.stderr).toBe("");
+
+  const stubJson = JSON.parse(stubRun.stdout.trim());
+  const realJson = JSON.parse(realRun.stdout.trim());
+
+  expect(stubJson).toMatchObject({
+    ok: true,
+    mode: "run",
+    adapter,
+  });
+  expect(stubJson.rawOutput).toContain(`[stub:${adapter}] [EXECUTE] ${prompt}`);
+  expect(realJson).toMatchObject({
+    ok: true,
+    mode: "run",
+    adapter,
+  });
+  expect(realJson.rawOutput).toContain(`[fake:${adapter}] [EXECUTE] ${prompt}`);
+  expect(realJson.rawOutput).not.toBe(stubJson.rawOutput);
+  expect(realJson).toHaveProperty("rawOutput");
+  expect(realRun.stdout).not.toBe(stubRun.stdout);
+};
 
 describe("detoks CLI smoke", () => {
   it("keeps default stdout concise and verbose stdout full", () => {
@@ -150,5 +217,13 @@ describe("detoks CLI smoke", () => {
     expect(verboseJson.results).toHaveLength(2);
     expect(verboseJson.results[0].compiled_prompt).toBe("Create a new file");
     expect(verboseJson.results[1].compiled_prompt).toBe("Run npm test");
+  });
+
+  it("keeps codex real rawOutput distinct from stub rawOutput in smoke mode", () => {
+    runAdapterRawOutputSmoke("codex", "hello detoks");
+  });
+
+  it("keeps gemini real rawOutput distinct from stub rawOutput in smoke mode", () => {
+    runAdapterRawOutputSmoke("gemini", "hello gemini");
   });
 });


### PR DESCRIPTION
## 요약
  - CLI smoke test에서 gemini adapter의 real execution rawOutput 계약을 추가로 고정했습니
  다.
  - codex/gemini 모두 fake binary 기반으로 stub vs real rawOutput 차이를 smoke 수준에서
  검증하도록 정리했습니다.

  ## 관련 이슈
  - Closes #
  - Related to #

  ## 변경 유형p
  - [ ] 기능 추가
  - [ ] 버그 수정
  - [ ] 리팩터링
  - [x] 문서 수정
  - [x] 테스트 추가/수정

  ## 영향 범위
  - 영향받는 모듈:
    - `tests/ts/integration/cli-smoke.test.ts`
    - `docs/my docs/CLI_PIPELINE_STATUS.md`
  - 영향받지 않는 모듈:
    - `src/cli/*`
    - `src/integrations/*`
    - real execution 구현 로직

  ## 테스트 방법
  1. `rtk npm test -- tests/ts/integration/cli-smoke.test.ts tests/ts/unit/integrations/
  adapters/real-path.test.ts`
  2. `rtk npm run typecheck`

  ## 체크리스트
  - [x] 로컬에서 테스트했습니다
  - [x] 필요한 경우 테스트를 추가하거나 수정했습니다
  - [x] 필요한 경우 문서를 수정했습니다
  - [x] 브레이킹 체인지 여부를 확인했습니다
  - [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

  ## 스크린샷 / 로그
  - cli smoke / real-path 테스트 통과
  - `rtk npm run typecheck` 통과

  ## 리뷰어 참고사항
  - 이번 변경은 구현 변경이 아니라 smoke coverage 대칭성 보강입니다.
  - fake binary를 통해 codex/gemini real rawOutput 계약을 얇게 고정했습니다.

