### PR TITLE
Feat/session persistence

### DIFF
--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -551,7 +551,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
   return {
     mode: "run",
     prompt,
-    sessionId,
+    ...(sessionId !== undefined ? { sessionId } : {}),
     adapter,
     executionMode,
     verbose,

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -18,12 +18,15 @@ import type {
   TaskExecutionRecord,
 } from "./types.js";
 
+const SESSION_VERSION = "1";
+
 function generateSessionId(): string {
   return createHash("sha256").update(String(Date.now())).digest("hex").slice(0, 12);
 }
 
 function initSessionState(sessionId: string, rawInput: string): SessionState {
   return {
+    version: SESSION_VERSION,
     shared_context: { session_id: sessionId, raw_input: rawInput },
     task_results: {},
     current_task_id: null,
@@ -264,27 +267,61 @@ export const orchestratePipeline = async (
   const taskRecords: TaskExecutionRecord[] = [];
   const failedTaskIds = new Set<string>();
 
+  PipelineTracer.startStage("SessionLoader");
+  const graphTaskIds = graph.tasks.map((t) => t.id);
+
   if (await SessionStateManager.sessionExists(sessionId)) {
-    logger.info(`Loading existing session: ${sessionId}`);
-    state = await SessionStateManager.loadSession(sessionId);
-    state = {
-      ...state,
-      shared_context: {
-        ...state.shared_context,
-        session_id: sessionId,
-        raw_input:
-          typeof state.shared_context.raw_input === "string" &&
-          state.shared_context.raw_input.trim().length > 0
-            ? state.shared_context.raw_input
-            : request.userRequest.raw_input,
-      },
-    };
-    // 이전에 실패한 작업들을 failedTaskIds에 추가하여 의존성 차단 로직이 작동하게 함
-    const loadedFailedIds = (state.shared_context.failed_task_ids as string[]) || [];
-    loadedFailedIds.forEach((id) => failedTaskIds.add(id));
+    try {
+      const loaded = await SessionStateManager.loadSession(sessionId);
+      if (loaded.version !== SESSION_VERSION) {
+        logger.warn(`[Role 2.2] 세션 버전 불일치 (${loaded.version ?? "none"} → ${SESSION_VERSION}). 새로 시작.`);
+        state = initSessionState(sessionId, request.userRequest.raw_input);
+        logger.info(`[Role 2.2] 새 세션 생성 (버전 불일치): ${sessionId}`);
+      } else {
+        const orphanedTaskIds = loaded.completed_task_ids.filter((id) => !graphTaskIds.includes(id));
+        if (orphanedTaskIds.length > 0) {
+          logger.warn(`[Role 2.2] 세션의 Task가 현재 그래프에 없음: ${orphanedTaskIds.join(", ")}. 세션 초기화.`);
+          state = initSessionState(sessionId, request.userRequest.raw_input);
+          logger.info(`[Role 2.2] 새 세션 생성 (그래프 불일치): ${sessionId}`);
+        } else {
+          logger.info(`Loading existing session: ${sessionId}`);
+          state = {
+            ...loaded,
+            shared_context: {
+              ...loaded.shared_context,
+              session_id: sessionId,
+              raw_input:
+                typeof loaded.shared_context.raw_input === "string" &&
+                loaded.shared_context.raw_input.trim().length > 0
+                  ? loaded.shared_context.raw_input
+                  : request.userRequest.raw_input,
+            },
+          };
+          const loadedFailedIds = (state.shared_context.failed_task_ids as string[]) || [];
+          loadedFailedIds.forEach((id) => failedTaskIds.add(id));
+        }
+      }
+    } catch (error) {
+      logger.warn(`[Role 2.2] 세션 로드 실패, 새 세션으로 재시작: ${error}`);
+      state = initSessionState(sessionId, request.userRequest.raw_input);
+    }
   } else {
     state = initSessionState(sessionId, request.userRequest.raw_input);
   }
+
+  await PipelineTracer.trace({
+    sessionId,
+    stage: "SessionLoader",
+    role: "role2.2",
+    phase: "output",
+    dataType: "SessionState",
+    data: {
+      session_id: state.shared_context.session_id,
+      completed_task_count: state.completed_task_ids.length,
+      next_task_id: state.current_task_id,
+    },
+    durationMs: PipelineTracer.endStage("SessionLoader"),
+  });
 
   // ── Step 6: 실행 루프 ────────────────────────────────────────────────────
   for (const { stage, tasks } of stages) {

--- a/src/core/state/SessionStateManager.ts
+++ b/src/core/state/SessionStateManager.ts
@@ -13,7 +13,48 @@ const STATE_DIR = '.state';
 const SESSIONS_DIR = join(STATE_DIR, 'sessions');
 const CHECKPOINTS_DIR = join(STATE_DIR, 'checkpoints');
 
+const LOCK_TIMEOUT_MS = 5000;
+const LOCK_RETRY_MS = 100;
+
 export class SessionStateManager {
+  private static lockPath(sessionId: string): string {
+    return join(SESSIONS_DIR, `${sessionId}.lock`);
+  }
+
+  private static async acquireLock(sessionId: string): Promise<void> {
+    const lockPath = this.lockPath(sessionId);
+    const deadline = Date.now() + LOCK_TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+      try {
+        const fd = await fs.open(lockPath, 'wx');
+        await fd.close();
+        return;
+      } catch (error: any) {
+        if (error.code !== 'EEXIST') throw error;
+        await new Promise<void>((resolve) => setTimeout(resolve, LOCK_RETRY_MS));
+      }
+    }
+
+    // 타임아웃 — 스테일 락으로 간주하고 강제 제거 후 재시도
+    logger.warn(`[SessionStateManager] Stale lock detected for session [${sessionId}], removing.`);
+    try {
+      await fs.unlink(lockPath);
+      const fd = await fs.open(lockPath, 'wx');
+      await fd.close();
+    } catch {
+      throw new StateIOError(`Failed to acquire lock for session [${sessionId}]`, { sessionId });
+    }
+  }
+
+  private static async releaseLock(sessionId: string): Promise<void> {
+    try {
+      await fs.unlink(this.lockPath(sessionId));
+    } catch {
+      // 이미 제거된 경우 무시
+    }
+  }
+
   private static ensureDirectories = async () => {
     try {
       await fs.mkdir(SESSIONS_DIR, { recursive: true });
@@ -28,9 +69,9 @@ export class SessionStateManager {
 
   static async saveSession(state: SessionState): Promise<void> {
     const sessionId = state.shared_context?.session_id as string || 'default';
+    await this.ensureDirectories();
+    await this.acquireLock(sessionId);
     try {
-      await this.ensureDirectories();
-
       // 1. 자동 정규화: task_results의 원시 데이터를 표준 스키마로 보정
       for (const [taskId, result] of Object.entries(state.task_results)) {
         const res = result as any;
@@ -55,7 +96,7 @@ export class SessionStateManager {
 
       // 4. 최종 무결성 검증
       const validated = StateValidator.validate(compressedState);
-      
+
       const filePath = join(SESSIONS_DIR, `${sessionId}.json`);
       await fs.writeFile(filePath, JSON.stringify(validated, null, 2));
     } catch (error: any) {
@@ -64,11 +105,15 @@ export class SessionStateManager {
         sessionId,
         originalError: error.message
       });
+    } finally {
+      await this.releaseLock(sessionId);
     }
   }
 
   static async loadSession(sessionId: string): Promise<SessionState> {
     const filePath = join(SESSIONS_DIR, `${sessionId}.json`);
+    await this.ensureDirectories();
+    await this.acquireLock(sessionId);
     try {
       const data = await fs.readFile(filePath, 'utf-8');
       const parsed = JSON.parse(data);
@@ -77,7 +122,7 @@ export class SessionStateManager {
       if (error instanceof StateValidationError) throw error;
       if (error instanceof SyntaxError) {
         throw new StateIOError(`Session file [${sessionId}] is corrupted`, {
-          sessionId, path: filePath, originalError: error.message
+          sessionId, path: filePath, originalError: (error as Error).message
         });
       }
       const nodeError = error as NodeJS.ErrnoException;
@@ -94,6 +139,8 @@ export class SessionStateManager {
       throw new StateIOError(`Failed to load session [${sessionId}]`, {
         sessionId, path: filePath, originalError: error instanceof Error ? error.message : String(error)
       });
+    } finally {
+      await this.releaseLock(sessionId);
     }
   }
 

--- a/src/core/task-graph/TaskSentenceSplitter.ts
+++ b/src/core/task-graph/TaskSentenceSplitter.ts
@@ -1,5 +1,10 @@
-import { CompiledSentencesSchema, type CompiledSentences } from "../../schemas/pipeline.js";
+import {
+  CompiledSentencesSchema,
+  type CompiledSentences,
+} from "../../schemas/pipeline.js";
 
+// 문장이 액션(동작)으로 시작하는지 판별하기 위한 동사 목록
+// sort: 긴 문자열 우선 매칭 (예: "set up"이 "set"보다 먼저 매칭되도록)
 const ACTION_STARTERS = [
   "find",
   "locate",
@@ -82,6 +87,8 @@ const ACTION_STARTERS = [
   "break down",
 ].sort((a, b) => b.length - a.length);
 
+// "and"로 연결된 후속 절이 독립 태스크인지 판별하는 동사 목록
+// ACTION_STARTERS의 부분집합으로, 후속 작업에 흔히 쓰이는 동사만 포함
 const FOLLOW_UP_STARTERS = [
   "test",
   "validate",
@@ -118,23 +125,33 @@ const FOLLOW_UP_STARTERS = [
   "add",
 ].sort((a, b) => b.length - a.length);
 
+// 문자열 앞부분이 액션 동사로 시작하는지 검사하는 정규식
 const ACTION_STARTER_REGEX = new RegExp(
   `^(?:${ACTION_STARTERS.map(escapeRegex).join("|")})\\b`,
   "i",
 );
 
+// 문자열 앞부분이 후속 액션 동사로 시작하는지 검사하는 정규식
 const FOLLOW_UP_STARTER_REGEX = new RegExp(
   `^(?:${FOLLOW_UP_STARTERS.map(escapeRegex).join("|")})\\b`,
   "i",
 );
 
+// 리터럴 보호용 토큰 prefix (backtick/따옴표 안의 내용을 임시 치환할 때 사용)
 const PROTECTED_TOKEN_PREFIX = "__DETOKS_TOKEN_";
 
 export class TaskSentenceSplitter {
+  // 자유형식 텍스트를 독립 태스크 문장 배열로 분리하는 진입점
   static split(rawInput: string): CompiledSentences {
+    // 1) 입력 정규화 → 2) 리터럴 보호 (코드/따옴표 내용을 토큰으로 치환)
     const protectedInput = this.protectLiterals(this.normalizeInput(rawInput));
+    // 3) 줄 단위로 분리
     const lineSegments = this.splitLines(protectedInput.text);
-    const sentences = lineSegments.flatMap((segment) => this.splitSegment(segment));
+    // 4) 각 줄을 문장 단위로 분리
+    const sentences = lineSegments.flatMap((segment) =>
+      this.splitSegment(segment),
+    );
+    // 5) 보호했던 리터럴 복원 → 클린업 → 빈 항목 제거
     const restored = sentences
       .map((sentence) => this.restoreLiterals(sentence, protectedInput.tokens))
       .map((sentence) => this.cleanClause(sentence))
@@ -143,28 +160,40 @@ export class TaskSentenceSplitter {
     return CompiledSentencesSchema.parse({ sentences: restored });
   }
 
+  // 줄바꿈/공백 등을 통일하여 파싱 오류를 줄임
   private static normalizeInput(rawInput: string): string {
     return rawInput
-      .replace(/\r\n?/g, "\n")
-      .replace(/\u00a0/g, " ")
-      .replace(/[ \t]+/g, " ")
-      .replace(/\n{3,}/g, "\n\n")
+      .replace(/\r\n?/g, "\n") // Windows/Mac 줄바꿈 → \n
+      .replace(/ /g, " ") // 비파괴 공백 → 일반 공백
+      .replace(/[ \t]+/g, " ") // 연속 공백/탭 → 공백 1개
+      .replace(/\n{3,}/g, "\n\n") // 3개 이상 빈 줄 → 2개로 축소
       .trim();
   }
 
-  private static protectLiterals(text: string): { text: string; tokens: Map<string, string> } {
+  // backtick/따옴표로 감싼 리터럴을 임시 토큰으로 치환하여 분리 로직이 내용을 건드리지 않도록 보호
+  private static protectLiterals(text: string): {
+    text: string;
+    tokens: Map<string, string>;
+  } {
     const tokens = new Map<string, string>();
     let index = 0;
-    const protectedText = text.replace(/`[^`]*`|"[^"]*"|(?<!\w)'[^']*'(?!\w)/g, (match) => {
-      const token = `${PROTECTED_TOKEN_PREFIX}${index++}__`;
-      tokens.set(token, match);
-      return token;
-    });
+    const protectedText = text.replace(
+      /`[^`]*`|"[^"]*"|(?<!\w)'[^']*'(?!\w)/g,
+      (match) => {
+        const token = `${PROTECTED_TOKEN_PREFIX}${index++}__`;
+        tokens.set(token, match);
+        return token;
+      },
+    );
 
     return { text: protectedText, tokens };
   }
 
-  private static restoreLiterals(text: string, tokens: Map<string, string>): string {
+  // 임시 토큰을 원래 리터럴 값으로 되돌림
+  private static restoreLiterals(
+    text: string,
+    tokens: Map<string, string>,
+  ): string {
     let restored = text;
     for (const [token, value] of tokens.entries()) {
       restored = restored.replaceAll(token, value);
@@ -172,11 +201,12 @@ export class TaskSentenceSplitter {
     return restored;
   }
 
+  // 글머리 기호(-, *, •) 및 번호 목록을 제거하고 줄 단위로 분리
   private static splitLines(text: string): string[] {
     const expanded = text
-      .replace(/(^|\n)\s*[-*•◦]\s+/g, "$1")
-      .replace(/(^|\n)\s*\d+[.)]\s+/g, "$1")
-      .replace(/\s+(?=\d+[.)]\s+)/g, "\n");
+      .replace(/(^|\n)\s*[-*•◦]\s+/g, "$1") // 글머리 기호 제거
+      .replace(/(^|\n)\s*\d+[.)]\s+/g, "$1") // "1. " / "1) " 형태 번호 제거
+      .replace(/\s+(?=\d+[.)]\s+)/g, "\n"); // 번호 앞 공백을 줄바꿈으로 변환
 
     return expanded
       .split(/\n+/)
@@ -184,8 +214,10 @@ export class TaskSentenceSplitter {
       .filter(Boolean);
   }
 
+  // 하나의 줄(segment)을 문장 부호([.!?;])를 기준으로 분리한 뒤 각 파트를 절 단위로 추가 분리
   private static splitSegment(segment: string): string[] {
     const sentenceParts = segment
+      // 문장 종결 부호 뒤에 대문자/숫자가 오면 분리 (lookbehind/lookahead 사용)
       .split(/(?<=[.!?;])\s+(?=[A-Z0-9])/)
       .map((part) => part.trim())
       .filter(Boolean);
@@ -193,11 +225,14 @@ export class TaskSentenceSplitter {
     return sentenceParts.flatMap((part) => this.splitClauses(part));
   }
 
+  // 쉼표 분리 → before/after/and then 순서 분리를 순서대로 적용
   private static splitClauses(segment: string): string[] {
     const clauses = this.splitByCommas(segment);
     return clauses.flatMap((clause) => this.splitByOrdering(clause));
   }
 
+  // 쉼표(", ")로 분리하되, 다음 절이 액션 동사로 시작하는 경우에만 독립 태스크로 분리
+  // 조건절(if/unless/when 등) 뒤에 오는 쉼표는 분리하지 않음
   private static splitByCommas(segment: string): string[] {
     const parts = segment.split(/,\s+/);
     if (parts.length === 1) return [segment];
@@ -208,11 +243,13 @@ export class TaskSentenceSplitter {
     for (let index = 1; index < parts.length; index += 1) {
       const next = parts[index] ?? "";
       const normalized = this.stripLeadingConnector(next);
-      const isConditionalClause = /^(?:if|unless|when|until|provided|assuming)\b/i.test(current.trim());
+      const isConditionalClause =
+        /^(?:if|unless|when|until|provided|assuming)\b/i.test(current.trim());
       if (this.startsWithAction(normalized) && !isConditionalClause) {
         results.push(current);
         current = normalized;
       } else {
+        // 액션이 아니거나 조건절이면 쉼표 포함 그대로 이어붙임
         current = `${current}, ${next}`;
       }
     }
@@ -221,6 +258,8 @@ export class TaskSentenceSplitter {
     return results.map((part) => this.cleanClause(part)).filter(Boolean);
   }
 
+  // before/after 키워드로 순서를 명시한 경우 올바른 실행 순서로 재배열하고,
+  // 그 다음 "and then" 계열 분리를 적용
   private static splitByOrdering(segment: string): string[] {
     const beforeAfter = this.splitBeforeAfter(segment);
     if (beforeAfter) {
@@ -229,6 +268,8 @@ export class TaskSentenceSplitter {
     return this.splitAndThen(segment);
   }
 
+  // "A before B" / "A after B" 패턴 감지 → 실행 순서에 맞게 [앞 작업, 뒤 작업] 반환
+  // 양쪽이 모두 액션 동사로 시작해야 분리 (그렇지 않으면 null 반환)
   private static splitBeforeAfter(segment: string): string[] | null {
     const match = /^(.*?)\b(before|after)\b(.*)$/i.exec(segment);
     if (!match) return null;
@@ -237,15 +278,24 @@ export class TaskSentenceSplitter {
     const relation = (match[2] ?? "").toLowerCase();
     const right = this.cleanClause(match[3] ?? "");
 
-    if (!left || !right || !this.startsWithAction(left) || !this.startsWithAction(right)) {
+    if (
+      !left ||
+      !right ||
+      !this.startsWithAction(left) ||
+      !this.startsWithAction(right)
+    ) {
       return null;
     }
 
+    // "after"이면 right가 먼저 실행, "before"이면 left가 먼저 실행
     return relation === "after" ? [right, left] : [left, right];
   }
 
+  // "and then", "then", "after that", "afterwards" 등의 명시적 순서 접속어로 분리
   private static splitAndThen(segment: string): string[] {
-    const explicit = segment.split(/\s+(?:and then|then|after that|afterwards)\s+/i);
+    const explicit = segment.split(
+      /\s+(?:and then|then|after that|afterwards)\s+/i,
+    );
     if (explicit.length > 1) {
       return explicit
         .map((part) => this.stripLeadingConnector(part))
@@ -255,6 +305,8 @@ export class TaskSentenceSplitter {
     return this.splitFollowUp(segment);
   }
 
+  // "A and B" 패턴에서 B가 후속 액션 동사로 시작하면 독립 태스크로 분리
+  // 단, "find and add" 같은 복합 동사(목적어 없는 단일 동사)는 분리하지 않음
   private static splitFollowUp(segment: string): string[] {
     const match = /^(.*?)\s+\band\b\s+(.*)$/i.exec(segment);
     if (!match) return [this.cleanClause(segment)].filter(Boolean);
@@ -263,14 +315,18 @@ export class TaskSentenceSplitter {
     const right = this.stripLeadingConnector(match[2] ?? "");
 
     if (!left || !right) return [this.cleanClause(segment)].filter(Boolean);
-    if (!this.startsWithAction(left)) return [this.cleanClause(segment)].filter(Boolean);
-    if (!this.startsWithFollowUpAction(right)) return [this.cleanClause(segment)].filter(Boolean);
+    if (!this.startsWithAction(left))
+      return [this.cleanClause(segment)].filter(Boolean);
+    if (!this.startsWithFollowUpAction(right))
+      return [this.cleanClause(segment)].filter(Boolean);
     // "find and add" 같은 compound verb 방지: left에 object(동사 외 단어)가 있어야 분리
-    if (left.trim().split(/\s+/).length < 2) return [this.cleanClause(segment)].filter(Boolean);
+    if (left.trim().split(/\s+/).length < 2)
+      return [this.cleanClause(segment)].filter(Boolean);
 
     return [left, ...this.splitFollowUp(right)];
   }
 
+  // 절 앞에 붙은 접속사(and/then/after that 등) 제거
   private static stripLeadingConnector(text: string): string {
     return text
       .trim()
@@ -278,26 +334,33 @@ export class TaskSentenceSplitter {
       .trim();
   }
 
+  // 번호 목록 접두사, 선행 구두점, 중복 공백 등을 정리하여 깔끔한 문장으로 만듦
   private static cleanClause(text: string): string {
     return text
       .trim()
-      .replace(/^\d+[.)]\s*/, "")
-      .replace(/^[,;:\-]+/, "")
-      .replace(/[ \t]+/g, " ")
-      .replace(/\s+([,.;!?])/g, "$1")
+      .replace(/^\d+[.)]\s*/, "") // "1. " / "1) " 제거
+      .replace(/^[,;:\-]+/, "") // 선행 구두점 제거
+      .replace(/[ \t]+/g, " ") // 중복 공백 제거
+      .replace(/\s+([,.;!?])/g, "$1") // 구두점 앞 공백 제거
       .trim();
   }
 
+  // 텍스트가 ACTION_STARTERS 동사 중 하나로 시작하는지 확인
   private static startsWithAction(text: string): boolean {
     return ACTION_STARTER_REGEX.test(text.trim());
   }
 
+  // 텍스트가 FOLLOW_UP_STARTERS 동사로 시작하거나 "run * test(s)" 형태인지 확인
   private static startsWithFollowUpAction(text: string): boolean {
     const trimmed = text.trim();
-    return FOLLOW_UP_STARTER_REGEX.test(trimmed) || /^run\s+\w+\s+(?:test|tests)\b/i.test(trimmed);
+    return (
+      FOLLOW_UP_STARTER_REGEX.test(trimmed) ||
+      /^run\s+\w+\s+(?:test|tests)\b/i.test(trimmed)
+    );
   }
 }
 
+// 정규식 특수문자를 이스케이프하여 리터럴 문자열로 사용할 수 있게 변환
 function escapeRegex(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/schemas/pipeline.ts
+++ b/src/schemas/pipeline.ts
@@ -219,6 +219,7 @@ export const CheckpointSchema = z.object({
 });
 
 export const SessionStateSchema = z.object({
+  version: z.string().optional(),
   shared_context: z.record(z.string(), z.unknown()).default({}),
   task_results: z.record(z.string(), z.unknown()).default({}),
   current_task_id: z.string().optional().nullable(),

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -550,6 +550,7 @@ describe("detoks CLI smoke", () => {
       writeFileSync(
         sessionPath,
         JSON.stringify({
+          version: "1",
           shared_context: {
             session_id: sessionId,
             raw_input: "Find the auth module. Test the auth module.",
@@ -955,6 +956,8 @@ describe("detoks CLI smoke", () => {
       expect(JSON.parse(showRun.stdout.trim())).toEqual({
         ok: true,
         mode: "checkpoint-show",
+        mutatesState: false,
+        message: `Checkpoint ${checkpointId} loaded.`,
         checkpoint: {
           id: checkpointId,
           title: "Smoke checkpoint",

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -202,6 +202,7 @@ describe("orchestratePipeline", () => {
   it("skips completed tasks from an existing session and resumes remaining work", async () => {
     vi.spyOn(SessionStateManager, "sessionExists").mockResolvedValue(true);
     vi.spyOn(SessionStateManager, "loadSession").mockResolvedValue({
+      version: "1",
       shared_context: {
         session_id: "resume_session",
         raw_input: "Find the auth module. Test the auth module.",


### PR DESCRIPTION
## 요약

- `ORCHESTRATOR_SESSION_PERSISTENCE.md` 가이드 기반으로 오케스트레이터 세션 영속성 전체 구현
- 기존 세션 로드·재개, 완료 Task 스킵, 세션 버전 관리, 파일 락(동시성 보호) 포함

## 관련 이슈

- Closes #133 

## 변경 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [ ] 테스트 추가/수정

## 영향 범위

- 변경된 파일:
  - `src/schemas/pipeline.ts` — `SessionStateSchema`에 `version?: string` 필드 추가
  - `src/core/pipeline/orchestrator.ts` — `SESSION_VERSION` 상수, 세션 로드·재개·버전 검증·고아 Task 체크·PipelineTracer 통합
  - `src/core/state/SessionStateManager.ts` — `acquireLock` / `releaseLock` 추가, `loadSession` / `saveSession` 락으로 보호

## 실행 흐름

### 세션 로드 (Step 5)

```
SessionStateManager.sessionExists(sessionId)
  ↓ true  → loadSession()
              ├─ version 불일치 → initSessionState() (버전 초기화)
              └─ version 일치  → 고아 Task 체크
                                  ├─ 고아 있음 → initSessionState() (그래프 불일치 초기화)
                                  └─ 정상     → state = loaded (세션 재개)
  ↓ false → initSessionState() (새 세션)
  ↓ catch → initSessionState() (fallback)
```

### 완료 Task 스킵 (Step 6 실행 루프)

```
for task of tasks:
  blockedBy 체크 → skip (기존)
  completed_task_ids.includes(task.id) → skip + 저장된 rawOutput 재사용  ← NEW
  실행 → markTaskCompleted() → saveSession()
```

### 파일 락 (SessionStateManager)

```
loadSession / saveSession 호출 시:
  acquireLock(sessionId)    ← wx 플래그로 원자적 lock 파일 생성
    └─ EEXIST → 100ms 후 재시도 (최대 5초)
    └─ 타임아웃 → 스테일 락 강제 제거 후 재획득
  try { 기존 로직 }
  finally { releaseLock(sessionId) }
```

## 타입 변경

```ts
// schemas/pipeline.ts
SessionStateSchema: {
  version?: string;  // 추가
  // 기존 필드 유지
}

// orchestrator.ts
const SESSION_VERSION = "1";  // 추가
```

## 체크리스트

- [x] 로컬에서 타입 체크 통과했습니다 (`npm run typecheck`)
- [ ] 세션 재개 단위 테스트를 추가했습니다
- [ ] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 리뷰어 참고사항

- 세션 버전이 없는 기존 세션 파일(`version: undefined`)은 불일치로 처리되어 자동 초기화됨 — 의도된 동작
- `task_results` 스키마(`z.unknown()`)로 인해 `raw_output` 접근에 `as any` 캐스팅 사용 — 스키마 강타입화 시 제거 가능
- 파일 락은 단일 머신 기준 — 분산 환경에서는 추가 검토 필요
