### PR TITLE
fix: strengthen Role1 validation and literal preservation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ tests/ts/integration/
 tests/integration/
 tests/data
 tmp
+graphify-out

--- a/docs/ROLE1_PIPELINE_IMPROVEMENT_REQUIREMENTS.md
+++ b/docs/ROLE1_PIPELINE_IMPROVEMENT_REQUIREMENTS.md
@@ -218,6 +218,39 @@ P2:
 - `src/core/guardrails/repair.ts`
 - `src/core/prompt/compression.ts`
 - `scripts/verify-role1.ts`
+
+## 2026-04-26 후속 반영 및 잔여 작업
+
+이번 반영에서 처리한 사항:
+
+- 일반 한국어 인용구가 `quoted_literal`로 과보호되지 않도록 필터를 추가했다.
+- 최종 결과에 `korean_text_remaining`, `source_korean_copied`가 남으면 item 단위 `final_retry`가 동작하도록 수정했다.
+- 관련 unit test를 추가해 일반 한국어 인용구 비마스킹과 한글 잔존 시 item 재시도를 회귀 테스트로 고정했다.
+
+같은 날짜 기준 `tests/data/row_data.json` 전체 106건 재검증 결과:
+
+- `completed_count: 104`
+- `failed_count: 2`
+- `average_inference_time_sec: 0.753`
+- `average_token_reduction_rate: 31.864`
+- `average_translation_token_reduction_rate: 30.776`
+- `average_compression_token_reduction_rate: 1.622`
+- `compression_fallback_count: 0`
+- `repair_action_item_count: 27`
+- `validation_failed_count: 2`
+
+이번 검증에서 남은 후속 작업:
+
+- `ROI(투자 대비 효과)`처럼 영문 토큰과 한글 설명이 섞인 괄호형 표현이 과보호되어 최종 복원 후 한글이 남는 케이스를 줄여야 한다.
+- `prometheus_exporter.collect()`처럼 필수 literal이 누락된 경우 fallback 이후에도 복구되지 않는 케이스를 줄여야 한다.
+- 이를 위해 retry prompt에 `required_literals`를 명시적으로 주입하거나, 혼합 괄호 표현을 high-confidence literal 후보에서 제외하는 추가 보정이 필요하다.
+
+대표 실패 케이스:
+
+- `index 36`
+  - `ROI(투자 대비 효과)`가 placeholder로 보호된 뒤 한글 설명이 최종 결과에 남아 `korean_text_remaining`, `source_korean_copied`로 실패
+- `index 84`
+  - `prometheus_exporter.collect()`가 번역 출력에서 누락되어 `required_literal_missing:prometheus_exporter.collect()`로 실패
 - `tests/ts/unit/core/guardrails`
 - `tests/ts/unit/core/prompt`
 - `tests/ts/integration`

--- a/docs/ROLE1_PIPELINE_IMPROVEMENT_REQUIREMENTS.md
+++ b/docs/ROLE1_PIPELINE_IMPROVEMENT_REQUIREMENTS.md
@@ -1,0 +1,237 @@
+# Role 1 파이프라인 개선 요구사항
+
+## 목적
+
+`tmp/role1-row-result.json` 분석 결과를 바탕으로 Role 1 파이프라인의 품질 결함과 개선 요구사항을 구현 관점에서 정리한다.
+
+이 문서는 다음 범위에 한정한다.
+
+- Role 1 번역 결과 검증
+- protected segment masking / restore
+- prompt compression 안전성
+- batch 검증 결과 집계
+- Role 1 회귀 테스트 보강
+
+다음은 범위에서 제외한다.
+
+- Role 2.1 request classification 변경
+- task graph 구조 변경
+- executor / runtime orchestration 변경
+
+## 배경
+
+`tmp/role1-row-result.json` 기준 요약은 다음과 같다.
+
+- `completed_count: 106`
+- `failed_count: 0`
+- `average_inference_time_sec: 0.577`
+- `average_token_reduction_rate: 32.182`
+
+겉보기 성공률은 높지만, 개별 결과를 보면 검증 누락과 의미 손실이 존재한다.
+
+대표 사례:
+
+- `index 12`
+  - 한글이 결과에 남아 있는데도 `validation_errors=[]`, `status=completed`
+- `index 71`
+  - `I/O bound`가 `bounded task`로 변형됨
+- `index 76`
+  - `matplotlib.pyplot.scatter` 의미가 문장 구조에 흡수됨
+- `index 85`
+  - `numpy.dot(A, B)`에서 핵심 API 식별자가 사라짐
+- `index 99`
+  - `unittest.mock.patch`가 잘못된 의미 구조로 재배치됨
+- `index 102`
+  - `RandomForestRegressor` 관련 번역이 깨지고 의미가 오염됨
+- `index 104`
+  - `threading.Event`와 `'GO'` 신호의 관계가 잘못 복원됨
+
+## 핵심 문제 정의
+
+### 1. 최종 결과 검증 누락
+
+현재 최종 `restoredText`에 대해 validator를 다시 적용하지 않아, span 단계에서는 없던 오류가 최종 결과에서 발생해도 누락될 수 있다.
+
+영향:
+
+- 실제 오류가 있어도 batch 결과가 `completed`로 기록될 수 있다.
+- `failed_count=0`가 품질 신호로서 약해진다.
+
+### 2. 보호 대상 토큰 보존 범위 부족
+
+현재 masking 규칙은 code/path/filename/numeric token 중심이다.  
+하지만 실제 오류는 다음 유형에서 반복된다.
+
+- dotted identifier
+- qualified class / module path
+- 함수 호출식
+- slash 기반 토큰 (`I/O`, `blue/green`)
+- 라이브러리 API 표현식
+
+영향:
+
+- 번역기 또는 압축기에서 핵심 API 명칭이 오염된다.
+- Role 2.1에 전달되는 `compiled_prompt` 의미가 바뀔 수 있다.
+
+### 3. repair가 형식 복구에 치우쳐 있음
+
+현재 repair는 placeholder 형식과 순서 복구에는 유효하지만, 의미 보존 실패까지 막지 못한다.
+
+영향:
+
+- `repair_actions`가 남아도 결과 품질이 보장되지 않는다.
+- 사용자 관점에서는 고쳐진 것처럼 보여도 실제 의미는 틀릴 수 있다.
+
+### 4. 압축 지표와 품질 지표가 섞여 있음
+
+현재 `average_token_reduction_rate`는 `raw_input -> compiled_prompt` 기준이라 번역 효과와 압축 효과가 분리되지 않는다.
+
+영향:
+
+- 압축기 성능을 과대평가할 수 있다.
+- `normalized_input == compiled_prompt`인 경우에도 압축이 잘 된 것처럼 보일 수 있다.
+
+### 5. 회귀 테스트 부족
+
+현재 테스트는 placeholder 복구와 기본 압축 동작 중심이다.  
+실제 실패 사례를 직접 고정하는 테스트가 부족하다.
+
+영향:
+
+- 동일한 품질 회귀가 다시 발생할 가능성이 높다.
+- 문서상 보존 규칙과 실제 동작 간 괴리가 누적된다.
+
+## 개선 요구사항
+
+### 요구사항 1. 최종 복원 후 재검증 추가
+
+해야 할 일:
+
+- `restore_placeholders()` 이후 최종 텍스트에 대해 `validate_translation()`를 다시 수행한다.
+- 최종 `validation_errors`는 span-level 오류 재사용이 아니라 최종 결과 기준으로 산출한다.
+- 최종 결과에 오류가 있으면 batch item을 `failed`로 기록한다.
+
+수용 기준:
+
+- 한글이 남은 결과는 `korean_text_remaining` 또는 동등한 오류로 기록된다.
+- 최종 결과에 required term 누락, placeholder mismatch가 있으면 `completed`가 되지 않는다.
+
+### 요구사항 2. masking 보호 범위 확장
+
+해야 할 일:
+
+- 다음 토큰 유형을 보호 구간 후보로 추가하거나 우선순위를 높인다.
+  - dotted identifier
+  - qualified module path
+  - 함수 호출식
+  - slash token
+  - 라이브러리 API 표현식
+- `numpy.dot(A, B)`, `unittest.mock.patch`, `threading.Event`, `matplotlib.pyplot.scatter` 같은 형태를 통째로 보존할 수 있게 한다.
+
+수용 기준:
+
+- 보호 대상 토큰이 번역 단계에서 부분 유실되지 않는다.
+- 복원 후 API/식별자 문자열이 원문과 동일하게 유지된다.
+
+### 요구사항 3. 의미 보존 검증 강화
+
+해야 할 일:
+
+- source에 포함된 핵심 protected token이 output에도 그대로 존재하는지 검사한다.
+- 필요한 경우 정책 기반 `required_terms` 자동 생성 규칙을 확장한다.
+- repair 이후에도 핵심 토큰이 누락되면 실패로 처리한다.
+
+수용 기준:
+
+- API 이름이 일반 명사나 설명 문구로 대체되면 validation 오류가 발생한다.
+- 형식은 정상이어도 핵심 식별자 누락 시 통과하지 않는다.
+
+### 요구사항 4. 압축 fallback 기준 보강
+
+해야 할 일:
+
+- 압축 결과가 의미를 바꾸거나 핵심 action signal을 약화시키면 `normalized_input` fallback 한다.
+- 압축 안전성 판정에 protected token 보존 여부를 포함한다.
+
+수용 기준:
+
+- 과도한 축약으로 의미 손실이 발생한 케이스는 `compressed_with_nlp_adapter` 대신 fallback 된다.
+- 압축 성공은 길이 절감이 아니라 의미 보존을 전제로 한다.
+
+### 요구사항 5. 검증 지표 분리
+
+해야 할 일:
+
+- 검증 결과에 다음 지표를 분리해 기록한다.
+  - `raw -> normalized` 토큰 변화율
+  - `normalized -> compiled` 토큰 변화율
+  - compression fallback 횟수
+  - repair 발생 횟수
+  - validation 실패 횟수
+
+수용 기준:
+
+- 번역 품질과 압축 품질을 서로 다른 수치로 확인할 수 있다.
+- 평균 압축률이 실제 압축 동작을 과장하지 않는다.
+
+### 요구사항 6. 실데이터 회귀 테스트 추가
+
+해야 할 일:
+
+- `row_data.json` 기반 실제 실패/오염 사례를 unit 또는 integration test로 고정한다.
+- 최소한 다음 케이스를 회귀 테스트에 포함한다.
+  - `index 12`
+  - `index 71`
+  - `index 76`
+  - `index 85`
+  - `index 99`
+  - `index 102`
+  - `index 104`
+
+수용 기준:
+
+- 위 케이스들이 다시 오염되면 테스트가 실패한다.
+- 문서상 보호 규칙이 테스트로 연결된다.
+
+## 우선순위
+
+P0:
+
+- 최종 복원 후 재검증 추가
+- masking 보호 범위 확장
+- 의미 보존 검증 강화
+
+P1:
+
+- 압축 fallback 기준 보강
+- 실데이터 회귀 테스트 추가
+
+P2:
+
+- 검증 지표 분리
+
+## 구현 대상 후보
+
+- `src/core/translate/translate.ts`
+- `src/core/translate/masking.ts`
+- `src/core/guardrails/validator.ts`
+- `src/core/guardrails/repair.ts`
+- `src/core/prompt/compression.ts`
+- `scripts/verify-role1.ts`
+- `tests/ts/unit/core/guardrails`
+- `tests/ts/unit/core/prompt`
+- `tests/ts/integration`
+
+## 비목표
+
+- Role 1이 task decomposition 책임을 가져가는 변경
+- Role 2.1 handoff schema 변경
+- 대규모 리팩터링
+- provider 구조 변경
+
+## 작업 원칙
+
+- 최소 변경 원칙을 유지한다.
+- 기존 Role 1 책임 경계를 넘지 않는다.
+- 문서에 있는 보존 규칙을 테스트로 고정한다.
+- 지표 개선보다 검증 정확도 개선을 우선한다.

--- a/scripts/verify-role1.ts
+++ b/scripts/verify-role1.ts
@@ -29,8 +29,11 @@ interface VerificationItem {
   status: "completed" | "failed";
   inference_time_sec: number;
   input_prompt_tokens: number;
+  normalized_input_tokens: number;
   compiled_prompt_tokens: number;
   token_reduction_rate: number | null;
+  translation_token_reduction_rate: number | null;
+  compression_token_reduction_rate: number | null;
   validation_errors: string[];
   repair_actions: string[];
   error?: string;
@@ -55,6 +58,11 @@ interface VerificationSummary {
   failed_count: number;
   average_inference_time_sec: number;
   average_token_reduction_rate: number;
+  average_translation_token_reduction_rate: number;
+  average_compression_token_reduction_rate: number;
+  compression_fallback_count: number;
+  repair_action_item_count: number;
+  validation_failed_count: number;
 }
 
 function getUsage(): string {
@@ -255,22 +263,33 @@ async function main(): Promise<void> {
   try {
     const results: VerificationItem[] = batchResult.results.map((item, index) => {
       const inputPromptTokens = encodeTokenCount(encoding, item.raw_input);
+      const normalizedInput = item.normalized_input ?? "";
+      const normalizedInputTokens = encodeTokenCount(encoding, normalizedInput);
       const compiledPrompt = item.compiled_prompt ?? "";
       const compiledPromptTokens = encodeTokenCount(encoding, compiledPrompt);
 
       return {
         index: options.index !== undefined ? options.index : index,
         raw_input: item.raw_input,
-        normalized_input: item.normalized_input ?? "",
+        normalized_input: normalizedInput,
         compiled_prompt: compiledPrompt,
         role2_handoff: item.role2_handoff ?? "",
         language: item.language ?? "en",
         status: item.status,
         inference_time_sec: item.inference_time_sec ?? 0,
         input_prompt_tokens: inputPromptTokens,
+        normalized_input_tokens: normalizedInputTokens,
         compiled_prompt_tokens: compiledPromptTokens,
         token_reduction_rate: calculateTokenReductionRate(
           inputPromptTokens,
+          compiledPromptTokens,
+        ),
+        translation_token_reduction_rate: calculateTokenReductionRate(
+          inputPromptTokens,
+          normalizedInputTokens,
+        ),
+        compression_token_reduction_rate: calculateTokenReductionRate(
+          normalizedInputTokens,
           compiledPromptTokens,
         ),
         validation_errors: item.validation_errors,
@@ -293,8 +312,13 @@ async function main(): Promise<void> {
             role2_handoff: item.role2_handoff,
             inference_time_sec: item.inference_time_sec,
             input_prompt_tokens: item.input_prompt_tokens,
+            normalized_input_tokens: item.normalized_input_tokens,
             compiled_prompt_tokens: item.compiled_prompt_tokens,
             token_reduction_rate: item.token_reduction_rate,
+            translation_token_reduction_rate:
+              item.translation_token_reduction_rate,
+            compression_token_reduction_rate:
+              item.compression_token_reduction_rate,
             validation_errors: item.validation_errors,
             repair_actions: item.repair_actions,
             ...(item.error ? { error: item.error } : {}),
@@ -323,6 +347,12 @@ async function main(): Promise<void> {
     const reductionSamples = results
       .map((item) => item.token_reduction_rate)
       .filter((value): value is number => value !== null);
+    const translationReductionSamples = results
+      .map((item) => item.translation_token_reduction_rate)
+      .filter((value): value is number => value !== null);
+    const compressionReductionSamples = results
+      .map((item) => item.compression_token_reduction_rate)
+      .filter((value): value is number => value !== null);
     const summary: VerificationSummary = {
       completed_count: completedCount,
       failed_count: failedCount,
@@ -340,6 +370,29 @@ async function main(): Promise<void> {
                 reductionSamples.length,
             )
           : 0,
+      average_translation_token_reduction_rate:
+        translationReductionSamples.length > 0
+          ? roundMetric(
+              translationReductionSamples.reduce((sum, value) => sum + value, 0) /
+                translationReductionSamples.length,
+            )
+          : 0,
+      average_compression_token_reduction_rate:
+        compressionReductionSamples.length > 0
+          ? roundMetric(
+              compressionReductionSamples.reduce((sum, value) => sum + value, 0) /
+                compressionReductionSamples.length,
+            )
+          : 0,
+      compression_fallback_count: results.filter((item) =>
+        item.repair_actions.includes("compression_fallback_to_normalized_input")
+      ).length,
+      repair_action_item_count: results.filter((item) =>
+        item.repair_actions.length > 0
+      ).length,
+      validation_failed_count: results.filter((item) =>
+        item.validation_errors.length > 0
+      ).length,
     };
 
     console.log(

--- a/src/core/guardrails/validator.ts
+++ b/src/core/guardrails/validator.ts
@@ -93,6 +93,36 @@ function normalizeInlineWhitespace(text: string): string {
   return text.replace(/\s+/g, " ").trim();
 }
 
+export function isHighConfidenceInferredLiteral(literal: string): boolean {
+  const normalized = normalizeInlineWhitespace(literal);
+
+  if (!normalized || hasKorean(normalized)) {
+    return false;
+  }
+
+  if (/\b[A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)*\([^()\n]*\)/.test(normalized)) {
+    return true;
+  }
+
+  if (/\b[A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)+\b/.test(normalized)) {
+    return true;
+  }
+
+  if (/\b[A-Za-z]+_[A-Za-z0-9_]+\b/.test(normalized)) {
+    return true;
+  }
+
+  if (/[\\/]/.test(normalized)) {
+    return true;
+  }
+
+  if (/[`'"]/.test(normalized)) {
+    return true;
+  }
+
+  return false;
+}
+
 export function findMissingRequiredLiterals(
   outputText: string,
   requiredLiterals: readonly string[] = [],
@@ -141,7 +171,7 @@ export function validate_translation(
         ? { model_names: request.model_names }
         : {}),
     },
-  );
+  ).filter(isHighConfidenceInferredLiteral);
   const validationErrors = [
     ...validatePlaceholderSequence(
       request.source_text,

--- a/src/core/guardrails/validator.ts
+++ b/src/core/guardrails/validator.ts
@@ -1,9 +1,13 @@
+import { collect_preservable_literals } from "../translate/masking.js";
+
 export interface TranslationGuardrailsRequest {
   source_text: string;
   compressed_prompt: string;
   placeholders?: string[];
   protected_terms?: string[];
   required_terms?: string[];
+  required_literals?: string[];
+  model_names?: string[];
   forbidden_patterns?: string[];
 }
 
@@ -85,6 +89,29 @@ function validateRequiredTerms(
     .map((term) => `required_term_missing:${term}`);
 }
 
+function normalizeInlineWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+export function findMissingRequiredLiterals(
+  outputText: string,
+  requiredLiterals: readonly string[] = [],
+): string[] {
+  const normalizedOutput = normalizeInlineWhitespace(outputText);
+
+  return [...new Set(requiredLiterals)]
+    .filter(Boolean)
+    .filter((literal) => !normalizedOutput.includes(normalizeInlineWhitespace(literal)));
+}
+
+function validateRequiredLiterals(
+  outputText: string,
+  requiredLiterals: readonly string[] = [],
+): string[] {
+  return findMissingRequiredLiterals(outputText, requiredLiterals)
+    .map((literal) => `required_literal_missing:${literal}`);
+}
+
 function validateLengthDelta(
   sourceText: string,
   outputText: string,
@@ -104,6 +131,17 @@ function validateLengthDelta(
 export function validate_translation(
   request: TranslationGuardrailsRequest,
 ): TranslationGuardrailsResponse {
+  const inferredRequiredLiterals = collect_preservable_literals(
+    request.source_text,
+    {
+      ...(request.protected_terms
+        ? { protected_terms: request.protected_terms }
+        : {}),
+      ...(request.model_names
+        ? { model_names: request.model_names }
+        : {}),
+    },
+  );
   const validationErrors = [
     ...validatePlaceholderSequence(
       request.source_text,
@@ -117,6 +155,10 @@ export function validate_translation(
     ...validateRequiredTerms(
       request.compressed_prompt,
       request.required_terms,
+    ),
+    ...validateRequiredLiterals(
+      request.compressed_prompt,
+      [...inferredRequiredLiterals, ...(request.required_literals ?? [])],
     ),
     ...validateLengthDelta(request.source_text, request.compressed_prompt),
   ];

--- a/src/core/llm-client/client.ts
+++ b/src/core/llm-client/client.ts
@@ -117,6 +117,10 @@ export async function complete_chat(
       },
     );
 
+    if (!response || typeof response.json !== "function") {
+      throw new Error("Invalid LLM response: fetch returned no response");
+    }
+
     const rawResponse = (await response.json()) as Record<string, unknown>;
     if (!response.ok) {
       throw new Error(

--- a/src/core/prompt/compression.ts
+++ b/src/core/prompt/compression.ts
@@ -1,6 +1,8 @@
 import type { Role1Policies } from "./config.js";
 import {
+  collect_preservable_literals,
   mask_protected_segments,
+  type MaskProtectedSegmentsOptions,
   restore_placeholders,
   type PlaceholderEntry,
 } from "../translate/masking.js";
@@ -195,6 +197,21 @@ function isUnsafeCompression(
   return false;
 }
 
+function normalizeLiteralText(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function isMissingCriticalLiteral(
+  outputText: string,
+  requiredLiterals: readonly string[],
+): boolean {
+  const normalizedOutput = normalizeLiteralText(outputText);
+
+  return [...new Set(requiredLiterals)]
+    .filter(Boolean)
+    .some((literal) => !normalizedOutput.includes(normalizeLiteralText(literal)));
+}
+
 function compressMaskedText(maskedText: string): string {
   const lines = maskedText.split("\n");
 
@@ -217,11 +234,7 @@ function compressMaskedText(maskedText: string): string {
 
 function buildMaskOptions(
   options: CompressPromptOptions,
-): {
-  protected_terms: string[];
-  preferred_translations: Record<string, string>;
-  model_names: string[];
-} {
+): MaskProtectedSegmentsOptions {
   return {
     protected_terms: options.policies.protectedTerms,
     preferred_translations: options.policies.preferredTranslations,
@@ -234,6 +247,10 @@ export function compress_prompt(
   options: CompressPromptOptions,
 ): CompressPromptResult {
   const maskOptions = buildMaskOptions(options);
+  const requiredLiterals = collect_preservable_literals(
+    normalized_input,
+    maskOptions,
+  );
   const masked = mask_protected_segments(normalized_input, maskOptions);
   const compressedMaskedText = compressMaskedText(masked.masked_text);
 
@@ -248,6 +265,13 @@ export function compress_prompt(
     compressedMaskedText,
     masked.placeholders as PlaceholderEntry[],
   );
+
+  if (isMissingCriticalLiteral(restored, requiredLiterals)) {
+    return {
+      compressed_prompt: normalized_input,
+      repair_actions: ["compression_fallback_to_normalized_input"],
+    };
+  }
 
   if (normalizeWhitespace(restored) === normalizeWhitespace(normalized_input)) {
     return {

--- a/src/core/translate/masking.ts
+++ b/src/core/translate/masking.ts
@@ -42,6 +42,10 @@ interface MatchCandidate {
   priority: number;
 }
 
+function hasKorean(text: string): boolean {
+  return /[가-힣]/.test(text);
+}
+
 const PATTERN_SPECS: ReadonlyArray<{
   kind: Exclude<
     ProtectedSegmentKind,
@@ -152,6 +156,10 @@ function addRegexCandidates(
       continue;
     }
 
+    if (kind === "quoted_literal" && !isTechnicalQuotedLiteral(original)) {
+      continue;
+    }
+
     candidates.push({
       start,
       end: start + original.length,
@@ -160,6 +168,28 @@ function addRegexCandidates(
       priority,
     });
   }
+}
+
+function isTechnicalQuotedLiteral(literal: string): boolean {
+  const inner = literal.slice(1, -1).trim();
+
+  if (!inner || hasKorean(inner)) {
+    return false;
+  }
+
+  if (/[\\/._:-]/.test(inner) || /\d/.test(inner)) {
+    return true;
+  }
+
+  if (/\b[A-Z]{2,}\b/.test(inner)) {
+    return true;
+  }
+
+  if (/\b[A-Za-z]+_[A-Za-z0-9_]+\b/.test(inner)) {
+    return true;
+  }
+
+  return false;
 }
 
 function addLiteralCandidates(

--- a/src/core/translate/masking.ts
+++ b/src/core/translate/masking.ts
@@ -4,9 +4,14 @@ export type ProtectedSegmentKind =
   | "url"
   | "email"
   | "json_key"
+  | "function_call"
+  | "qualified_identifier"
+  | "slash_token"
+  | "quoted_literal"
   | "filename"
   | "directory_path"
   | "model_name"
+  | "snake_identifier"
   | "numeric_token"
   | "uppercase_abbreviation"
   | "protected_term"
@@ -71,6 +76,26 @@ const PATTERN_SPECS: ReadonlyArray<{
     regex: /"[^"\n]+"(?=\s*:)/g,
   },
   {
+    kind: "function_call",
+    priority: 74,
+    regex: /\b[A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)*\([^()\n]*\)/g,
+  },
+  {
+    kind: "qualified_identifier",
+    priority: 73,
+    regex: /\b[A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*){1,}\b/g,
+  },
+  {
+    kind: "slash_token",
+    priority: 72,
+    regex: /[A-Za-z0-9가-힣._+-]+\/[A-Za-z0-9가-힣._+-]+/g,
+  },
+  {
+    kind: "quoted_literal",
+    priority: 71,
+    regex: /"(?:[^"\\\n]|\\.)+"|'(?:[^'\\\n]|\\.)+'/g,
+  },
+  {
     kind: "directory_path",
     priority: 70,
     regex: /(?:\.\.?\/|\/)[^\s`"'|]+|\b[\w.-]+(?:\/[\w.-]+){1,}\b/g,
@@ -79,6 +104,11 @@ const PATTERN_SPECS: ReadonlyArray<{
     kind: "model_name",
     priority: 65,
     regex: /\b(?:GPT|Claude|Gemini|Llama|gpt|claude|gemini|llama)[A-Za-z0-9._-]*\b/g,
+  },
+  {
+    kind: "snake_identifier",
+    priority: 56,
+    regex: /\b[A-Za-z]+_[A-Za-z0-9_]+\b/g,
   },
   {
     kind: "filename",
@@ -200,20 +230,46 @@ function collectCandidates(
   });
 }
 
-export function mask_protected_segments(
-  source_text: string,
-  options: MaskProtectedSegmentsOptions = {},
-): MaskProtectedSegmentsResult {
-  const candidates = collectCandidates(source_text, options);
-  const placeholders: PlaceholderEntry[] = [];
+function selectCandidates(
+  candidates: readonly MatchCandidate[],
+): MatchCandidate[] {
+  const selected: MatchCandidate[] = [];
   let cursor = 0;
-  let maskedText = "";
 
   for (const candidate of candidates) {
     if (candidate.start < cursor) {
       continue;
     }
 
+    selected.push(candidate);
+    cursor = candidate.end;
+  }
+
+  return selected;
+}
+
+export function collect_preservable_literals(
+  source_text: string,
+  options: MaskProtectedSegmentsOptions = {},
+): string[] {
+  const selected = selectCandidates(collectCandidates(source_text, options));
+  const literals = selected
+    .map((candidate) => candidate.original)
+    .filter((literal) => literal && !/^__PH_\d{4}__$/.test(literal));
+
+  return [...new Set(literals)];
+}
+
+export function mask_protected_segments(
+  source_text: string,
+  options: MaskProtectedSegmentsOptions = {},
+): MaskProtectedSegmentsResult {
+  const candidates = selectCandidates(collectCandidates(source_text, options));
+  const placeholders: PlaceholderEntry[] = [];
+  let cursor = 0;
+  let maskedText = "";
+
+  for (const candidate of candidates) {
     const placeholder = createPlaceholder(placeholders.length + 1);
     maskedText += source_text.slice(cursor, candidate.start);
     maskedText += placeholder;

--- a/src/core/translate/translate.ts
+++ b/src/core/translate/translate.ts
@@ -79,6 +79,16 @@ function containsKorean(text: string): boolean {
   return /[가-힣]/.test(text);
 }
 
+function collectRequiredTerms(
+  sourceText: string,
+  preferredTranslations: Role1Policies["preferredTranslations"],
+): string[] {
+  return Object.keys(preferredTranslations)
+    .filter((term) => sourceText.includes(term))
+    .map((term) => preferredTranslations[term]!)
+    .filter(Boolean);
+}
+
 async function translate_span(
   span: TranslatableSpan,
   options: TranslateToEnglishOptions,
@@ -173,16 +183,17 @@ export async function translate_to_english(
     const placeholderTokens = masked.placeholders
       .filter((entry) => span.text.includes(entry.placeholder))
       .map((entry) => entry.placeholder);
-    const requiredTerms = Object.keys(options.policies.preferredTranslations)
-      .filter((term) => span.text.includes(term))
-      .map((term) => options.policies.preferredTranslations[term]!)
-      .filter(Boolean);
+    const requiredTerms = collectRequiredTerms(
+      span.text,
+      options.policies.preferredTranslations,
+    );
     const initialValidation = validate_translation({
       source_text: span.text,
       compressed_prompt: cleaned,
       placeholders: placeholderTokens,
       protected_terms: options.policies.protectedTerms,
       required_terms: requiredTerms,
+      model_names: options.config.modelName ? [options.config.modelName] : [],
       forbidden_patterns: options.policies.forbiddenPatterns,
     });
     const repaired = repair_translation({
@@ -199,6 +210,7 @@ export async function translate_to_english(
       placeholders: placeholderTokens,
       protected_terms: options.policies.protectedTerms,
       required_terms: requiredTerms,
+      model_names: options.config.modelName ? [options.config.modelName] : [],
       forbidden_patterns: options.policies.forbiddenPatterns,
     });
 
@@ -229,6 +241,7 @@ export async function translate_to_english(
           placeholders: placeholderTokens,
           protected_terms: options.policies.protectedTerms,
           required_terms: requiredTerms,
+          model_names: options.config.modelName ? [options.config.modelName] : [],
           forbidden_patterns: options.policies.forbiddenPatterns,
         });
 
@@ -246,6 +259,7 @@ export async function translate_to_english(
           placeholders: placeholderTokens,
           protected_terms: options.policies.protectedTerms,
           required_terms: requiredTerms,
+          model_names: options.config.modelName ? [options.config.modelName] : [],
           forbidden_patterns: options.policies.forbiddenPatterns,
         });
         repairActions.push(...fallbackRepaired.repair_actions);
@@ -284,9 +298,19 @@ export async function translate_to_english(
     reassemble_spans(translatedSpans),
     masked.placeholders,
   );
-  const finalValidationErrors = containsKorean(restoredText)
-    ? [...new Set(spanResults.flatMap((result) => result.validation_errors))]
-    : [];
+  const finalValidation = validate_translation({
+    source_text,
+    compressed_prompt: restoredText,
+    protected_terms: options.policies.protectedTerms,
+    required_terms: collectRequiredTerms(
+      source_text,
+      options.policies.preferredTranslations,
+    ),
+    required_literals: masked.placeholders.map((entry) => entry.original),
+    model_names: options.config.modelName ? [options.config.modelName] : [],
+    forbidden_patterns: options.policies.forbiddenPatterns,
+  });
+  const finalValidationErrors = finalValidation.validation_errors;
   const finalRepairActions = [
     ...new Set(spanResults.flatMap((result) => result.repair_actions)),
   ];

--- a/src/core/translate/translate.ts
+++ b/src/core/translate/translate.ts
@@ -75,6 +75,8 @@ const TRANSLATION_SYSTEM_PROMPT = `You are a translator that translates Korean i
 const TRANSLATION_USER_PROMPT_PREFIX =
   "Translate the following text data into English.\n\n";
 
+type TranslationPassPromptType = "primary" | "fallback" | "final_retry";
+
 function containsKorean(text: string): boolean {
   return /[가-힣]/.test(text);
 }
@@ -89,10 +91,31 @@ function collectRequiredTerms(
     .filter(Boolean);
 }
 
+function shouldRetryWholeItem(
+  sourceText: string,
+  validationErrors: readonly string[],
+): boolean {
+  if (!containsKorean(sourceText) || validationErrors.length === 0) {
+    return false;
+  }
+
+  return validationErrors.some((error) =>
+    error.startsWith("required_literal_missing:") ||
+    error.startsWith("required_term_missing:")
+  );
+}
+
+function isBetterValidationResult(
+  currentErrors: readonly string[],
+  nextErrors: readonly string[],
+): boolean {
+  return nextErrors.length < currentErrors.length;
+}
+
 async function translate_span(
   span: TranslatableSpan,
   options: TranslateToEnglishOptions,
-  promptType: "primary" | "fallback" = "primary",
+  promptType: TranslationPassPromptType = "primary",
   fallbackContext?: {
     previous_output: string;
     validation_errors: string[];
@@ -108,14 +131,15 @@ async function translate_span(
         {
           role: "system",
           content:
-            promptType === "fallback"
+            promptType === "fallback" || promptType === "final_retry"
               ? `${TRANSLATION_SYSTEM_PROMPT}
 
 Return only the corrected English translation.
 Preserve placeholder count and order exactly.
 If placeholders were malformed, restore them exactly as in the source.
 The previous attempt failed validation for: ${fallbackContext?.validation_errors.join(", ") ?? "unknown_error"}.
-Previous invalid output: ${fallbackContext?.previous_output ?? ""}`
+Previous invalid output: ${fallbackContext?.previous_output ?? ""}
+Pay extra attention to missing technical literals and untranslated Korean text.`
               : TRANSLATION_SYSTEM_PROMPT,
         },
         {
@@ -143,9 +167,14 @@ Previous invalid output: ${fallbackContext?.previous_output ?? ""}`
   );
 }
 
-export async function translate_to_english(
+async function runTranslationPass(
   source_text: string,
   options: TranslateToEnglishOptions,
+  initialPromptType: Exclude<TranslationPassPromptType, "fallback"> = "primary",
+  finalRetryContext?: {
+    previous_output: string;
+    validation_errors: string[];
+  },
 ): Promise<TranslateToEnglishResult> {
   const masked = mask_protected_segments(source_text, {
     protected_terms: options.policies.protectedTerms,
@@ -160,7 +189,12 @@ export async function translate_to_english(
   const spanResults: TranslationSpanResult[] = [];
 
   for (const span of spans) {
-    const llmResponse = await translate_span(span, options);
+    const llmResponse = await translate_span(
+      span,
+      options,
+      initialPromptType,
+      finalRetryContext,
+    );
     if (!llmResponse) {
       translatedSpans.push(span);
       spanResults.push({
@@ -234,16 +268,6 @@ export async function translate_to_english(
           rawResponses.push(fallbackResponse.raw_response);
         }
         inferenceTimeSec += fallbackResponse.inference_time_sec ?? 0;
-
-        const fallbackValidation = validate_translation({
-          source_text: span.text,
-          compressed_prompt: fallbackCleaned,
-          placeholders: placeholderTokens,
-          protected_terms: options.policies.protectedTerms,
-          required_terms: requiredTerms,
-          model_names: options.config.modelName ? [options.config.modelName] : [],
-          forbidden_patterns: options.policies.forbiddenPatterns,
-        });
 
         const fallbackRepaired = repair_translation({
           source_text: span.text,
@@ -336,5 +360,51 @@ export async function translate_to_english(
           },
         }
       : {}),
+  };
+}
+
+export async function translate_to_english(
+  source_text: string,
+  options: TranslateToEnglishOptions,
+): Promise<TranslateToEnglishResult> {
+  const initialPass = await runTranslationPass(source_text, options);
+
+  if (!shouldRetryWholeItem(source_text, initialPass.validation_errors)) {
+    return initialPass;
+  }
+
+  const retriedPass = await runTranslationPass(
+    source_text,
+    options,
+    "final_retry",
+    {
+      previous_output: initialPass.text,
+      validation_errors: initialPass.validation_errors,
+    },
+  );
+
+  const preferredPass = isBetterValidationResult(
+    initialPass.validation_errors,
+    retriedPass.validation_errors,
+  )
+    ? retriedPass
+    : initialPass;
+
+  return {
+    ...preferredPass,
+    raw_responses: [
+      ...initialPass.raw_responses,
+      ...retriedPass.raw_responses,
+    ],
+    inference_time_sec:
+      initialPass.inference_time_sec + retriedPass.inference_time_sec,
+    fallback_span_count:
+      initialPass.fallback_span_count + retriedPass.fallback_span_count,
+    repair_actions: [
+      ...new Set([
+        ...initialPass.repair_actions,
+        ...retriedPass.repair_actions,
+      ]),
+    ],
   };
 }

--- a/src/core/translate/translate.ts
+++ b/src/core/translate/translate.ts
@@ -104,7 +104,9 @@ function shouldRetryWholeItem(
 
   return validationErrors.some((error) =>
     error.startsWith("required_literal_missing:") ||
-    error.startsWith("required_term_missing:")
+    error.startsWith("required_term_missing:") ||
+    error === "korean_text_remaining" ||
+    error === "source_korean_copied"
   );
 }
 

--- a/src/core/translate/translate.ts
+++ b/src/core/translate/translate.ts
@@ -15,7 +15,10 @@ import {
 } from "./spans.js";
 import { clean_translation } from "./clean.js";
 import { repair_translation } from "../guardrails/repair.js";
-import { validate_translation } from "../guardrails/validator.js";
+import {
+  isHighConfidenceInferredLiteral,
+  validate_translation,
+} from "../guardrails/validator.js";
 
 export interface TranslateToEnglishOptions {
   config: Role1RuntimeConfig;
@@ -330,7 +333,9 @@ async function runTranslationPass(
       source_text,
       options.policies.preferredTranslations,
     ),
-    required_literals: masked.placeholders.map((entry) => entry.original),
+    required_literals: masked.placeholders
+      .map((entry) => entry.original)
+      .filter(isHighConfidenceInferredLiteral),
     model_names: options.config.modelName ? [options.config.modelName] : [],
     forbidden_patterns: options.policies.forbiddenPatterns,
   });

--- a/tests/ts/unit/core/guardrails/validator.test.ts
+++ b/tests/ts/unit/core/guardrails/validator.test.ts
@@ -23,4 +23,19 @@ describe("validate_translation", () => {
     expect(result.validation_errors).toContain("source_korean_copied");
     expect(result.validation_errors).toContain("forbidden_pattern:^Translation:");
   });
+
+  it("핵심 기술 토큰이 누락되면 required literal 오류를 검출한다", () => {
+    const result = validate_translation({
+      source_text: "numpy.dot(A, B)으로 계산하고 unittest.mock.patch도 유지해",
+      compressed_prompt: "Calculate it and keep the mock patch.",
+      required_literals: ["numpy.dot(A, B)", "unittest.mock.patch"],
+    });
+
+    expect(result.validation_errors).toContain(
+      "required_literal_missing:numpy.dot(A, B)",
+    );
+    expect(result.validation_errors).toContain(
+      "required_literal_missing:unittest.mock.patch",
+    );
+  });
 });

--- a/tests/ts/unit/core/guardrails/validator.test.ts
+++ b/tests/ts/unit/core/guardrails/validator.test.ts
@@ -38,4 +38,23 @@ describe("validate_translation", () => {
       "required_literal_missing:unittest.mock.patch",
     );
   });
+
+  it("자동 추론된 저신뢰 literal은 과민 검출하지 않는다", () => {
+    const result = validate_translation({
+      source_text: "API Gateway 뒤 서비스가 느려",
+      compressed_prompt: "The services behind the gateway are slow.",
+    });
+
+    expect(result.validation_errors).not.toContain("required_literal_missing:API");
+  });
+
+  it("명시적으로 요구한 literal은 confidence와 무관하게 유지한다", () => {
+    const result = validate_translation({
+      source_text: "API Gateway 뒤 서비스가 느려",
+      compressed_prompt: "The services behind the gateway are slow.",
+      required_literals: ["API"],
+    });
+
+    expect(result.validation_errors).toContain("required_literal_missing:API");
+  });
 });

--- a/tests/ts/unit/core/llm-client/client.test.ts
+++ b/tests/ts/unit/core/llm-client/client.test.ts
@@ -69,4 +69,27 @@ describe("complete_chat", () => {
       ),
     ).rejects.toThrow("LLM client requires OPENAI_API_BASE");
   });
+
+  it("fetch가 응답 객체를 반환하지 않으면 명시적 오류를 반환한다", async () => {
+    const fetchImplementation = vi.fn(async () => undefined as never);
+
+    await expect(() =>
+      complete_chat(
+        {
+          messages: [
+            {
+              role: "user",
+              content: "파일 생성",
+            },
+          ],
+        },
+        {
+          apiBase: "http://127.0.0.1:1234/v1",
+          apiKey: "test-key",
+          modelName: "local-model",
+          fetchImplementation,
+        },
+      ),
+    ).rejects.toThrow("Invalid LLM response: fetch returned no response");
+  });
 });

--- a/tests/ts/unit/core/prompt/compiler.test.ts
+++ b/tests/ts/unit/core/prompt/compiler.test.ts
@@ -117,6 +117,25 @@ describe("compilePrompt", () => {
             },
           },
         ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: "새 파일을 생성해",
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+            },
+          },
+        ),
       );
 
     const compiled = await compilePrompt(
@@ -134,6 +153,7 @@ describe("compilePrompt", () => {
       },
     );
 
+    expect(fetchImplementation).toHaveBeenCalledTimes(2);
     expect(compiled.validation_errors).toContain("korean_text_remaining");
     expect(compiled.repair_actions ?? []).toContain(
       "compression_fallback_to_normalized_input",

--- a/tests/ts/unit/core/prompt/compression.test.ts
+++ b/tests/ts/unit/core/prompt/compression.test.ts
@@ -45,4 +45,16 @@ describe("compress_prompt", () => {
       "compression_fallback_to_normalized_input",
     );
   });
+
+  it("기술 식별자가 포함된 문장은 압축 후에도 핵심 토큰을 유지한다", () => {
+    const result = compress_prompt(
+      "Please run numpy.dot(A, B) first and then replace the external call with unittest.mock.patch.",
+      {
+        policies: defaultPolicies,
+      },
+    );
+
+    expect(result.compressed_prompt).toContain("numpy.dot(A, B)");
+    expect(result.compressed_prompt).toContain("unittest.mock.patch");
+  });
 });

--- a/tests/ts/unit/core/translate/masking.test.ts
+++ b/tests/ts/unit/core/translate/masking.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  collect_preservable_literals,
   mask_protected_segments,
   restore_placeholders,
 } from "../../../../../src/core/translate/masking.js";
@@ -44,6 +45,28 @@ describe("mask_protected_segments", () => {
     expect(masked.placeholders[0]!.original).toBe("REST API");
     expect(masked.placeholders[1]!.original).toBe("API");
     expect(masked.masked_text).toBe("Use __PH_0001__ and __PH_0002__ together.");
+    expect(restore_placeholders(masked.masked_text, masked.placeholders)).toBe(
+      sourceText,
+    );
+  });
+
+  it("qualified identifier, 함수 호출식, slash token, quoted literal을 보호한다", () => {
+    const sourceText = [
+      "Use unittest.mock.patch on external API calls.",
+      "Run numpy.dot(A, B) before visualization.",
+      "Keep I/O and blue/green deployment terms unchanged.",
+      "Wait for 'GO' after threading.Event is set.",
+    ].join(" ");
+
+    const masked = mask_protected_segments(sourceText);
+    const literals = collect_preservable_literals(sourceText);
+
+    expect(literals).toContain("unittest.mock.patch");
+    expect(literals).toContain("numpy.dot(A, B)");
+    expect(literals).toContain("I/O");
+    expect(literals).toContain("blue/green");
+    expect(literals).toContain("'GO'");
+    expect(literals).toContain("threading.Event");
     expect(restore_placeholders(masked.masked_text, masked.placeholders)).toBe(
       sourceText,
     );

--- a/tests/ts/unit/core/translate/masking.test.ts
+++ b/tests/ts/unit/core/translate/masking.test.ts
@@ -71,4 +71,14 @@ describe("mask_protected_segments", () => {
       sourceText,
     );
   });
+
+  it("일반 한국어 인용구는 보호하지 않는다", () => {
+    const sourceText = "사용자에게 '확인 버튼을 눌러 주세요'라고 안내해";
+    const masked = mask_protected_segments(sourceText);
+    const literals = collect_preservable_literals(sourceText);
+
+    expect(masked.placeholders).toHaveLength(0);
+    expect(literals).toEqual([]);
+    expect(masked.masked_text).toBe(sourceText);
+  });
 });

--- a/tests/ts/unit/core/translate/translate.test.ts
+++ b/tests/ts/unit/core/translate/translate.test.ts
@@ -400,4 +400,52 @@ describe("translate_to_english", () => {
     expect(result.text).toBe("Create a file named `app.ts`");
     expect(result.validation_errors).toEqual([]);
   });
+
+  it("저신뢰 placeholder literal은 최종 validation에서 강제하지 않는다", async () => {
+    const fetchImplementation = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content: "The services behind the gateway are too slow.",
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    });
+
+    const result = await translate_to_english(
+      "API Gateway 뒤에서 돌아가는 서비스들이 너무 느려",
+      {
+        config: {
+          openaiApiBase: "http://127.0.0.1:1234/v1",
+          openaiApiKey: "test-key",
+          modelName: "local-model",
+          pipelineMode: "safe",
+          requestTimeout: 30000,
+          translationMaxAttempts: 1,
+          temperature: 0,
+        },
+        policies: {
+          protectedTerms: [],
+          preferredTranslations: {},
+          forbiddenPatterns: [],
+        },
+        fetchImplementation,
+      },
+    );
+
+    expect(result.text).toBe("The services behind the gateway are too slow.");
+    expect(result.validation_errors).not.toContain(
+      "required_literal_missing:API",
+    );
+  });
 });

--- a/tests/ts/unit/core/translate/translate.test.ts
+++ b/tests/ts/unit/core/translate/translate.test.ts
@@ -335,4 +335,69 @@ describe("translate_to_english", () => {
     expect(result.validation_errors).toContain("korean_text_remaining");
     expect(result.validation_errors).toContain("source_korean_copied");
   });
+
+  it("최종 validation에서 literal 누락이 나면 item 단위로 한 번 더 재호출한다", async () => {
+    const fetchImplementation = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: "Create a file",
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: "Create a file named __PH_0001__",
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+            },
+          },
+        ),
+      );
+
+    const result = await translate_to_english("`app.ts` 파일을 생성해", {
+      config: {
+        openaiApiBase: "http://127.0.0.1:1234/v1",
+        openaiApiKey: "test-key",
+        modelName: "local-model",
+        pipelineMode: "safe",
+        requestTimeout: 30000,
+        translationMaxAttempts: 1,
+        temperature: 0,
+      },
+      policies: {
+        protectedTerms: [],
+        preferredTranslations: {},
+        forbiddenPatterns: [],
+      },
+      fetchImplementation,
+    });
+
+    expect(fetchImplementation).toHaveBeenCalledTimes(2);
+    expect(result.text).toBe("Create a file named `app.ts`");
+    expect(result.validation_errors).toEqual([]);
+  });
 });

--- a/tests/ts/unit/core/translate/translate.test.ts
+++ b/tests/ts/unit/core/translate/translate.test.ts
@@ -195,7 +195,7 @@ describe("translate_to_english", () => {
       fetchImplementation,
     });
 
-    expect(fetchImplementation).toHaveBeenCalledOnce();
+    expect(fetchImplementation).toHaveBeenCalledTimes(2);
     expect(result.span_results[0]!.status).toBe("failed");
     expect(result.span_results[0]!.attempts).toBe(1);
     expect(result.span_results[0]!.validation_errors).toContain(
@@ -331,6 +331,7 @@ describe("translate_to_english", () => {
       fetchImplementation,
     });
 
+    expect(fetchImplementation).toHaveBeenCalledTimes(2);
     expect(result.text).toBe("Review 블루/그린 deployment first");
     expect(result.validation_errors).toContain("korean_text_remaining");
     expect(result.validation_errors).toContain("source_korean_copied");

--- a/tests/ts/unit/core/translate/translate.test.ts
+++ b/tests/ts/unit/core/translate/translate.test.ts
@@ -291,4 +291,48 @@ describe("translate_to_english", () => {
     expect(result.span_results[0]!.output_text).toContain("__PH_0001__");
     expect(result.validation_errors).toEqual([]);
   });
+
+  it("복원 이후 한글이 다시 남으면 최종 validation 오류를 남긴다", async () => {
+    const fetchImplementation = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content: "Review __PH_0001__ deployment first",
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    });
+
+    const result = await translate_to_english("블루/그린 배포를 먼저 검토해", {
+      config: {
+        openaiApiBase: "http://127.0.0.1:1234/v1",
+        openaiApiKey: "test-key",
+        modelName: "local-model",
+        pipelineMode: "safe",
+        requestTimeout: 30000,
+        translationMaxAttempts: 1,
+        temperature: 0,
+      },
+      policies: {
+        protectedTerms: [],
+        preferredTranslations: {},
+        forbiddenPatterns: [],
+      },
+      fetchImplementation,
+    });
+
+    expect(result.text).toBe("Review 블루/그린 deployment first");
+    expect(result.validation_errors).toContain("korean_text_remaining");
+    expect(result.validation_errors).toContain("source_korean_copied");
+  });
 });


### PR DESCRIPTION
## 요약
- Role 1 번역/압축 파이프라인의 literal 보존, 최종 validation, whole-item retry 경로를 강화했습니다.
- 기술 식별자 보존 범위를 확대하고, 최종 복원 후 validation을 다시 수행하도록 해 `completed`로 잘못 기록되던 품질 누락을 줄였습니다.
- `verify-role1` 지표를 세분화하고, 실제 검증 결과를 바탕으로 남은 후속 과제를 문서화했습니다.

변경 상세:
- `src/core/translate/masking.ts`
  - 함수 호출식, qualified identifier, slash token, quoted literal, snake identifier 등 보호 후보를 확장했습니다.
  - 일반 한국어 인용구는 `quoted_literal`로 과보호하지 않도록 필터를 추가했습니다.
- `src/core/guardrails/validator.ts`
  - 추론 가능한 high-confidence literal을 자동 수집해 `required_literal_missing:*` 검증을 수행하도록 보강했습니다.
  - 명시적 `required_literals`, `model_names` 입력을 지원합니다.
- `src/core/prompt/compression.ts`
  - 압축 후 핵심 literal이 사라지면 `compression_fallback_to_normalized_input`으로 fallback 하도록 보강했습니다.
- `src/core/translate/translate.ts`
  - 최종 placeholder 복원 이후 전체 결과에 대해 다시 validation 하도록 수정했습니다.
  - `required_literal_missing`, `required_term_missing`뿐 아니라 `korean_text_remaining`, `source_korean_copied`도 whole-item `final_retry` 트리거로 포함했습니다.
- `scripts/verify-role1.ts`
  - `raw -> normalized`, `normalized -> compiled` 절감률을 분리하고, compression fallback / repair / validation 실패 집계를 추가했습니다.
- 테스트
  - validator / masking / compression / translate 단위 테스트를 확장해 literal 누락, 일반 한국어 인용구 비마스킹, whole-item retry, 최종 validation 회귀를 고정했습니다.
- 문서
  - `docs/ROLE1_PIPELINE_IMPROVEMENT_REQUIREMENTS.md`에 2026-04-26 기준 verify 결과와 남은 follow-up을 정리했습니다.

- 왜 이 변경이 필요한가요?
  - 기존에는 span 단계에서는 문제가 없어도 최종 placeholder 복원 후 한글이 다시 남거나 핵심 API literal이 사라져도 `completed`로 기록될 수 있었습니다.
  - 실제 `row_data.json` 검증에서 `numpy.dot(A, B)`, `unittest.mock.patch`, `threading.Event`, `I/O`, `blue/green` 같은 기술 토큰 오염과 한글 잔존 케이스가 관찰되어 guardrail과 retry 조건을 강화할 필요가 있었습니다.

## 관련 이슈
- Closes # 없음
- Related to # 없음

## 변경 유형p
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩터링
- [x] 문서 수정
- [x] 테스트 추가/수정

## 영향 범위
- 영향받는 모듈:
  - `src/core/translate/masking.ts`
  - `src/core/translate/translate.ts`
  - `src/core/guardrails/validator.ts`
  - `src/core/prompt/compression.ts`
  - `scripts/verify-role1.ts`
  - 관련 unit test 및 Role 1 개선 요구사항 문서
- 영향받지 않는 모듈:
  - Role 2.1 request classification
  - task graph 구조
  - executor / runtime orchestration
  - Python 런타임 로직

## 테스트 방법
1. `npx vitest run tests/ts/unit/core/guardrails/validator.test.ts tests/ts/unit/core/prompt/compression.test.ts tests/ts/unit/core/translate/masking.test.ts tests/ts/unit/core/translate/translate.test.ts`
2. `npm run verify:role1 -- --file tests/data/row_data.json --output tmp/role1-verify-latest.json`
3. 실패 케이스 debug 재검증
   - `npm run verify:role1 -- --file tests/data/row_data.json --index 36 --debug --output tmp/role1-verify-36-debug.json`
   - `npm run verify:role1 -- --file tests/data/row_data.json --index 84 --debug --output tmp/role1-verify-84-debug.json`

검증 요약:
- 전체 106건 중 `completed_count: 104`, `failed_count: 2`
- `average_inference_time_sec: 0.753`
- `average_token_reduction_rate: 31.864`
- `average_translation_token_reduction_rate: 30.776`
- `average_compression_token_reduction_rate: 1.622`
- `compression_fallback_count: 0`
- `repair_action_item_count: 27`
- `validation_failed_count: 2`

남은 실패 2건:
- `index 36`: `ROI(투자 대비 효과)` 혼합 괄호 표현이 과보호되어 최종 복원 후 한글이 남음
- `index 84`: `prometheus_exporter.collect()` literal이 fallback 이후에도 복구되지 않음

## 체크리스트
- [x] 로컬에서 테스트했습니다
- [x] 필요한 경우 테스트를 추가하거나 수정했습니다
- [x] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 스크린샷 / 로그
```text
role1 verify summary
- completed_count: 104
- failed_count: 2
- average_inference_time_sec: 0.753
- average_token_reduction_rate: 31.864
- average_translation_token_reduction_rate: 30.776
- average_compression_token_reduction_rate: 1.622
- compression_fallback_count: 0
- repair_action_item_count: 27
- validation_failed_count: 2
```

## 리뷰어 참고사항
- 이번 PR은 Role 1 품질 guardrail 강화와 verify 지표 개선이 중심입니다.
- 실패 2건은 문서에 후속 작업으로 남겨두었고, 이번 PR에서는 최소 변경 원칙에 따라 추적 가능한 범위까지만 반영했습니다.
- 특히 `quoted_literal` 과보호 축소와 `final_retry` 트리거 확장이 실제 회귀를 줄였는지 `masking.test.ts`, `translate.test.ts`, `tmp/role1-verify-36-debug.json`, `tmp/role1-verify-84-debug.json` 기준으로 봐주시면 됩니다.
