### PR TITLE
[codex] Role1 llama.cpp 로컬 런타임 자동 시작 구성

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,16 @@
 LOCAL_LLM_API_BASE=http://127.0.0.1:12370/v1
 LOCAL_LLM_API_KEY=
-LOCAL_LLM_MODEL_NAME=mradermacher/gemma-4-E2B-it-heretic-ara-GGUF
+LOCAL_LLM_MODEL_NAME=gemma-4-E2B-it-heretic-ara-GGUF
 LOCAL_LLM_AUTO_START=1
 LOCAL_LLM_SERVER_BINARY=llama-server
 LOCAL_LLM_SERVER_HOST=127.0.0.1
 LOCAL_LLM_SERVER_PORT=12370
+# Set to none if Metal fails with "failed to create command queue".
+# LOCAL_LLM_DEVICE=none
 LOCAL_LLM_GPU_LAYERS=all
+LOCAL_LLM_CONTEXT_SIZE=4096
+LOCAL_LLM_MAX_TOKENS=512
+LOCAL_LLM_REASONING=off
 LOCAL_LLM_HF_REPO=mradermacher/gemma-4-E2B-it-heretic-ara-GGUF:Q4_K_S
 LOCAL_LLM_HF_FILE=gemma-4-E2B-it-heretic-ara.Q4_K_S.gguf
 # LOCAL_LLM_MODEL_PATH=/absolute/path/to/model.gguf

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
-LOCAL_LLM_API_BASE=http://127.0.0.1:1234/v1
+LOCAL_LLM_API_BASE=http://127.0.0.1:12370/v1
 LOCAL_LLM_API_KEY=
-LOCAL_LLM_MODEL_NAME=local-small-model
+LOCAL_LLM_MODEL_NAME=mradermacher/gemma-4-E2B-it-heretic-ara-GGUF
+LOCAL_LLM_AUTO_START=1
+LOCAL_LLM_SERVER_BINARY=llama-server
+LOCAL_LLM_SERVER_HOST=127.0.0.1
+LOCAL_LLM_SERVER_PORT=12370
+LOCAL_LLM_HF_REPO=mradermacher/gemma-4-E2B-it-heretic-ara-GGUF
+# LOCAL_LLM_MODEL_PATH=/absolute/path/to/model.gguf
+# LOCAL_LLM_MODEL_URL=https://example.com/model.gguf
 
 # Optional runtime tuning
 PIPELINE_MODE=safe

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,9 @@ LOCAL_LLM_AUTO_START=1
 LOCAL_LLM_SERVER_BINARY=llama-server
 LOCAL_LLM_SERVER_HOST=127.0.0.1
 LOCAL_LLM_SERVER_PORT=12370
-LOCAL_LLM_HF_REPO=mradermacher/gemma-4-E2B-it-heretic-ara-GGUF
+LOCAL_LLM_GPU_LAYERS=all
+LOCAL_LLM_HF_REPO=mradermacher/gemma-4-E2B-it-heretic-ara-GGUF:Q4_K_S
+LOCAL_LLM_HF_FILE=gemma-4-E2B-it-heretic-ara.Q4_K_S.gguf
 # LOCAL_LLM_MODEL_PATH=/absolute/path/to/model.gguf
 # LOCAL_LLM_MODEL_URL=https://example.com/model.gguf
 

--- a/docs/LLAMA_CPP_SERVER_SPEC.md
+++ b/docs/LLAMA_CPP_SERVER_SPEC.md
@@ -50,7 +50,7 @@ This document defines the current `python/llama-server` runtime contract used by
 | `LLAMA_SERVER_PORT`          | `12370`                                        | Bind port                                            |
 | `LLAMA_SERVER_API_PREFIX`    | `/v1`                                          | API prefix                                           |
 | `LLAMA_SERVER_HEALTH_PATH`   | `/health`                                      | Health endpoint path                                 |
-| `LOCAL_LLM_MODEL_NAME`       | `mradermacher/gemma-4-E2B-it-heretic-ara-GGUF` | Default model name returned to clients               |
+| `LOCAL_LLM_MODEL_NAME`       | `gemma-4-E2B-it-heretic-ara-GGUF`              | Default model alias returned to clients              |
 | `REQUEST_TIMEOUT`            | `30`                                           | Upstream timeout in seconds                          |
 | `LLAMA_SERVER_API_KEY`       | unset                                          | Optional Bearer auth for inbound requests            |
 | `LLAMA_CPP_API_BASE`         | unset                                          | Upstream OpenAI-compatible llama.cpp base URL        |
@@ -61,7 +61,11 @@ This document defines the current `python/llama-server` runtime contract used by
 | `LOCAL_LLM_SERVER_BINARY`    | `llama-server`                                 | llama.cpp server executable                          |
 | `LOCAL_LLM_SERVER_HOST`      | `127.0.0.1`                                    | Auto-start bind host                                 |
 | `LOCAL_LLM_SERVER_PORT`      | `12370`                                        | Auto-start bind port                                 |
+| `LOCAL_LLM_DEVICE`           | unset                                          | Optional llama.cpp device selector, e.g. `none`      |
 | `LOCAL_LLM_GPU_LAYERS`       | `all`                                          | llama.cpp GPU offload layer count                    |
+| `LOCAL_LLM_CONTEXT_SIZE`     | `4096`                                         | llama.cpp prompt context size                        |
+| `LOCAL_LLM_MAX_TOKENS`       | `512`                                          | Maximum generated tokens per Role 1 translation span |
+| `LOCAL_LLM_REASONING`        | `off`                                          | llama.cpp reasoning mode for chat templates          |
 | `LOCAL_LLM_HF_REPO`          | `mradermacher/gemma-4-E2B-it-heretic-ara-GGUF:Q4_K_S` | Hugging Face GGUF repo and quant used when no model path exists |
 | `LOCAL_LLM_HF_FILE`          | `gemma-4-E2B-it-heretic-ara.Q4_K_S.gguf`       | Exact Hugging Face GGUF file                         |
 | `LOCAL_LLM_MODEL_PATH`       | unset                                          | Optional local GGUF model path                       |
@@ -123,6 +127,10 @@ Behavior:
 - If `LOCAL_LLM_MODEL_PATH` is missing and `LOCAL_LLM_MODEL_URL` is set, download the GGUF file first
 - If no local model path is set, start `llama-server -hf <LOCAL_LLM_HF_REPO> --hf-file <LOCAL_LLM_HF_FILE>` and let llama.cpp handle Hugging Face GGUF download/cache
 - Pass `--gpu-layers <LOCAL_LLM_GPU_LAYERS>`, default `all`, so Metal/GPU offload is requested on supported llama.cpp builds
+- If GPU startup fails before readiness, retry once with `--device none --gpu-layers 0`
+- Pass `--ctx-size <LOCAL_LLM_CONTEXT_SIZE>`, default `4096`, instead of inheriting very large model context defaults
+- Role 1 chat completion requests include `max_tokens`, capped by `LOCAL_LLM_MAX_TOKENS`
+- Pass `--reasoning off` by default so Gemma chat templates do not spend translation budget on hidden reasoning
 - The default Hugging Face GGUF quant is explicitly `Q4_K_S`
 - The server is opened on `LOCAL_LLM_SERVER_HOST:LOCAL_LLM_SERVER_PORT`, default `127.0.0.1:12370`
 

--- a/docs/LLAMA_CPP_SERVER_SPEC.md
+++ b/docs/LLAMA_CPP_SERVER_SPEC.md
@@ -12,8 +12,10 @@ This document defines the current `python/llama-server` runtime contract used by
 - Health check endpoint for runtime readiness
 - Environment-based runtime configuration
 - Optional upstream proxy mode for an external llama.cpp-compatible server
+- Role 1 local llama.cpp server auto-start on `127.0.0.1:12370`
+- GGUF model loading from a local path or Hugging Face GGUF repository
 
-<!-- 한국어 설명: 이 명세는 TypeScript 클라이언트가 호출하는 채팅 완성 endpoint, 헬스체크, 환경변수 설정, 그리고 외부 llama.cpp 서버 프록시 모드만 다룹니다. -->
+<!-- 한국어 설명: 이 명세는 TypeScript 클라이언트가 호출하는 채팅 완성 endpoint, 헬스체크, 환경변수 설정, 외부 llama.cpp 서버 프록시 모드, 그리고 Role 1 번역용 로컬 llama.cpp 서버 자동 실행을 다룹니다. -->
 
 ---
 
@@ -42,20 +44,28 @@ This document defines the current `python/llama-server` runtime contract used by
 
 ## Default Configuration
 
-| Key | Default | Description |
-| --- | --- | --- |
-| `LLAMA_SERVER_HOST` | `127.0.0.1` | Bind host |
-| `LLAMA_SERVER_PORT` | `1234` | Bind port |
-| `LLAMA_SERVER_API_PREFIX` | `/v1` | API prefix |
-| `LLAMA_SERVER_HEALTH_PATH` | `/health` | Health endpoint path |
-| `LOCAL_LLM_MODEL_NAME` | `mradermacher/gemma-4-E2B-it-heretic-ara-GGUF` | Default model name returned to clients |
-| `REQUEST_TIMEOUT` | `30` | Upstream timeout in seconds |
-| `LLAMA_SERVER_API_KEY` | unset | Optional Bearer auth for inbound requests |
-| `LLAMA_CPP_API_BASE` | unset | Upstream OpenAI-compatible llama.cpp base URL |
-| `LLAMA_CPP_API_KEY` | unset | Optional Bearer auth for upstream requests |
-| `LLAMA_SERVER_RESPONSE_TEXT` | unset | Mock response text for local/serverless verification |
+| Key                          | Default                                        | Description                                          |
+| ---------------------------- | ---------------------------------------------- | ---------------------------------------------------- |
+| `LLAMA_SERVER_HOST`          | `127.0.0.1`                                    | Bind host                                            |
+| `LLAMA_SERVER_PORT`          | `12370`                                        | Bind port                                            |
+| `LLAMA_SERVER_API_PREFIX`    | `/v1`                                          | API prefix                                           |
+| `LLAMA_SERVER_HEALTH_PATH`   | `/health`                                      | Health endpoint path                                 |
+| `LOCAL_LLM_MODEL_NAME`       | `mradermacher/gemma-4-E2B-it-heretic-ara-GGUF` | Default model name returned to clients               |
+| `REQUEST_TIMEOUT`            | `30`                                           | Upstream timeout in seconds                          |
+| `LLAMA_SERVER_API_KEY`       | unset                                          | Optional Bearer auth for inbound requests            |
+| `LLAMA_CPP_API_BASE`         | unset                                          | Upstream OpenAI-compatible llama.cpp base URL        |
+| `LLAMA_CPP_API_KEY`          | unset                                          | Optional Bearer auth for upstream requests           |
+| `LLAMA_SERVER_RESPONSE_TEXT` | unset                                          | Mock response text for local/serverless verification |
+| `LOCAL_LLM_API_BASE`         | `http://127.0.0.1:12370/v1`                   | TypeScript Role 1 local LLM API base                 |
+| `LOCAL_LLM_AUTO_START`       | `1`                                            | Auto-start local llama.cpp server for Role 1         |
+| `LOCAL_LLM_SERVER_BINARY`    | `llama-server`                                 | llama.cpp server executable                          |
+| `LOCAL_LLM_SERVER_HOST`      | `127.0.0.1`                                    | Auto-start bind host                                 |
+| `LOCAL_LLM_SERVER_PORT`      | `12370`                                        | Auto-start bind port                                 |
+| `LOCAL_LLM_HF_REPO`          | `mradermacher/gemma-4-E2B-it-heretic-ara-GGUF` | Hugging Face GGUF repo used when no model path exists |
+| `LOCAL_LLM_MODEL_PATH`       | unset                                          | Optional local GGUF model path                       |
+| `LOCAL_LLM_MODEL_URL`        | unset                                          | Optional download URL when model path is missing     |
 
-<!-- 한국어 설명: 기본 모델명은 현재 로컬 서버 기본값이며, 실제 추론은 upstream 프록시 또는 mock 응답 모드 중 하나로 동작합니다. -->
+<!-- 한국어 설명: 기본 모델명은 현재 로컬 서버 기본값입니다. Python 서버는 upstream 프록시 또는 mock 응답 모드로 동작하고, TypeScript Role 1 경로는 필요 시 llama.cpp `llama-server`를 로컬에서 자동 실행합니다. -->
 
 ---
 
@@ -64,9 +74,11 @@ This document defines the current `python/llama-server` runtime contract used by
 ### 1. Proxy Mode
 
 Condition:
+
 - `LLAMA_CPP_API_BASE` is set
 
 Behavior:
+
 - Incoming `POST /v1/chat/completions` request is forwarded to `{LLAMA_CPP_API_BASE}/chat/completions`
 - Request body is passed through in OpenAI-compatible shape
 - Upstream JSON is preserved as `raw_response`
@@ -74,21 +86,43 @@ Behavior:
 ### 2. Mock Mode
 
 Condition:
+
 - `LLAMA_SERVER_RESPONSE_TEXT` is set
 
 Behavior:
+
 - Server returns a fixed assistant message without contacting an upstream server
 - Intended for contract tests and local verification only
 
 ### 3. Invalid Runtime State
 
 Condition:
+
 - Neither `LLAMA_CPP_API_BASE` nor `LLAMA_SERVER_RESPONSE_TEXT` is set
 
 Behavior:
+
 - Chat completion requests fail with `503 Service Unavailable`
 
 <!-- 한국어 설명: 현재 서버는 자체 llama.cpp 프로세스를 직접 관리하지 않고, upstream 프록시 또는 mock 응답 두 모드만 지원합니다. -->
+
+### 4. Role 1 Auto-Start Mode
+
+Condition:
+
+- Role 1 translation is requested
+- `LOCAL_LLM_AUTO_START` is not disabled
+- `fetchImplementation` test override is not provided
+
+Behavior:
+
+- If `LOCAL_LLM_API_BASE` health check is already ready, reuse the running server
+- If `LOCAL_LLM_MODEL_PATH` exists, start `llama-server -m <path>`
+- If `LOCAL_LLM_MODEL_PATH` is missing and `LOCAL_LLM_MODEL_URL` is set, download the GGUF file first
+- If no local model path is set, start `llama-server -hf <LOCAL_LLM_HF_REPO>` and let llama.cpp handle Hugging Face GGUF download/cache
+- The server is opened on `LOCAL_LLM_SERVER_HOST:LOCAL_LLM_SERVER_PORT`, default `127.0.0.1:12370`
+
+<!-- 한국어 설명: Role 1 번역은 기본적으로 12370 포트의 로컬 llama.cpp 서버를 준비한 뒤 OpenAI-compatible `/v1/chat/completions`를 호출합니다. -->
 
 ---
 
@@ -97,19 +131,21 @@ Behavior:
 ### `GET /health`
 
 Purpose:
+
 - Runtime liveness and minimal readiness check
 
 Response:
 
 ```json
 {
-  "ok": true,
-  "model": "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
-  "backend": "configured"
+	"ok": true,
+	"model": "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
+	"backend": "configured"
 }
 ```
 
 Rules:
+
 - Returns `200 OK`
 - `ok` is `true` when either proxy mode or mock mode is configured
 - `ok` is `false` when no inference backend is configured
@@ -117,24 +153,26 @@ Rules:
 ### `POST /v1/chat/completions`
 
 Purpose:
+
 - OpenAI-compatible chat completion interface consumed by `src/core/llm-client`
 
 Required request shape:
 
 ```json
 {
-  "model": "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
-  "messages": [
-    {
-      "role": "user",
-      "content": "Translate this text"
-    }
-  ],
-  "temperature": 0
+	"model": "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
+	"messages": [
+		{
+			"role": "user",
+			"content": "Translate this text"
+		}
+	],
+	"temperature": 0
 }
 ```
 
 Current validation rules:
+
 - `model`: non-empty string
 - `messages`: non-empty array
 - `message.role`: `system` | `user` | `assistant`
@@ -146,34 +184,34 @@ Successful response shape:
 
 ```json
 {
-  "id": "chatcmpl-...",
-  "object": "chat.completion",
-  "created": 1710000000,
-  "model": "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
-  "choices": [
-    {
-      "index": 0,
-      "message": {
-        "role": "assistant",
-        "content": "Translated text"
-      },
-      "finish_reason": "stop"
-    }
-  ],
-  "usage": {
-    "prompt_tokens": 0,
-    "completion_tokens": 0,
-    "total_tokens": 0
-  },
-  "raw_response": {
-    "choices": [
-      {
-        "message": {
-          "content": "Translated text"
-        }
-      }
-    ]
-  }
+	"id": "chatcmpl-...",
+	"object": "chat.completion",
+	"created": 1710000000,
+	"model": "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
+	"choices": [
+		{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"content": "Translated text"
+			},
+			"finish_reason": "stop"
+		}
+	],
+	"usage": {
+		"prompt_tokens": 0,
+		"completion_tokens": 0,
+		"total_tokens": 0
+	},
+	"raw_response": {
+		"choices": [
+			{
+				"message": {
+					"content": "Translated text"
+				}
+			}
+		]
+	}
 }
 ```
 
@@ -184,11 +222,13 @@ Successful response shape:
 ## Authentication
 
 Inbound request auth:
+
 - Disabled by default
 - Enabled only when `LLAMA_SERVER_API_KEY` is set
 - Requires `Authorization: Bearer <LLAMA_SERVER_API_KEY>`
 
 Upstream request auth:
+
 - Disabled by default
 - Enabled only when `LLAMA_CPP_API_KEY` is set
 - Sends `Authorization: Bearer <LLAMA_CPP_API_KEY>` to upstream
@@ -197,9 +237,9 @@ Auth failure response:
 
 ```json
 {
-  "error": {
-    "message": "Unauthorized"
-  }
+	"error": {
+		"message": "Unauthorized"
+	}
 }
 ```
 
@@ -212,61 +252,65 @@ Auth failure response:
 ### Invalid JSON
 
 Status:
+
 - `400 Bad Request`
 
 Body:
 
 ```json
 {
-  "error": {
-    "message": "Invalid JSON body"
-  }
+	"error": {
+		"message": "Invalid JSON body"
+	}
 }
 ```
 
 ### Invalid Request Schema
 
 Status:
+
 - `400 Bad Request`
 
 Body:
 
 ```json
 {
-  "error": {
-    "message": "Invalid chat completions request",
-    "details": []
-  }
+	"error": {
+		"message": "Invalid chat completions request",
+		"details": []
+	}
 }
 ```
 
 ### Missing Backend Configuration or Upstream Failure
 
 Status:
+
 - `503 Service Unavailable`
 
 Body:
 
 ```json
 {
-  "error": {
-    "message": "No inference backend configured. Set LLAMA_CPP_API_BASE or LLAMA_SERVER_RESPONSE_TEXT."
-  }
+	"error": {
+		"message": "No inference backend configured. Set LLAMA_CPP_API_BASE or LLAMA_SERVER_RESPONSE_TEXT."
+	}
 }
 ```
 
 ### Unknown Path
 
 Status:
+
 - `404 Not Found`
 
 Body:
 
 ```json
 {
-  "error": {
-    "message": "Not found"
-  }
+	"error": {
+		"message": "Not found"
+	}
 }
 ```
 
@@ -297,7 +341,7 @@ The following are intentionally not specified yet:
 - context window policy
 - concurrency limits
 - retry policy inside the Python server
-- local llama.cpp process spawn lifecycle
-- GGUF file discovery rules
+- advanced local llama.cpp process supervision
+- automatic GGUF file discovery rules beyond explicit path, URL, or Hugging Face repo
 
 <!-- 한국어 설명: 위 항목들은 아직 팀 차원의 계약이 없으므로, 이후 필요할 때 별도 명세로 고정해야 합니다. -->

--- a/docs/LLAMA_CPP_SERVER_SPEC.md
+++ b/docs/LLAMA_CPP_SERVER_SPEC.md
@@ -61,7 +61,9 @@ This document defines the current `python/llama-server` runtime contract used by
 | `LOCAL_LLM_SERVER_BINARY`    | `llama-server`                                 | llama.cpp server executable                          |
 | `LOCAL_LLM_SERVER_HOST`      | `127.0.0.1`                                    | Auto-start bind host                                 |
 | `LOCAL_LLM_SERVER_PORT`      | `12370`                                        | Auto-start bind port                                 |
-| `LOCAL_LLM_HF_REPO`          | `mradermacher/gemma-4-E2B-it-heretic-ara-GGUF` | Hugging Face GGUF repo used when no model path exists |
+| `LOCAL_LLM_GPU_LAYERS`       | `all`                                          | llama.cpp GPU offload layer count                    |
+| `LOCAL_LLM_HF_REPO`          | `mradermacher/gemma-4-E2B-it-heretic-ara-GGUF:Q4_K_S` | Hugging Face GGUF repo and quant used when no model path exists |
+| `LOCAL_LLM_HF_FILE`          | `gemma-4-E2B-it-heretic-ara.Q4_K_S.gguf`       | Exact Hugging Face GGUF file                         |
 | `LOCAL_LLM_MODEL_PATH`       | unset                                          | Optional local GGUF model path                       |
 | `LOCAL_LLM_MODEL_URL`        | unset                                          | Optional download URL when model path is missing     |
 
@@ -119,7 +121,9 @@ Behavior:
 - If `LOCAL_LLM_API_BASE` health check is already ready, reuse the running server
 - If `LOCAL_LLM_MODEL_PATH` exists, start `llama-server -m <path>`
 - If `LOCAL_LLM_MODEL_PATH` is missing and `LOCAL_LLM_MODEL_URL` is set, download the GGUF file first
-- If no local model path is set, start `llama-server -hf <LOCAL_LLM_HF_REPO>` and let llama.cpp handle Hugging Face GGUF download/cache
+- If no local model path is set, start `llama-server -hf <LOCAL_LLM_HF_REPO> --hf-file <LOCAL_LLM_HF_FILE>` and let llama.cpp handle Hugging Face GGUF download/cache
+- Pass `--gpu-layers <LOCAL_LLM_GPU_LAYERS>`, default `all`, so Metal/GPU offload is requested on supported llama.cpp builds
+- The default Hugging Face GGUF quant is explicitly `Q4_K_S`
 - The server is opened on `LOCAL_LLM_SERVER_HOST:LOCAL_LLM_SERVER_PORT`, default `127.0.0.1:12370`
 
 <!-- 한국어 설명: Role 1 번역은 기본적으로 12370 포트의 로컬 llama.cpp 서버를 준비한 뒤 OpenAI-compatible `/v1/chat/completions`를 호출합니다. -->

--- a/python/llama_server/config.py
+++ b/python/llama_server/config.py
@@ -11,7 +11,7 @@ class LlamaServerConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     host: str = Field(default="127.0.0.1")
-    port: int = Field(default=1234, ge=1, le=65535)
+    port: int = Field(default=12370, ge=1, le=65535)
     api_prefix: str = Field(default="/v1", min_length=1)
     health_path: str = Field(default="/health", min_length=1)
     model_name: str = Field(default=DEFAULT_MODEL_NAME, min_length=1)
@@ -27,10 +27,13 @@ def load_llama_server_config(env: dict[str, str] | None = None) -> LlamaServerCo
 
     return LlamaServerConfig(
         host=source.get("LLAMA_SERVER_HOST", "127.0.0.1"),
-        port=int(source.get("LLAMA_SERVER_PORT", "1234")),
+        port=int(source.get("LLAMA_SERVER_PORT", "12370")),
         api_prefix=source.get("LLAMA_SERVER_API_PREFIX", "/v1"),
         health_path=source.get("LLAMA_SERVER_HEALTH_PATH", "/health"),
-        model_name=source.get("MODEL_NAME", DEFAULT_MODEL_NAME),
+        model_name=source.get(
+            "LOCAL_LLM_MODEL_NAME",
+            source.get("MODEL_NAME", DEFAULT_MODEL_NAME),
+        ),
         request_timeout_sec=float(source.get("REQUEST_TIMEOUT", "30")),
         api_key=source.get("LLAMA_SERVER_API_KEY"),
         upstream_api_base=source.get("LLAMA_CPP_API_BASE"),

--- a/src/core/llm-client/client.ts
+++ b/src/core/llm-client/client.ts
@@ -8,6 +8,7 @@ export interface LlmMessage {
 export interface LlmCompletionRequest {
   messages: LlmMessage[];
   temperature?: number;
+  max_tokens?: number;
   timeout_ms?: number;
 }
 
@@ -112,6 +113,7 @@ export async function complete_chat(
           model: options.localLlmModelName,
           messages: request.messages,
           temperature: request.temperature ?? 0,
+          ...(request.max_tokens ? { max_tokens: request.max_tokens } : {}),
         }),
         signal: controller.signal,
       },

--- a/src/core/llm-client/local-runtime.ts
+++ b/src/core/llm-client/local-runtime.ts
@@ -82,6 +82,9 @@ export function buildLlamaServerArgs(config: Role1RuntimeConfig): string[] {
     }
 
     args.push("-hf", hfRepo);
+    if (config.localLlmHfFile) {
+      args.push("--hf-file", config.localLlmHfFile);
+    }
   }
 
   if (config.localLlmModelName) {
@@ -94,6 +97,10 @@ export function buildLlamaServerArgs(config: Role1RuntimeConfig): string[] {
     "--port",
     String(config.localLlmServerPort ?? 12370),
   );
+
+  if (config.localLlmGpuLayers) {
+    args.push("--gpu-layers", config.localLlmGpuLayers);
+  }
 
   return args;
 }

--- a/src/core/llm-client/local-runtime.ts
+++ b/src/core/llm-client/local-runtime.ts
@@ -4,6 +4,7 @@ import { dirname } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { Role1RuntimeConfig } from "../prompt/config.js";
+import { logger } from "../utils/logger.js";
 
 let startupPromise: Promise<void> | null = null;
 
@@ -14,6 +15,19 @@ function isLocalHost(hostname: string): boolean {
 function healthUrlFromApiBase(apiBase: string): string {
   const url = new URL(apiBase);
   return `${url.origin}/health`;
+}
+
+function formatBytes(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${value.toFixed(unitIndex === 0 ? 0 : 1)}${units[unitIndex]}`;
 }
 
 async function isServerReady(apiBase: string): Promise<boolean> {
@@ -30,10 +44,18 @@ async function waitForServerReady(
   timeoutMs: number,
 ): Promise<void> {
   const startedAt = Date.now();
+  let nextLogAt = startedAt + 10_000;
 
   while (Date.now() - startedAt < timeoutMs) {
     if (await isServerReady(apiBase)) {
+      logger.warn(`llama.cpp server is ready at ${apiBase}`);
       return;
+    }
+
+    const now = Date.now();
+    if (now >= nextLogAt) {
+      logger.warn(`Waiting for llama.cpp server startup at ${apiBase}...`);
+      nextLogAt = now + 10_000;
     }
 
     await new Promise((resolve) => setTimeout(resolve, 500));
@@ -50,10 +72,33 @@ async function downloadModel(modelUrl: string, modelPath: string): Promise<void>
     throw new Error(`Failed to download GGUF model: ${response.status} ${response.statusText}`);
   }
 
+  const totalBytes = Number(response.headers.get("content-length") ?? 0);
+  let downloadedBytes = 0;
+  let nextLogAt = Date.now();
+  logger.warn(
+    `Downloading GGUF model to ${modelPath}${totalBytes > 0 ? ` (${formatBytes(totalBytes)})` : ""}...`,
+  );
+
+  const progressStream = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      downloadedBytes += chunk.byteLength;
+      const now = Date.now();
+
+      if (now >= nextLogAt) {
+        const totalText = totalBytes > 0 ? ` / ${formatBytes(totalBytes)}` : "";
+        logger.warn(`Downloading GGUF model: ${formatBytes(downloadedBytes)}${totalText}`);
+        nextLogAt = now + 5_000;
+      }
+
+      controller.enqueue(chunk);
+    },
+  });
+
   await pipeline(
-    Readable.fromWeb(response.body),
+    Readable.fromWeb(response.body.pipeThrough(progressStream)),
     createWriteStream(modelPath, { flags: "wx" }),
   );
+  logger.warn(`Downloaded GGUF model to ${modelPath}`);
 }
 
 async function ensureModelFile(config: Role1RuntimeConfig): Promise<void> {
@@ -102,7 +147,65 @@ export function buildLlamaServerArgs(config: Role1RuntimeConfig): string[] {
     args.push("--gpu-layers", config.localLlmGpuLayers);
   }
 
+  if (config.localLlmDevice) {
+    args.push("--device", config.localLlmDevice);
+  }
+
+  if (config.localLlmContextSize) {
+    args.push("--ctx-size", String(config.localLlmContextSize));
+  }
+
+  if (config.localLlmReasoning) {
+    args.push("--reasoning", config.localLlmReasoning);
+  }
+
   return args;
+}
+
+async function startServerProcess(
+  config: Role1RuntimeConfig,
+  apiBase: string,
+): Promise<void> {
+  const binary = config.localLlmServerBinary ?? "llama-server";
+  const args = buildLlamaServerArgs(config);
+  logger.warn(`Starting llama.cpp server: ${binary} ${args.join(" ")}`);
+  const child = spawn(binary, args, {
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    String(chunk)
+      .trimEnd()
+      .split(/\r?\n/u)
+      .filter(Boolean)
+      .forEach((line) => logger.warn(`[llama-server] ${line}`));
+  });
+  child.stderr.on("data", (chunk) => {
+    String(chunk)
+      .trimEnd()
+      .split(/\r?\n/u)
+      .filter(Boolean)
+      .forEach((line) => logger.warn(`[llama-server] ${line}`));
+  });
+  child.unref();
+
+  await Promise.race([
+    waitForServerReady(apiBase, config.localLlmStartupTimeout ?? 600_000),
+    new Promise<never>((_, reject) => {
+      child.once("error", (error) => {
+        reject(new Error(`Failed to start llama.cpp server with ${binary}: ${error.message}`));
+      });
+      child.once("exit", (code) => {
+        reject(new Error(`llama.cpp server exited before becoming ready: ${code ?? "unknown"}`));
+      });
+    }),
+  ]);
+}
+
+function shouldRetryWithoutGpu(config: Role1RuntimeConfig): boolean {
+  return config.localLlmDevice !== "none" || config.localLlmGpuLayers !== "0";
 }
 
 async function startLocalServer(config: Role1RuntimeConfig): Promise<void> {
@@ -122,24 +225,24 @@ async function startLocalServer(config: Role1RuntimeConfig): Promise<void> {
 
   await ensureModelFile(config);
 
-  const binary = config.localLlmServerBinary ?? "llama-server";
-  const child = spawn(binary, buildLlamaServerArgs(config), {
-    detached: true,
-    stdio: "ignore",
-  });
-  child.unref();
+  try {
+    await startServerProcess(config, apiBase);
+  } catch (error) {
+    if (!shouldRetryWithoutGpu(config)) {
+      throw error;
+    }
 
-  await Promise.race([
-    waitForServerReady(apiBase, config.localLlmStartupTimeout ?? 600_000),
-    new Promise<never>((_, reject) => {
-      child.once("error", (error) => {
-        reject(new Error(`Failed to start llama.cpp server with ${binary}: ${error.message}`));
-      });
-      child.once("exit", (code) => {
-        reject(new Error(`llama.cpp server exited before becoming ready: ${code ?? "unknown"}`));
-      });
-    }),
-  ]);
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(`llama.cpp GPU startup failed, retrying with CPU only: ${message}`);
+    await startServerProcess(
+      {
+        ...config,
+        localLlmDevice: "none",
+        localLlmGpuLayers: "0",
+      },
+      apiBase,
+    );
+  }
 }
 
 export async function ensureLocalLlmRuntime(config: Role1RuntimeConfig): Promise<void> {

--- a/src/core/llm-client/local-runtime.ts
+++ b/src/core/llm-client/local-runtime.ts
@@ -1,0 +1,149 @@
+import { spawn } from "node:child_process";
+import { createWriteStream, existsSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { Role1RuntimeConfig } from "../prompt/config.js";
+
+let startupPromise: Promise<void> | null = null;
+
+function isLocalHost(hostname: string): boolean {
+  return ["127.0.0.1", "localhost", "::1"].includes(hostname);
+}
+
+function healthUrlFromApiBase(apiBase: string): string {
+  const url = new URL(apiBase);
+  return `${url.origin}/health`;
+}
+
+async function isServerReady(apiBase: string): Promise<boolean> {
+  try {
+    const response = await fetch(healthUrlFromApiBase(apiBase));
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForServerReady(
+  apiBase: string,
+  timeoutMs: number,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await isServerReady(apiBase)) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`llama.cpp server did not become ready within ${timeoutMs}ms`);
+}
+
+async function downloadModel(modelUrl: string, modelPath: string): Promise<void> {
+  mkdirSync(dirname(modelPath), { recursive: true });
+
+  const response = await fetch(modelUrl);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download GGUF model: ${response.status} ${response.statusText}`);
+  }
+
+  await pipeline(
+    Readable.fromWeb(response.body),
+    createWriteStream(modelPath, { flags: "wx" }),
+  );
+}
+
+async function ensureModelFile(config: Role1RuntimeConfig): Promise<void> {
+  if (!config.localLlmModelPath || existsSync(config.localLlmModelPath)) {
+    return;
+  }
+
+  if (!config.localLlmModelUrl) {
+    throw new Error(
+      `GGUF model file not found: ${config.localLlmModelPath}. Set LOCAL_LLM_MODEL_URL or LOCAL_LLM_HF_REPO.`,
+    );
+  }
+
+  await downloadModel(config.localLlmModelUrl, config.localLlmModelPath);
+}
+
+export function buildLlamaServerArgs(config: Role1RuntimeConfig): string[] {
+  const args: string[] = [];
+
+  if (config.localLlmModelPath) {
+    args.push("-m", config.localLlmModelPath);
+  } else {
+    const hfRepo = config.localLlmHfRepo ?? config.localLlmModelName;
+    if (!hfRepo) {
+      throw new Error("Role 1 local LLM requires LOCAL_LLM_MODEL_PATH or LOCAL_LLM_HF_REPO");
+    }
+
+    args.push("-hf", hfRepo);
+  }
+
+  if (config.localLlmModelName) {
+    args.push("--alias", config.localLlmModelName);
+  }
+
+  args.push(
+    "--host",
+    config.localLlmServerHost ?? "127.0.0.1",
+    "--port",
+    String(config.localLlmServerPort ?? 12370),
+  );
+
+  return args;
+}
+
+async function startLocalServer(config: Role1RuntimeConfig): Promise<void> {
+  const apiBase = config.localLlmApiBase;
+  if (!apiBase) {
+    throw new Error("LLM client requires LOCAL_LLM_API_BASE");
+  }
+
+  const apiBaseUrl = new URL(apiBase);
+  if (!isLocalHost(apiBaseUrl.hostname)) {
+    return;
+  }
+
+  if (await isServerReady(apiBase)) {
+    return;
+  }
+
+  await ensureModelFile(config);
+
+  const binary = config.localLlmServerBinary ?? "llama-server";
+  const child = spawn(binary, buildLlamaServerArgs(config), {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+
+  await Promise.race([
+    waitForServerReady(apiBase, config.localLlmStartupTimeout ?? 600_000),
+    new Promise<never>((_, reject) => {
+      child.once("error", (error) => {
+        reject(new Error(`Failed to start llama.cpp server with ${binary}: ${error.message}`));
+      });
+      child.once("exit", (code) => {
+        reject(new Error(`llama.cpp server exited before becoming ready: ${code ?? "unknown"}`));
+      });
+    }),
+  ]);
+}
+
+export async function ensureLocalLlmRuntime(config: Role1RuntimeConfig): Promise<void> {
+  if (config.localLlmAutoStart === false) {
+    return;
+  }
+
+  startupPromise ??= startLocalServer(config).catch((error) => {
+    startupPromise = null;
+    throw error;
+  });
+
+  await startupPromise;
+}

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -98,9 +98,12 @@ function inferPromptFailureNextAction(errorMessage: string): string {
     errorMessage.includes("LOCAL_LLM_API_BASE") ||
     errorMessage.includes("LOCAL_LLM_MODEL_NAME") ||
     errorMessage.includes("MODEL_NAME") ||
+    errorMessage.includes("llama.cpp server") ||
+    errorMessage.includes("llama-server") ||
+    errorMessage.includes("GGUF model") ||
     errorMessage.includes("fetch support")
   ) {
-    return "Set Role 1 local LLM runtime config (LOCAL_LLM_API_BASE, LOCAL_LLM_MODEL_NAME) and retry";
+    return "Install llama-server or set Role 1 local LLM runtime config (LOCAL_LLM_API_BASE, LOCAL_LLM_MODEL_NAME) and retry";
   }
 
   return "Fix prompt compilation inputs or runtime config and retry";

--- a/src/core/prompt/config.ts
+++ b/src/core/prompt/config.ts
@@ -5,6 +5,12 @@ import { z } from "zod";
 const DEFAULT_REQUEST_TIMEOUT = 30_000;
 const DEFAULT_TRANSLATION_MAX_ATTEMPTS = 5;
 const DEFAULT_TEMPERATURE = 0;
+const DEFAULT_LOCAL_LLM_API_BASE = "http://127.0.0.1:12370/v1";
+const DEFAULT_LOCAL_LLM_MODEL_NAME = "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF";
+const DEFAULT_LOCAL_LLM_SERVER_BINARY = "llama-server";
+const DEFAULT_LOCAL_LLM_SERVER_HOST = "127.0.0.1";
+const DEFAULT_LOCAL_LLM_SERVER_PORT = 12370;
+const DEFAULT_LOCAL_LLM_STARTUP_TIMEOUT = 600_000;
 
 const PipelineModeSchema = z.enum(["safe", "debug"]);
 
@@ -12,6 +18,14 @@ const Role1RuntimeConfigSchema = z.object({
   localLlmApiBase: z.string().optional(),
   localLlmApiKey: z.string().optional(),
   localLlmModelName: z.string().optional(),
+  localLlmAutoStart: z.boolean().optional(),
+  localLlmServerBinary: z.string().optional(),
+  localLlmServerHost: z.string().optional(),
+  localLlmServerPort: z.number().int().positive().optional(),
+  localLlmStartupTimeout: z.number().int().positive().optional(),
+  localLlmModelPath: z.string().optional(),
+  localLlmModelUrl: z.string().optional(),
+  localLlmHfRepo: z.string().optional(),
   pipelineMode: PipelineModeSchema,
   requestTimeout: z.number().int().positive(),
   translationMaxAttempts: z.number().int().positive(),
@@ -104,6 +118,43 @@ function parseNumber(
   return parsed;
 }
 
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  return ["1", "true", "on", "yes"].includes(value.toLowerCase());
+}
+
+function readEnvValue(
+  env: Record<string, string | undefined>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = env[key]?.trim();
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function readEnvValueWithDefault(
+  env: Record<string, string | undefined>,
+  keys: string[],
+  fallback: string,
+): string | undefined {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(env, key)) {
+      const value = env[key]?.trim();
+      return value || undefined;
+    }
+  }
+
+  return fallback;
+}
+
 function readJsonFile<T>(
   filePath: string,
   schema: z.ZodSchema<T>,
@@ -133,10 +184,38 @@ export function loadRole1RuntimeConfig(
 
   return Role1RuntimeConfigSchema.parse({
     localLlmApiBase:
-      env.LOCAL_LLM_API_BASE ?? env.OPENAI_API_BASE ?? env.LM_STUDIO_URL,
+      readEnvValueWithDefault(
+        env,
+        ["LOCAL_LLM_API_BASE", "OPENAI_API_BASE", "LM_STUDIO_URL"],
+        DEFAULT_LOCAL_LLM_API_BASE,
+      ),
     localLlmApiKey:
-      env.LOCAL_LLM_API_KEY ?? env.OPENAI_API_KEY ?? env.LM_STUDIO_API_KEY,
-    localLlmModelName: env.LOCAL_LLM_MODEL_NAME ?? env.MODEL_NAME,
+      readEnvValue(env, "LOCAL_LLM_API_KEY", "OPENAI_API_KEY", "LM_STUDIO_API_KEY"),
+    localLlmModelName:
+      readEnvValueWithDefault(
+        env,
+        ["LOCAL_LLM_MODEL_NAME", "MODEL_NAME"],
+        DEFAULT_LOCAL_LLM_MODEL_NAME,
+      ),
+    localLlmAutoStart: parseBoolean(env.LOCAL_LLM_AUTO_START, true),
+    localLlmServerBinary:
+      readEnvValue(env, "LOCAL_LLM_SERVER_BINARY") ?? DEFAULT_LOCAL_LLM_SERVER_BINARY,
+    localLlmServerHost:
+      readEnvValue(env, "LOCAL_LLM_SERVER_HOST") ?? DEFAULT_LOCAL_LLM_SERVER_HOST,
+    localLlmServerPort: parseNumber(
+      env.LOCAL_LLM_SERVER_PORT,
+      DEFAULT_LOCAL_LLM_SERVER_PORT,
+      "LOCAL_LLM_SERVER_PORT",
+    ),
+    localLlmStartupTimeout: parseNumber(
+      env.LOCAL_LLM_STARTUP_TIMEOUT,
+      DEFAULT_LOCAL_LLM_STARTUP_TIMEOUT,
+      "LOCAL_LLM_STARTUP_TIMEOUT",
+    ),
+    localLlmModelPath: readEnvValue(env, "LOCAL_LLM_MODEL_PATH"),
+    localLlmModelUrl: readEnvValue(env, "LOCAL_LLM_MODEL_URL"),
+    localLlmHfRepo:
+      readEnvValue(env, "LOCAL_LLM_HF_REPO") ?? DEFAULT_LOCAL_LLM_MODEL_NAME,
     pipelineMode,
     requestTimeout: parseNumber(
       env.REQUEST_TIMEOUT,

--- a/src/core/prompt/config.ts
+++ b/src/core/prompt/config.ts
@@ -6,35 +6,42 @@ const DEFAULT_REQUEST_TIMEOUT = 30_000;
 const DEFAULT_TRANSLATION_MAX_ATTEMPTS = 5;
 const DEFAULT_TEMPERATURE = 0;
 const DEFAULT_LOCAL_LLM_API_BASE = "http://127.0.0.1:12370/v1";
-const DEFAULT_LOCAL_LLM_MODEL_NAME = "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF";
-const DEFAULT_LOCAL_LLM_HF_REPO = `${DEFAULT_LOCAL_LLM_MODEL_NAME}:Q4_K_S`;
+const DEFAULT_LOCAL_LLM_MODEL_NAME = "gemma-4-E2B-it-heretic-ara-GGUF";
+const DEFAULT_LOCAL_LLM_HF_REPO = "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF:Q4_K_S";
 const DEFAULT_LOCAL_LLM_HF_FILE = "gemma-4-E2B-it-heretic-ara.Q4_K_S.gguf";
 const DEFAULT_LOCAL_LLM_SERVER_BINARY = "llama-server";
 const DEFAULT_LOCAL_LLM_SERVER_HOST = "127.0.0.1";
 const DEFAULT_LOCAL_LLM_SERVER_PORT = 12370;
 const DEFAULT_LOCAL_LLM_STARTUP_TIMEOUT = 600_000;
 const DEFAULT_LOCAL_LLM_GPU_LAYERS = "all";
+const DEFAULT_LOCAL_LLM_CONTEXT_SIZE = 4096;
+const DEFAULT_LOCAL_LLM_MAX_TOKENS = 512;
+const DEFAULT_LOCAL_LLM_REASONING = "off";
 
 const PipelineModeSchema = z.enum(["safe", "debug"]);
 
 const Role1RuntimeConfigSchema = z.object({
-  localLlmApiBase: z.string().optional(),
-  localLlmApiKey: z.string().optional(),
-  localLlmModelName: z.string().optional(),
-  localLlmAutoStart: z.boolean().optional(),
-  localLlmServerBinary: z.string().optional(),
-  localLlmServerHost: z.string().optional(),
-  localLlmServerPort: z.number().int().positive().optional(),
-  localLlmStartupTimeout: z.number().int().positive().optional(),
-  localLlmGpuLayers: z.string().optional(),
-  localLlmModelPath: z.string().optional(),
-  localLlmModelUrl: z.string().optional(),
-  localLlmHfRepo: z.string().optional(),
-  localLlmHfFile: z.string().optional(),
-  pipelineMode: PipelineModeSchema,
-  requestTimeout: z.number().int().positive(),
-  translationMaxAttempts: z.number().int().positive(),
-  temperature: z.number().min(0),
+	localLlmApiBase: z.string().optional(),
+	localLlmApiKey: z.string().optional(),
+	localLlmModelName: z.string().optional(),
+	localLlmAutoStart: z.boolean().optional(),
+	localLlmServerBinary: z.string().optional(),
+	localLlmServerHost: z.string().optional(),
+	localLlmServerPort: z.number().int().positive().optional(),
+	localLlmStartupTimeout: z.number().int().positive().optional(),
+	localLlmDevice: z.string().optional(),
+	localLlmGpuLayers: z.string().optional(),
+	localLlmContextSize: z.number().int().positive().optional(),
+	localLlmMaxTokens: z.number().int().positive().optional(),
+	localLlmReasoning: z.string().optional(),
+	localLlmModelPath: z.string().optional(),
+	localLlmModelUrl: z.string().optional(),
+	localLlmHfRepo: z.string().optional(),
+	localLlmHfFile: z.string().optional(),
+	pipelineMode: PipelineModeSchema,
+	requestTimeout: z.number().int().positive(),
+	translationMaxAttempts: z.number().int().positive(),
+	temperature: z.number().min(0),
 });
 
 const ProtectedTermsSchema = z.array(z.string().min(1));
@@ -42,9 +49,9 @@ const PreferredTranslationsSchema = z.record(z.string(), z.string());
 const ForbiddenPatternsSchema = z.array(z.string().min(1));
 
 const Role1PoliciesSchema = z.object({
-  protectedTerms: ProtectedTermsSchema,
-  preferredTranslations: PreferredTranslationsSchema,
-  forbiddenPatterns: ForbiddenPatternsSchema,
+	protectedTerms: ProtectedTermsSchema,
+	preferredTranslations: PreferredTranslationsSchema,
+	forbiddenPatterns: ForbiddenPatternsSchema,
 });
 
 export type PipelineMode = z.infer<typeof PipelineModeSchema>;
@@ -52,217 +59,236 @@ export type Role1RuntimeConfig = z.infer<typeof Role1RuntimeConfigSchema>;
 export type Role1Policies = z.infer<typeof Role1PoliciesSchema>;
 
 interface LoaderOptions {
-  cwd?: string;
-  env?: NodeJS.ProcessEnv;
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
 }
 
 function parseEnvFile(content: string): Record<string, string> {
-  const parsed: Record<string, string> = {};
+	const parsed: Record<string, string> = {};
 
-  for (const rawLine of content.split(/\r?\n/u)) {
-    const line = rawLine.trim();
-    if (!line || line.startsWith("#")) {
-      continue;
-    }
+	for (const rawLine of content.split(/\r?\n/u)) {
+		const line = rawLine.trim();
+		if (!line || line.startsWith("#")) {
+			continue;
+		}
 
-    const normalized = line.startsWith("export ")
-      ? line.slice("export ".length)
-      : line;
-    const separatorIndex = normalized.indexOf("=");
+		const normalized = line.startsWith("export ")
+			? line.slice("export ".length)
+			: line;
+		const separatorIndex = normalized.indexOf("=");
 
-    if (separatorIndex <= 0) {
-      continue;
-    }
+		if (separatorIndex <= 0) {
+			continue;
+		}
 
-    const key = normalized.slice(0, separatorIndex).trim();
-    let value = normalized.slice(separatorIndex + 1).trim();
+		const key = normalized.slice(0, separatorIndex).trim();
+		let value = normalized.slice(separatorIndex + 1).trim();
 
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		}
 
-    parsed[key] = value;
-  }
+		parsed[key] = value;
+	}
 
-  return parsed;
+	return parsed;
 }
 
 function loadDotEnv(cwd: string): Record<string, string> {
-  const envFiles = [".env", ".env.local"];
+	const envFiles = [".env", ".env.local"];
 
-  return envFiles.reduce<Record<string, string>>((acc, fileName) => {
-    const filePath = join(cwd, fileName);
-    if (!existsSync(filePath)) {
-      return acc;
-    }
+	return envFiles.reduce<Record<string, string>>((acc, fileName) => {
+		const filePath = join(cwd, fileName);
+		if (!existsSync(filePath)) {
+			return acc;
+		}
 
-    return {
-      ...acc,
-      ...parseEnvFile(readFileSync(filePath, "utf8")),
-    };
-  }, {});
+		return {
+			...acc,
+			...parseEnvFile(readFileSync(filePath, "utf8")),
+		};
+	}, {});
 }
 
 function parseNumber(
-  value: string | undefined,
-  fallback: number,
-  fieldName: string,
+	value: string | undefined,
+	fallback: number,
+	fieldName: string,
 ): number {
-  if (value === undefined) {
-    return fallback;
-  }
+	if (value === undefined) {
+		return fallback;
+	}
 
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) {
-    throw new Error(`Invalid numeric env value: ${fieldName}`);
-  }
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed)) {
+		throw new Error(`Invalid numeric env value: ${fieldName}`);
+	}
 
-  return parsed;
+	return parsed;
 }
 
 function parseBoolean(value: string | undefined, fallback: boolean): boolean {
-  if (value === undefined) {
-    return fallback;
-  }
+	if (value === undefined) {
+		return fallback;
+	}
 
-  return ["1", "true", "on", "yes"].includes(value.toLowerCase());
+	return ["1", "true", "on", "yes"].includes(value.toLowerCase());
 }
 
 function readEnvValue(
-  env: Record<string, string | undefined>,
-  ...keys: string[]
+	env: Record<string, string | undefined>,
+	...keys: string[]
 ): string | undefined {
-  for (const key of keys) {
-    const value = env[key]?.trim();
-    if (value) {
-      return value;
-    }
-  }
+	for (const key of keys) {
+		const value = env[key]?.trim();
+		if (value) {
+			return value;
+		}
+	}
 
-  return undefined;
+	return undefined;
 }
 
 function readEnvValueWithDefault(
-  env: Record<string, string | undefined>,
-  keys: string[],
-  fallback: string,
+	env: Record<string, string | undefined>,
+	keys: string[],
+	fallback: string,
 ): string | undefined {
-  for (const key of keys) {
-    if (Object.prototype.hasOwnProperty.call(env, key)) {
-      const value = env[key]?.trim();
-      return value || undefined;
-    }
-  }
+	for (const key of keys) {
+		if (Object.prototype.hasOwnProperty.call(env, key)) {
+			const value = env[key]?.trim();
+			return value || undefined;
+		}
+	}
 
-  return fallback;
+	return fallback;
 }
 
 function readJsonFile<T>(
-  filePath: string,
-  schema: z.ZodSchema<T>,
-  fallback: T,
+	filePath: string,
+	schema: z.ZodSchema<T>,
+	fallback: T,
 ): T {
-  if (!existsSync(filePath)) {
-    return fallback;
-  }
+	if (!existsSync(filePath)) {
+		return fallback;
+	}
 
-  try {
-    const parsed = JSON.parse(readFileSync(filePath, "utf8"));
-    return schema.parse(parsed);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Invalid policy file: ${filePath} (${message})`);
-  }
+	try {
+		const parsed = JSON.parse(readFileSync(filePath, "utf8"));
+		return schema.parse(parsed);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Invalid policy file: ${filePath} (${message})`);
+	}
 }
 
 export function loadRole1RuntimeConfig(
-  options: LoaderOptions = {},
+	options: LoaderOptions = {},
 ): Role1RuntimeConfig {
-  const cwd = options.cwd ?? process.cwd();
-  const fileEnv = loadDotEnv(cwd);
-  const env = { ...fileEnv, ...(options.env ?? process.env) };
+	const cwd = options.cwd ?? process.cwd();
+	const fileEnv = loadDotEnv(cwd);
+	const env = { ...fileEnv, ...(options.env ?? process.env) };
 
-  const pipelineMode = env.PIPELINE_MODE ?? "safe";
+	const pipelineMode = env.PIPELINE_MODE ?? "safe";
 
-  return Role1RuntimeConfigSchema.parse({
-    localLlmApiBase:
-      readEnvValueWithDefault(
-        env,
-        ["LOCAL_LLM_API_BASE", "OPENAI_API_BASE", "LM_STUDIO_URL"],
-        DEFAULT_LOCAL_LLM_API_BASE,
-      ),
-    localLlmApiKey:
-      readEnvValue(env, "LOCAL_LLM_API_KEY", "OPENAI_API_KEY", "LM_STUDIO_API_KEY"),
-    localLlmModelName:
-      readEnvValueWithDefault(
-        env,
-        ["LOCAL_LLM_MODEL_NAME", "MODEL_NAME"],
-        DEFAULT_LOCAL_LLM_MODEL_NAME,
-      ),
-    localLlmAutoStart: parseBoolean(env.LOCAL_LLM_AUTO_START, true),
-    localLlmServerBinary:
-      readEnvValue(env, "LOCAL_LLM_SERVER_BINARY") ?? DEFAULT_LOCAL_LLM_SERVER_BINARY,
-    localLlmServerHost:
-      readEnvValue(env, "LOCAL_LLM_SERVER_HOST") ?? DEFAULT_LOCAL_LLM_SERVER_HOST,
-    localLlmServerPort: parseNumber(
-      env.LOCAL_LLM_SERVER_PORT,
-      DEFAULT_LOCAL_LLM_SERVER_PORT,
-      "LOCAL_LLM_SERVER_PORT",
-    ),
-    localLlmStartupTimeout: parseNumber(
-      env.LOCAL_LLM_STARTUP_TIMEOUT,
-      DEFAULT_LOCAL_LLM_STARTUP_TIMEOUT,
-      "LOCAL_LLM_STARTUP_TIMEOUT",
-    ),
-    localLlmGpuLayers:
-      readEnvValue(env, "LOCAL_LLM_GPU_LAYERS") ?? DEFAULT_LOCAL_LLM_GPU_LAYERS,
-    localLlmModelPath: readEnvValue(env, "LOCAL_LLM_MODEL_PATH"),
-    localLlmModelUrl: readEnvValue(env, "LOCAL_LLM_MODEL_URL"),
-    localLlmHfRepo: readEnvValue(env, "LOCAL_LLM_HF_REPO") ?? DEFAULT_LOCAL_LLM_HF_REPO,
-    localLlmHfFile: readEnvValue(env, "LOCAL_LLM_HF_FILE") ?? DEFAULT_LOCAL_LLM_HF_FILE,
-    pipelineMode,
-    requestTimeout: parseNumber(
-      env.REQUEST_TIMEOUT,
-      DEFAULT_REQUEST_TIMEOUT,
-      "REQUEST_TIMEOUT",
-    ),
-    translationMaxAttempts: parseNumber(
-      env.TRANSLATION_MAX_ATTEMPTS,
-      DEFAULT_TRANSLATION_MAX_ATTEMPTS,
-      "TRANSLATION_MAX_ATTEMPTS",
-    ),
-    temperature: parseNumber(
-      env.TEMPERATURE,
-      DEFAULT_TEMPERATURE,
-      "TEMPERATURE",
-    ),
-  });
+	return Role1RuntimeConfigSchema.parse({
+		localLlmApiBase: readEnvValueWithDefault(
+			env,
+			["LOCAL_LLM_API_BASE", "OPENAI_API_BASE", "LM_STUDIO_URL"],
+			DEFAULT_LOCAL_LLM_API_BASE,
+		),
+		localLlmApiKey: readEnvValue(
+			env,
+			"LOCAL_LLM_API_KEY",
+			"OPENAI_API_KEY",
+			"LM_STUDIO_API_KEY",
+		),
+		localLlmModelName: readEnvValueWithDefault(
+			env,
+			["LOCAL_LLM_MODEL_NAME", "MODEL_NAME"],
+			DEFAULT_LOCAL_LLM_MODEL_NAME,
+		),
+		localLlmAutoStart: parseBoolean(env.LOCAL_LLM_AUTO_START, true),
+		localLlmServerBinary:
+			readEnvValue(env, "LOCAL_LLM_SERVER_BINARY") ??
+			DEFAULT_LOCAL_LLM_SERVER_BINARY,
+		localLlmServerHost:
+			readEnvValue(env, "LOCAL_LLM_SERVER_HOST") ??
+			DEFAULT_LOCAL_LLM_SERVER_HOST,
+		localLlmServerPort: parseNumber(
+			env.LOCAL_LLM_SERVER_PORT,
+			DEFAULT_LOCAL_LLM_SERVER_PORT,
+			"LOCAL_LLM_SERVER_PORT",
+		),
+		localLlmStartupTimeout: parseNumber(
+			env.LOCAL_LLM_STARTUP_TIMEOUT,
+			DEFAULT_LOCAL_LLM_STARTUP_TIMEOUT,
+			"LOCAL_LLM_STARTUP_TIMEOUT",
+		),
+		localLlmDevice: readEnvValue(env, "LOCAL_LLM_DEVICE"),
+		localLlmGpuLayers:
+			readEnvValue(env, "LOCAL_LLM_GPU_LAYERS") ?? DEFAULT_LOCAL_LLM_GPU_LAYERS,
+		localLlmContextSize: parseNumber(
+			env.LOCAL_LLM_CONTEXT_SIZE,
+			DEFAULT_LOCAL_LLM_CONTEXT_SIZE,
+			"LOCAL_LLM_CONTEXT_SIZE",
+		),
+		localLlmMaxTokens: parseNumber(
+			env.LOCAL_LLM_MAX_TOKENS,
+			DEFAULT_LOCAL_LLM_MAX_TOKENS,
+			"LOCAL_LLM_MAX_TOKENS",
+		),
+		localLlmReasoning:
+			readEnvValue(env, "LOCAL_LLM_REASONING") ?? DEFAULT_LOCAL_LLM_REASONING,
+		localLlmModelPath: readEnvValue(env, "LOCAL_LLM_MODEL_PATH"),
+		localLlmModelUrl: readEnvValue(env, "LOCAL_LLM_MODEL_URL"),
+		localLlmHfRepo:
+			readEnvValue(env, "LOCAL_LLM_HF_REPO") ?? DEFAULT_LOCAL_LLM_HF_REPO,
+		localLlmHfFile:
+			readEnvValue(env, "LOCAL_LLM_HF_FILE") ?? DEFAULT_LOCAL_LLM_HF_FILE,
+		pipelineMode,
+		requestTimeout: parseNumber(
+			env.REQUEST_TIMEOUT,
+			DEFAULT_REQUEST_TIMEOUT,
+			"REQUEST_TIMEOUT",
+		),
+		translationMaxAttempts: parseNumber(
+			env.TRANSLATION_MAX_ATTEMPTS,
+			DEFAULT_TRANSLATION_MAX_ATTEMPTS,
+			"TRANSLATION_MAX_ATTEMPTS",
+		),
+		temperature: parseNumber(
+			env.TEMPERATURE,
+			DEFAULT_TEMPERATURE,
+			"TEMPERATURE",
+		),
+	});
 }
 
 export function loadRole1Policies(
-  options: Pick<LoaderOptions, "cwd"> = {},
+	options: Pick<LoaderOptions, "cwd"> = {},
 ): Role1Policies {
-  const cwd = options.cwd ?? process.cwd();
-  const dataDir = join(cwd, "data");
+	const cwd = options.cwd ?? process.cwd();
+	const dataDir = join(cwd, "data");
 
-  return Role1PoliciesSchema.parse({
-    protectedTerms: readJsonFile(
-      join(dataDir, "protected_terms.json"),
-      ProtectedTermsSchema,
-      [],
-    ),
-    preferredTranslations: readJsonFile(
-      join(dataDir, "preferred_translations.json"),
-      PreferredTranslationsSchema,
-      {},
-    ),
-    forbiddenPatterns: readJsonFile(
-      join(dataDir, "forbidden_patterns.json"),
-      ForbiddenPatternsSchema,
-      [],
-    ),
-  });
+	return Role1PoliciesSchema.parse({
+		protectedTerms: readJsonFile(
+			join(dataDir, "protected_terms.json"),
+			ProtectedTermsSchema,
+			[],
+		),
+		preferredTranslations: readJsonFile(
+			join(dataDir, "preferred_translations.json"),
+			PreferredTranslationsSchema,
+			{},
+		),
+		forbiddenPatterns: readJsonFile(
+			join(dataDir, "forbidden_patterns.json"),
+			ForbiddenPatternsSchema,
+			[],
+		),
+	});
 }

--- a/src/core/prompt/config.ts
+++ b/src/core/prompt/config.ts
@@ -7,10 +7,13 @@ const DEFAULT_TRANSLATION_MAX_ATTEMPTS = 5;
 const DEFAULT_TEMPERATURE = 0;
 const DEFAULT_LOCAL_LLM_API_BASE = "http://127.0.0.1:12370/v1";
 const DEFAULT_LOCAL_LLM_MODEL_NAME = "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF";
+const DEFAULT_LOCAL_LLM_HF_REPO = `${DEFAULT_LOCAL_LLM_MODEL_NAME}:Q4_K_S`;
+const DEFAULT_LOCAL_LLM_HF_FILE = "gemma-4-E2B-it-heretic-ara.Q4_K_S.gguf";
 const DEFAULT_LOCAL_LLM_SERVER_BINARY = "llama-server";
 const DEFAULT_LOCAL_LLM_SERVER_HOST = "127.0.0.1";
 const DEFAULT_LOCAL_LLM_SERVER_PORT = 12370;
 const DEFAULT_LOCAL_LLM_STARTUP_TIMEOUT = 600_000;
+const DEFAULT_LOCAL_LLM_GPU_LAYERS = "all";
 
 const PipelineModeSchema = z.enum(["safe", "debug"]);
 
@@ -23,9 +26,11 @@ const Role1RuntimeConfigSchema = z.object({
   localLlmServerHost: z.string().optional(),
   localLlmServerPort: z.number().int().positive().optional(),
   localLlmStartupTimeout: z.number().int().positive().optional(),
+  localLlmGpuLayers: z.string().optional(),
   localLlmModelPath: z.string().optional(),
   localLlmModelUrl: z.string().optional(),
   localLlmHfRepo: z.string().optional(),
+  localLlmHfFile: z.string().optional(),
   pipelineMode: PipelineModeSchema,
   requestTimeout: z.number().int().positive(),
   translationMaxAttempts: z.number().int().positive(),
@@ -212,10 +217,12 @@ export function loadRole1RuntimeConfig(
       DEFAULT_LOCAL_LLM_STARTUP_TIMEOUT,
       "LOCAL_LLM_STARTUP_TIMEOUT",
     ),
+    localLlmGpuLayers:
+      readEnvValue(env, "LOCAL_LLM_GPU_LAYERS") ?? DEFAULT_LOCAL_LLM_GPU_LAYERS,
     localLlmModelPath: readEnvValue(env, "LOCAL_LLM_MODEL_PATH"),
     localLlmModelUrl: readEnvValue(env, "LOCAL_LLM_MODEL_URL"),
-    localLlmHfRepo:
-      readEnvValue(env, "LOCAL_LLM_HF_REPO") ?? DEFAULT_LOCAL_LLM_MODEL_NAME,
+    localLlmHfRepo: readEnvValue(env, "LOCAL_LLM_HF_REPO") ?? DEFAULT_LOCAL_LLM_HF_REPO,
+    localLlmHfFile: readEnvValue(env, "LOCAL_LLM_HF_FILE") ?? DEFAULT_LOCAL_LLM_HF_FILE,
     pipelineMode,
     requestTimeout: parseNumber(
       env.REQUEST_TIMEOUT,

--- a/src/core/translate/translate.ts
+++ b/src/core/translate/translate.ts
@@ -1,57 +1,58 @@
-import { complete_chat, type LlmCompletionResponse } from "../llm-client/client.js";
-import type {
-  Role1Policies,
-  Role1RuntimeConfig,
-} from "../prompt/config.js";
 import {
-  mask_protected_segments,
-  restore_placeholders,
-  type PlaceholderEntry,
+	complete_chat,
+	type LlmCompletionResponse,
+} from "../llm-client/client.js";
+import { ensureLocalLlmRuntime } from "../llm-client/local-runtime.js";
+import type { Role1Policies, Role1RuntimeConfig } from "../prompt/config.js";
+import {
+	mask_protected_segments,
+	restore_placeholders,
+	type PlaceholderEntry,
 } from "./masking.js";
 import {
-  extract_translatable_spans,
-  reassemble_spans,
-  type TranslatableSpan,
+	extract_translatable_spans,
+	reassemble_spans,
+	type TranslatableSpan,
 } from "./spans.js";
 import { clean_translation } from "./clean.js";
 import { repair_translation } from "../guardrails/repair.js";
 import {
-  isHighConfidenceInferredLiteral,
-  validate_translation,
+	isHighConfidenceInferredLiteral,
+	validate_translation,
 } from "../guardrails/validator.js";
 
 export interface TranslateToEnglishOptions {
-  config: Role1RuntimeConfig;
-  policies: Role1Policies;
-  fetchImplementation?: typeof fetch;
+	config: Role1RuntimeConfig;
+	policies: Role1Policies;
+	fetchImplementation?: typeof fetch;
 }
 
 export interface TranslateToEnglishResult {
-  text: string;
-  masked_text: string;
-  placeholders: PlaceholderEntry[];
-  spans: TranslatableSpan[];
-  raw_responses: Record<string, unknown>[];
-  inference_time_sec: number;
-  fallback_span_count: number;
-  span_results: TranslationSpanResult[];
-  validation_errors: string[];
-  repair_actions: string[];
-  debug?: {
-    masked_text: string;
-    placeholders: PlaceholderEntry[];
-    spans: TranslatableSpan[];
-    fallback_span_count: number;
-  };
+	text: string;
+	masked_text: string;
+	placeholders: PlaceholderEntry[];
+	spans: TranslatableSpan[];
+	raw_responses: Record<string, unknown>[];
+	inference_time_sec: number;
+	fallback_span_count: number;
+	span_results: TranslationSpanResult[];
+	validation_errors: string[];
+	repair_actions: string[];
+	debug?: {
+		masked_text: string;
+		placeholders: PlaceholderEntry[];
+		spans: TranslatableSpan[];
+		fallback_span_count: number;
+	};
 }
 
 export interface TranslationSpanResult {
-  source_text: string;
-  output_text: string;
-  status: "skipped" | "translated" | "fallback_succeeded" | "failed";
-  attempts: number;
-  validation_errors: string[];
-  repair_actions: string[];
+	source_text: string;
+	output_text: string;
+	status: "skipped" | "translated" | "fallback_succeeded" | "failed";
+	attempts: number;
+	validation_errors: string[];
+	repair_actions: string[];
 }
 
 const TRANSLATION_SYSTEM_PROMPT = `You are a translator that translates Korean into English.
@@ -73,345 +74,443 @@ const TRANSLATION_SYSTEM_PROMPT = `You are a translator that translates Korean i
 - DO NOT modify or remove markdown symbols or punctuation.
 
 ✅ REQUIREMENT:
-- The output must be a FULL, COMPLETE, and FAITHFUL translation of the input text.`;
+- The output must be a FULL, COMPLETE, and FAITHFUL translation of the input text.
+
+### Few-shot Example 1
+
+Input:
+기존 REST API의 응답 속도가 점점 느려지고 있습니다.
+특히 사용자 인증 이후 대시보드 데이터를 불러오는 구간에서 병목이 발생합니다.
+가장 먼저 점검해야 할 포인트를 우선순위대로 정리해 주세요.
+
+Output:
+The response speed of the existing REST API is gradually getting slower.
+In particular, a bottleneck occurs in the section that loads dashboard data after user authentication.
+Please organize the points that should be checked first in order of priority.
+
+
+### Few-shot Example 2
+
+Input:
+## 오늘의 목표
+- 번역 모델 확정
+- 프롬프트 압축 로직 구체화
+
+## 실제 수행한 일
+- 번역 정확도 향상을 위해 placeholder 기반 보호 로직을 적용했다.
+- 검증 실패 시 fallback 레이어를 추가했다.
+
+Output:
+## Today's Goals
+- Finalize the translation model
+- Specify the prompt compression logic
+
+## Work Actually Performed
+- Applied placeholder-based protection logic to improve translation accuracy.
+- Added a fallback layer when validation fails.
+
+
+### Few-shot Example 3
+Input:
+기존 PostgreSQL 기반 인증 시스템을 MongoDB 중심 구조로 점진적으로 마이그레이션하려고 합니다.
+
+다음 작업을 모두 수행해 주세요.
+
+1. 현재 시스템에서 가장 먼저 점검해야 할 데이터 무결성 리스크를 정리해 주세요.
+2. 무중단 배포를 전제로 한 단계별 마이그레이션 로드맵을 작성해 주세요.
+3. 사용자 세션, JWT, OAuth 2.0 연동 과정에서 발생할 수 있는 주요 장애 포인트를 설명해 주세요.
+4. 각 단계별로 필요한 테스트 전략(단위 테스트, 통합 테스트, 회귀 테스트)을 구분해서 제안해 주세요.
+5. 최종적으로 운영 비용, 유지보수성, 확장성 측면에서 MongoDB 전환이 실제로 유리한지 평가해 주세요.
+
+Output:
+We are planning to gradually migrate the existing PostgreSQL-based authentication system to a MongoDB-centered structure.
+
+Please perform all of the following tasks.
+
+1. Summarize the data integrity risks that should be checked first in the current system.
+2. Create a step-by-step migration roadmap based on zero-downtime deployment.
+3. Explain the major failure points that may occur during user session, JWT, and OAuth 2.0 integration.
+4. Propose the necessary testing strategies for each phase, separating unit tests, integration tests, and regression tests.
+5. Finally, evaluate whether switching to MongoDB is actually beneficial in terms of operating costs, maintainability, and scalability.`;
 
 const TRANSLATION_USER_PROMPT_PREFIX =
-  "Translate the following text data into English.\n\n";
+	"Translate the following text data into English.\n\n";
 
 type TranslationPassPromptType = "primary" | "fallback" | "final_retry";
 
 function containsKorean(text: string): boolean {
-  return /[가-힣]/.test(text);
+	return /[가-힣]/.test(text);
 }
 
 function collectRequiredTerms(
-  sourceText: string,
-  preferredTranslations: Role1Policies["preferredTranslations"],
+	sourceText: string,
+	preferredTranslations: Role1Policies["preferredTranslations"],
 ): string[] {
-  return Object.keys(preferredTranslations)
-    .filter((term) => sourceText.includes(term))
-    .map((term) => preferredTranslations[term]!)
-    .filter(Boolean);
+	return Object.keys(preferredTranslations)
+		.filter((term) => sourceText.includes(term))
+		.map((term) => preferredTranslations[term]!)
+		.filter(Boolean);
 }
 
 function shouldRetryWholeItem(
-  sourceText: string,
-  validationErrors: readonly string[],
+	sourceText: string,
+	validationErrors: readonly string[],
 ): boolean {
-  if (!containsKorean(sourceText) || validationErrors.length === 0) {
-    return false;
-  }
+	if (!containsKorean(sourceText) || validationErrors.length === 0) {
+		return false;
+	}
 
-  return validationErrors.some((error) =>
-    error.startsWith("required_literal_missing:") ||
-    error.startsWith("required_term_missing:") ||
-    error === "korean_text_remaining" ||
-    error === "source_korean_copied"
-  );
+	return validationErrors.some(
+		(error) =>
+			error.startsWith("required_literal_missing:") ||
+			error.startsWith("required_term_missing:") ||
+			error === "korean_text_remaining" ||
+			error === "source_korean_copied",
+	);
 }
 
 function isBetterValidationResult(
-  currentErrors: readonly string[],
-  nextErrors: readonly string[],
+	currentErrors: readonly string[],
+	nextErrors: readonly string[],
 ): boolean {
-  return nextErrors.length < currentErrors.length;
+	return nextErrors.length < currentErrors.length;
 }
 
 async function translate_span(
-  span: TranslatableSpan,
-  options: TranslateToEnglishOptions,
-  promptType: TranslationPassPromptType = "primary",
-  fallbackContext?: {
-    previous_output: string;
-    validation_errors: string[];
-  },
+	span: TranslatableSpan,
+	options: TranslateToEnglishOptions,
+	promptType: TranslationPassPromptType = "primary",
+	fallbackContext?: {
+		previous_output: string;
+		validation_errors: string[];
+	},
 ): Promise<LlmCompletionResponse | null> {
-  if (!span.translate || !containsKorean(span.text)) {
-    return null;
-  }
+	if (!span.translate || !containsKorean(span.text)) {
+		return null;
+	}
 
-  return complete_chat(
-    {
-      messages: [
-        {
-          role: "system",
-          content:
-            promptType === "fallback" || promptType === "final_retry"
-              ? `${TRANSLATION_SYSTEM_PROMPT}
+	return complete_chat(
+		{
+			messages: [
+				{
+					role: "system",
+					content:
+						promptType === "fallback" || promptType === "final_retry"
+							? `${TRANSLATION_SYSTEM_PROMPT}
 
 Return only the corrected English translation.
-Preserve placeholder count and order exactly.
-If placeholders were malformed, restore them exactly as in the source.
-The previous attempt failed validation for: ${fallbackContext?.validation_errors.join(", ") ?? "unknown_error"}.
-Previous invalid output: ${fallbackContext?.previous_output ?? ""}
-Pay extra attention to missing technical literals and untranslated Korean text.`
-              : TRANSLATION_SYSTEM_PROMPT,
-        },
-        {
-          role: "user",
-          content: `${TRANSLATION_USER_PROMPT_PREFIX}${span.text}`,
-        },
-      ],
-      temperature: options.config.temperature,
-      timeout_ms: options.config.requestTimeout,
-    },
-    {
-      ...(options.config.localLlmApiBase
-        ? { apiBase: options.config.localLlmApiBase }
-        : {}),
-      ...(options.config.localLlmApiKey
-        ? { apiKey: options.config.localLlmApiKey }
-        : {}),
-      ...(options.config.localLlmModelName
-        ? { localLlmModelName: options.config.localLlmModelName }
-        : {}),
-      ...(options.fetchImplementation
-        ? { fetchImplementation: options.fetchImplementation }
-        : {}),
-    },
-  );
+
+STRICTLY preserve:
+- placeholder count and order
+- technical literals
+- API/class/function names
+- framework names
+- acronyms
+- parenthetical explanations
+
+If placeholders or technical literals were malformed, restore them exactly as in the source.
+
+Never paraphrase technical expressions into natural language.
+
+The previous attempt failed validation for:
+${fallbackContext?.validation_errors.join(", ") ?? "unknown_error"}
+
+Previous invalid output:
+${fallbackContext?.previous_output ?? ""}
+
+Pay special attention to:
+- missing technical literals
+- untranslated Korean text
+- dropped acronyms
+- omitted parenthetical meanings
+- rewritten framework/class names`
+							: TRANSLATION_SYSTEM_PROMPT,
+				},
+				{
+					role: "user",
+					content: `${TRANSLATION_USER_PROMPT_PREFIX}${span.text}`,
+				},
+			],
+			temperature: options.config.temperature,
+			timeout_ms: options.config.requestTimeout,
+		},
+		{
+			...(options.config.localLlmApiBase
+				? { apiBase: options.config.localLlmApiBase }
+				: {}),
+			...(options.config.localLlmApiKey
+				? { apiKey: options.config.localLlmApiKey }
+				: {}),
+			...(options.config.localLlmModelName
+				? { localLlmModelName: options.config.localLlmModelName }
+				: {}),
+			...(options.fetchImplementation
+				? { fetchImplementation: options.fetchImplementation }
+				: {}),
+		},
+	);
 }
 
 async function runTranslationPass(
-  source_text: string,
-  options: TranslateToEnglishOptions,
-  initialPromptType: Exclude<TranslationPassPromptType, "fallback"> = "primary",
-  finalRetryContext?: {
-    previous_output: string;
-    validation_errors: string[];
-  },
+	source_text: string,
+	options: TranslateToEnglishOptions,
+	initialPromptType: Exclude<TranslationPassPromptType, "fallback"> = "primary",
+	finalRetryContext?: {
+		previous_output: string;
+		validation_errors: string[];
+	},
 ): Promise<TranslateToEnglishResult> {
-  const masked = mask_protected_segments(source_text, {
-    protected_terms: options.policies.protectedTerms,
-    preferred_translations: options.policies.preferredTranslations,
-    model_names: options.config.localLlmModelName ? [options.config.localLlmModelName] : [],
-  });
-  const spans = extract_translatable_spans(masked.masked_text, masked.placeholders);
-  const translatedSpans: TranslatableSpan[] = [];
-  const rawResponses: Record<string, unknown>[] = [];
-  let inferenceTimeSec = 0;
-  let fallbackSpanCount = 0;
-  const spanResults: TranslationSpanResult[] = [];
+	const masked = mask_protected_segments(source_text, {
+		protected_terms: options.policies.protectedTerms,
+		preferred_translations: options.policies.preferredTranslations,
+		model_names: options.config.localLlmModelName
+			? [options.config.localLlmModelName]
+			: [],
+	});
+	const spans = extract_translatable_spans(
+		masked.masked_text,
+		masked.placeholders,
+	);
+	const translatedSpans: TranslatableSpan[] = [];
+	const rawResponses: Record<string, unknown>[] = [];
+	let inferenceTimeSec = 0;
+	let fallbackSpanCount = 0;
+	const spanResults: TranslationSpanResult[] = [];
 
-  for (const span of spans) {
-    const llmResponse = await translate_span(
-      span,
-      options,
-      initialPromptType,
-      finalRetryContext,
-    );
-    if (!llmResponse) {
-      translatedSpans.push(span);
-      spanResults.push({
-        source_text: span.text,
-        output_text: span.text,
-        status: "skipped",
-        attempts: 0,
-        validation_errors: [],
-        repair_actions: [],
-      });
-      continue;
-    }
+	for (const span of spans) {
+		const llmResponse = await translate_span(
+			span,
+			options,
+			initialPromptType,
+			finalRetryContext,
+		);
+		if (!llmResponse) {
+			translatedSpans.push(span);
+			spanResults.push({
+				source_text: span.text,
+				output_text: span.text,
+				status: "skipped",
+				attempts: 0,
+				validation_errors: [],
+				repair_actions: [],
+			});
+			continue;
+		}
 
-    const cleaned = clean_translation(span.text, llmResponse.content);
-    if (llmResponse.raw_response) {
-      rawResponses.push(llmResponse.raw_response);
-    }
-    inferenceTimeSec += llmResponse.inference_time_sec ?? 0;
+		const cleaned = clean_translation(span.text, llmResponse.content);
+		if (llmResponse.raw_response) {
+			rawResponses.push(llmResponse.raw_response);
+		}
+		inferenceTimeSec += llmResponse.inference_time_sec ?? 0;
 
-    const placeholderTokens = masked.placeholders
-      .filter((entry) => span.text.includes(entry.placeholder))
-      .map((entry) => entry.placeholder);
-    const requiredTerms = collectRequiredTerms(
-      span.text,
-      options.policies.preferredTranslations,
-    );
-    const initialValidation = validate_translation({
-      source_text: span.text,
-      compressed_prompt: cleaned,
-      placeholders: placeholderTokens,
-      protected_terms: options.policies.protectedTerms,
-      required_terms: requiredTerms,
-      model_names: options.config.localLlmModelName ? [options.config.localLlmModelName] : [],
-      forbidden_patterns: options.policies.forbiddenPatterns,
-    });
-    const repaired = repair_translation({
-      source_text: span.text,
-      compressed_prompt: initialValidation.output,
-      placeholders: placeholderTokens,
-      protected_terms: options.policies.protectedTerms,
-      required_terms: requiredTerms,
-      forbidden_patterns: options.policies.forbiddenPatterns,
-    });
-    const repairedValidation = validate_translation({
-      source_text: span.text,
-      compressed_prompt: repaired.output,
-      placeholders: placeholderTokens,
-      protected_terms: options.policies.protectedTerms,
-      required_terms: requiredTerms,
-      model_names: options.config.localLlmModelName ? [options.config.localLlmModelName] : [],
-      forbidden_patterns: options.policies.forbiddenPatterns,
-    });
+		const placeholderTokens = masked.placeholders
+			.filter((entry) => span.text.includes(entry.placeholder))
+			.map((entry) => entry.placeholder);
+		const requiredTerms = collectRequiredTerms(
+			span.text,
+			options.policies.preferredTranslations,
+		);
+		const initialValidation = validate_translation({
+			source_text: span.text,
+			compressed_prompt: cleaned,
+			placeholders: placeholderTokens,
+			protected_terms: options.policies.protectedTerms,
+			required_terms: requiredTerms,
+			model_names: options.config.localLlmModelName
+				? [options.config.localLlmModelName]
+				: [],
+			forbidden_patterns: options.policies.forbiddenPatterns,
+		});
+		const repaired = repair_translation({
+			source_text: span.text,
+			compressed_prompt: initialValidation.output,
+			placeholders: placeholderTokens,
+			protected_terms: options.policies.protectedTerms,
+			required_terms: requiredTerms,
+			forbidden_patterns: options.policies.forbiddenPatterns,
+		});
+		const repairedValidation = validate_translation({
+			source_text: span.text,
+			compressed_prompt: repaired.output,
+			placeholders: placeholderTokens,
+			protected_terms: options.policies.protectedTerms,
+			required_terms: requiredTerms,
+			model_names: options.config.localLlmModelName
+				? [options.config.localLlmModelName]
+				: [],
+			forbidden_patterns: options.policies.forbiddenPatterns,
+		});
 
-    let finalText = repaired.output;
-    let status: TranslationSpanResult["status"] = "translated";
-    let attempts = 1;
-    let validationErrors = repairedValidation.validation_errors;
-    const repairActions = repaired.repair_actions;
+		let finalText = repaired.output;
+		let status: TranslationSpanResult["status"] = "translated";
+		let attempts = 1;
+		let validationErrors = repairedValidation.validation_errors;
+		const repairActions = repaired.repair_actions;
 
-    if (validationErrors.length > 0 && attempts < options.config.translationMaxAttempts) {
-      const fallbackResponse = await translate_span(span, options, "fallback", {
-        previous_output: repaired.output,
-        validation_errors: validationErrors,
-      });
-      attempts += 1;
+		if (
+			validationErrors.length > 0 &&
+			attempts < options.config.translationMaxAttempts
+		) {
+			const fallbackResponse = await translate_span(span, options, "fallback", {
+				previous_output: repaired.output,
+				validation_errors: validationErrors,
+			});
+			attempts += 1;
 
-      if (fallbackResponse) {
-        fallbackSpanCount += 1;
-        const fallbackCleaned = clean_translation(span.text, fallbackResponse.content);
-        if (fallbackResponse.raw_response) {
-          rawResponses.push(fallbackResponse.raw_response);
-        }
-        inferenceTimeSec += fallbackResponse.inference_time_sec ?? 0;
+			if (fallbackResponse) {
+				fallbackSpanCount += 1;
+				const fallbackCleaned = clean_translation(
+					span.text,
+					fallbackResponse.content,
+				);
+				if (fallbackResponse.raw_response) {
+					rawResponses.push(fallbackResponse.raw_response);
+				}
+				inferenceTimeSec += fallbackResponse.inference_time_sec ?? 0;
 
-        const fallbackRepaired = repair_translation({
-          source_text: span.text,
-          compressed_prompt: fallbackCleaned,
-          placeholders: placeholderTokens,
-          protected_terms: options.policies.protectedTerms,
-          required_terms: requiredTerms,
-          forbidden_patterns: options.policies.forbiddenPatterns,
-        });
-        const fallbackRepairedValidation = validate_translation({
-          source_text: span.text,
-          compressed_prompt: fallbackRepaired.output,
-          placeholders: placeholderTokens,
-          protected_terms: options.policies.protectedTerms,
-          required_terms: requiredTerms,
-          model_names: options.config.localLlmModelName ? [options.config.localLlmModelName] : [],
-          forbidden_patterns: options.policies.forbiddenPatterns,
-        });
-        repairActions.push(...fallbackRepaired.repair_actions);
+				const fallbackRepaired = repair_translation({
+					source_text: span.text,
+					compressed_prompt: fallbackCleaned,
+					placeholders: placeholderTokens,
+					protected_terms: options.policies.protectedTerms,
+					required_terms: requiredTerms,
+					forbidden_patterns: options.policies.forbiddenPatterns,
+				});
+				const fallbackRepairedValidation = validate_translation({
+					source_text: span.text,
+					compressed_prompt: fallbackRepaired.output,
+					placeholders: placeholderTokens,
+					protected_terms: options.policies.protectedTerms,
+					required_terms: requiredTerms,
+					model_names: options.config.localLlmModelName
+						? [options.config.localLlmModelName]
+						: [],
+					forbidden_patterns: options.policies.forbiddenPatterns,
+				});
+				repairActions.push(...fallbackRepaired.repair_actions);
 
-        if (fallbackRepairedValidation.validation_errors.length === 0) {
-          finalText = fallbackRepaired.output;
-          validationErrors = [];
-          status = "fallback_succeeded";
-        } else {
-          status = "failed";
-          validationErrors = fallbackRepairedValidation.validation_errors;
-          finalText = fallbackRepaired.output;
-        }
-      } else {
-        status = "failed";
-      }
-    } else if (validationErrors.length > 0) {
-      status = "failed";
-    }
+				if (fallbackRepairedValidation.validation_errors.length === 0) {
+					finalText = fallbackRepaired.output;
+					validationErrors = [];
+					status = "fallback_succeeded";
+				} else {
+					status = "failed";
+					validationErrors = fallbackRepairedValidation.validation_errors;
+					finalText = fallbackRepaired.output;
+				}
+			} else {
+				status = "failed";
+			}
+		} else if (validationErrors.length > 0) {
+			status = "failed";
+		}
 
-    translatedSpans.push({
-      ...span,
-      text: finalText,
-    });
-    spanResults.push({
-      source_text: span.text,
-      output_text: finalText,
-      status,
-      attempts,
-      validation_errors: validationErrors,
-      repair_actions: repairActions,
-    });
-  }
+		translatedSpans.push({
+			...span,
+			text: finalText,
+		});
+		spanResults.push({
+			source_text: span.text,
+			output_text: finalText,
+			status,
+			attempts,
+			validation_errors: validationErrors,
+			repair_actions: repairActions,
+		});
+	}
 
-  const restoredText = restore_placeholders(
-    reassemble_spans(translatedSpans),
-    masked.placeholders,
-  );
-  const finalValidation = validate_translation({
-    source_text,
-    compressed_prompt: restoredText,
-    protected_terms: options.policies.protectedTerms,
-    required_terms: collectRequiredTerms(
-      source_text,
-      options.policies.preferredTranslations,
-    ),
-    required_literals: masked.placeholders
-      .map((entry) => entry.original)
-      .filter(isHighConfidenceInferredLiteral),
-    model_names: options.config.localLlmModelName ? [options.config.localLlmModelName] : [],
-    forbidden_patterns: options.policies.forbiddenPatterns,
-  });
-  const finalValidationErrors = finalValidation.validation_errors;
-  const finalRepairActions = [
-    ...new Set(spanResults.flatMap((result) => result.repair_actions)),
-  ];
+	const restoredText = restore_placeholders(
+		reassemble_spans(translatedSpans),
+		masked.placeholders,
+	);
+	const finalValidation = validate_translation({
+		source_text,
+		compressed_prompt: restoredText,
+		protected_terms: options.policies.protectedTerms,
+		required_terms: collectRequiredTerms(
+			source_text,
+			options.policies.preferredTranslations,
+		),
+		required_literals: masked.placeholders
+			.map((entry) => entry.original)
+			.filter(isHighConfidenceInferredLiteral),
+		model_names: options.config.localLlmModelName
+			? [options.config.localLlmModelName]
+			: [],
+		forbidden_patterns: options.policies.forbiddenPatterns,
+	});
+	const finalValidationErrors = finalValidation.validation_errors;
+	const finalRepairActions = [
+		...new Set(spanResults.flatMap((result) => result.repair_actions)),
+	];
 
-  return {
-    text: restoredText,
-    masked_text: masked.masked_text,
-    placeholders: masked.placeholders,
-    spans: translatedSpans,
-    raw_responses: rawResponses,
-    inference_time_sec: inferenceTimeSec,
-    fallback_span_count: fallbackSpanCount,
-    span_results: spanResults,
-    validation_errors: finalValidationErrors,
-    repair_actions: finalRepairActions,
-    ...(options.config.pipelineMode === "debug"
-      ? {
-          debug: {
-            masked_text: masked.masked_text,
-            placeholders: masked.placeholders,
-            spans: translatedSpans,
-            fallback_span_count: fallbackSpanCount,
-          },
-        }
-      : {}),
-  };
+	return {
+		text: restoredText,
+		masked_text: masked.masked_text,
+		placeholders: masked.placeholders,
+		spans: translatedSpans,
+		raw_responses: rawResponses,
+		inference_time_sec: inferenceTimeSec,
+		fallback_span_count: fallbackSpanCount,
+		span_results: spanResults,
+		validation_errors: finalValidationErrors,
+		repair_actions: finalRepairActions,
+		...(options.config.pipelineMode === "debug"
+			? {
+					debug: {
+						masked_text: masked.masked_text,
+						placeholders: masked.placeholders,
+						spans: translatedSpans,
+						fallback_span_count: fallbackSpanCount,
+					},
+				}
+			: {}),
+	};
 }
 
 export async function translate_to_english(
-  source_text: string,
-  options: TranslateToEnglishOptions,
+	source_text: string,
+	options: TranslateToEnglishOptions,
 ): Promise<TranslateToEnglishResult> {
-  const initialPass = await runTranslationPass(source_text, options);
+	if (!options.fetchImplementation) {
+		await ensureLocalLlmRuntime(options.config);
+	}
 
-  if (!shouldRetryWholeItem(source_text, initialPass.validation_errors)) {
-    return initialPass;
-  }
+	const initialPass = await runTranslationPass(source_text, options);
 
-  const retriedPass = await runTranslationPass(
-    source_text,
-    options,
-    "final_retry",
-    {
-      previous_output: initialPass.text,
-      validation_errors: initialPass.validation_errors,
-    },
-  );
+	if (!shouldRetryWholeItem(source_text, initialPass.validation_errors)) {
+		return initialPass;
+	}
 
-  const preferredPass = isBetterValidationResult(
-    initialPass.validation_errors,
-    retriedPass.validation_errors,
-  )
-    ? retriedPass
-    : initialPass;
+	const retriedPass = await runTranslationPass(
+		source_text,
+		options,
+		"final_retry",
+		{
+			previous_output: initialPass.text,
+			validation_errors: initialPass.validation_errors,
+		},
+	);
 
-  return {
-    ...preferredPass,
-    raw_responses: [
-      ...initialPass.raw_responses,
-      ...retriedPass.raw_responses,
-    ],
-    inference_time_sec:
-      initialPass.inference_time_sec + retriedPass.inference_time_sec,
-    fallback_span_count:
-      initialPass.fallback_span_count + retriedPass.fallback_span_count,
-    repair_actions: [
-      ...new Set([
-        ...initialPass.repair_actions,
-        ...retriedPass.repair_actions,
-      ]),
-    ],
-  };
+	const preferredPass = isBetterValidationResult(
+		initialPass.validation_errors,
+		retriedPass.validation_errors,
+	)
+		? retriedPass
+		: initialPass;
+
+	return {
+		...preferredPass,
+		raw_responses: [...initialPass.raw_responses, ...retriedPass.raw_responses],
+		inference_time_sec:
+			initialPass.inference_time_sec + retriedPass.inference_time_sec,
+		fallback_span_count:
+			initialPass.fallback_span_count + retriedPass.fallback_span_count,
+		repair_actions: [
+			...new Set([
+				...initialPass.repair_actions,
+				...retriedPass.repair_actions,
+			]),
+		],
+	};
 }

--- a/src/core/translate/translate.ts
+++ b/src/core/translate/translate.ts
@@ -176,6 +176,14 @@ function isBetterValidationResult(
 	return nextErrors.length < currentErrors.length;
 }
 
+function estimateTranslationMaxTokens(
+	text: string,
+	config: Role1RuntimeConfig,
+): number {
+	const configuredMax = config.localLlmMaxTokens ?? 512;
+	return Math.min(configuredMax, Math.max(128, Math.ceil(text.length * 1.5)));
+}
+
 async function translate_span(
 	span: TranslatableSpan,
 	options: TranslateToEnglishOptions,
@@ -232,6 +240,7 @@ Pay special attention to:
 				},
 			],
 			temperature: options.config.temperature,
+			max_tokens: estimateTranslationMaxTokens(span.text, options.config),
 			timeout_ms: options.config.requestTimeout,
 		},
 		{

--- a/tests/python/unit/test_llama_server.py
+++ b/tests/python/unit/test_llama_server.py
@@ -21,10 +21,16 @@ def test_load_llama_server_config_defaults() -> None:
     config = load_llama_server_config({})
 
     assert config.host == "127.0.0.1"
-    assert config.port == 1234
+    assert config.port == 12370
     assert config.api_prefix == "/v1"
     assert config.health_path == "/health"
     assert config.model_name == "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF"
+
+
+def test_load_llama_server_config_reads_local_llm_model_name() -> None:
+    config = load_llama_server_config({"LOCAL_LLM_MODEL_NAME": "detoks-local"})
+
+    assert config.model_name == "detoks-local"
 
 
 def test_build_health_response_reports_backend_state() -> None:

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -1077,6 +1077,8 @@ describe("detoks CLI smoke", () => {
         [
           "LOCAL_LLM_API_BASE=http://127.0.0.1:1234/v1",
           "LOCAL_LLM_API_KEY=test-key",
+          "LOCAL_LLM_MODEL_NAME=",
+          "LOCAL_LLM_AUTO_START=0",
         ].join("\n"),
         "utf8",
       );

--- a/tests/ts/unit/core/llm-client/client.test.ts
+++ b/tests/ts/unit/core/llm-client/client.test.ts
@@ -31,6 +31,7 @@ describe("complete_chat", () => {
             content: "파일 생성",
           },
         ],
+        max_tokens: 128,
       },
       {
         apiBase: "http://127.0.0.1:1234/v1",
@@ -47,6 +48,9 @@ describe("complete_chat", () => {
     expect(mockCalls[0]?.[0]).toBe(
       "http://127.0.0.1:1234/v1/chat/completions",
     );
+    expect(JSON.parse(String(mockCalls[0]?.[1]?.body))).toMatchObject({
+      max_tokens: 128,
+    });
     expect(response.content).toBe("Create a new file");
     expect(response.raw_response).toBeTruthy();
     expect(response.inference_time_sec).toBeTypeOf("number");

--- a/tests/ts/unit/core/llm-client/local-runtime.test.ts
+++ b/tests/ts/unit/core/llm-client/local-runtime.test.ts
@@ -9,6 +9,8 @@ describe("buildLlamaServerArgs", () => {
       localLlmServerHost: "127.0.0.1",
       localLlmServerPort: 12370,
       localLlmGpuLayers: "all",
+      localLlmContextSize: 4096,
+      localLlmReasoning: "off",
       pipelineMode: "safe",
       requestTimeout: 30000,
       translationMaxAttempts: 5,
@@ -26,6 +28,10 @@ describe("buildLlamaServerArgs", () => {
       "12370",
       "--gpu-layers",
       "all",
+      "--ctx-size",
+      "4096",
+      "--reasoning",
+      "off",
     ]);
   });
 
@@ -37,6 +43,8 @@ describe("buildLlamaServerArgs", () => {
       localLlmServerHost: "127.0.0.1",
       localLlmServerPort: 12370,
       localLlmGpuLayers: "all",
+      localLlmContextSize: 4096,
+      localLlmReasoning: "off",
       pipelineMode: "safe",
       requestTimeout: 30000,
       translationMaxAttempts: 5,
@@ -56,6 +64,32 @@ describe("buildLlamaServerArgs", () => {
       "12370",
       "--gpu-layers",
       "all",
+      "--ctx-size",
+      "4096",
+      "--reasoning",
+      "off",
     ]);
+  });
+
+  it("device가 지정되면 llama.cpp device 인자를 추가한다", () => {
+    const args = buildLlamaServerArgs({
+      localLlmHfRepo: "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF:Q4_K_S",
+      localLlmHfFile: "gemma-4-E2B-it-heretic-ara.Q4_K_S.gguf",
+      localLlmModelName: "detoks-local",
+      localLlmServerHost: "127.0.0.1",
+      localLlmServerPort: 12370,
+      localLlmGpuLayers: "0",
+      localLlmDevice: "none",
+      localLlmContextSize: 4096,
+      pipelineMode: "safe",
+      requestTimeout: 30000,
+      translationMaxAttempts: 5,
+      temperature: 0,
+    });
+
+    expect(args).toContain("--device");
+    expect(args).toContain("none");
+    expect(args).toContain("--gpu-layers");
+    expect(args).toContain("0");
   });
 });

--- a/tests/ts/unit/core/llm-client/local-runtime.test.ts
+++ b/tests/ts/unit/core/llm-client/local-runtime.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { buildLlamaServerArgs } from "../../../../../src/core/llm-client/local-runtime.js";
+
+describe("buildLlamaServerArgs", () => {
+  it("GGUF 경로가 있으면 해당 파일을 모델로 로드한다", () => {
+    const args = buildLlamaServerArgs({
+      localLlmModelPath: "/models/detoks.gguf",
+      localLlmModelName: "detoks-local",
+      localLlmServerHost: "127.0.0.1",
+      localLlmServerPort: 12370,
+      pipelineMode: "safe",
+      requestTimeout: 30000,
+      translationMaxAttempts: 5,
+      temperature: 0,
+    });
+
+    expect(args).toEqual([
+      "-m",
+      "/models/detoks.gguf",
+      "--alias",
+      "detoks-local",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      "12370",
+    ]);
+  });
+
+  it("GGUF 경로가 없으면 Hugging Face GGUF repo를 llama-server 다운로드 대상으로 넘긴다", () => {
+    const args = buildLlamaServerArgs({
+      localLlmHfRepo: "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
+      localLlmModelName: "detoks-local",
+      localLlmServerHost: "127.0.0.1",
+      localLlmServerPort: 12370,
+      pipelineMode: "safe",
+      requestTimeout: 30000,
+      translationMaxAttempts: 5,
+      temperature: 0,
+    });
+
+    expect(args).toEqual([
+      "-hf",
+      "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
+      "--alias",
+      "detoks-local",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      "12370",
+    ]);
+  });
+});

--- a/tests/ts/unit/core/llm-client/local-runtime.test.ts
+++ b/tests/ts/unit/core/llm-client/local-runtime.test.ts
@@ -8,6 +8,7 @@ describe("buildLlamaServerArgs", () => {
       localLlmModelName: "detoks-local",
       localLlmServerHost: "127.0.0.1",
       localLlmServerPort: 12370,
+      localLlmGpuLayers: "all",
       pipelineMode: "safe",
       requestTimeout: 30000,
       translationMaxAttempts: 5,
@@ -23,15 +24,19 @@ describe("buildLlamaServerArgs", () => {
       "127.0.0.1",
       "--port",
       "12370",
+      "--gpu-layers",
+      "all",
     ]);
   });
 
   it("GGUF 경로가 없으면 Hugging Face GGUF repo를 llama-server 다운로드 대상으로 넘긴다", () => {
     const args = buildLlamaServerArgs({
-      localLlmHfRepo: "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
+      localLlmHfRepo: "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF:Q4_K_S",
+      localLlmHfFile: "gemma-4-E2B-it-heretic-ara.Q4_K_S.gguf",
       localLlmModelName: "detoks-local",
       localLlmServerHost: "127.0.0.1",
       localLlmServerPort: 12370,
+      localLlmGpuLayers: "all",
       pipelineMode: "safe",
       requestTimeout: 30000,
       translationMaxAttempts: 5,
@@ -40,13 +45,17 @@ describe("buildLlamaServerArgs", () => {
 
     expect(args).toEqual([
       "-hf",
-      "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
+      "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF:Q4_K_S",
+      "--hf-file",
+      "gemma-4-E2B-it-heretic-ara.Q4_K_S.gguf",
       "--alias",
       "detoks-local",
       "--host",
       "127.0.0.1",
       "--port",
       "12370",
+      "--gpu-layers",
+      "all",
     ]);
   });
 });

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -92,6 +92,10 @@ describe("orchestratePipeline", () => {
         raw_input: "새 파일을 생성해",
         cwd: "/tmp",
       },
+      env: {
+        LOCAL_LLM_API_BASE: "",
+        LOCAL_LLM_MODEL_NAME: "",
+      },
     });
 
     expect(result.ok).toBe(false);
@@ -157,7 +161,7 @@ describe("orchestratePipeline", () => {
       },
       env: {
         LM_STUDIO_URL: "http://127.0.0.1:1234/v1",
-        LM_STUDIO_API_KEY: "test-key",
+        LOCAL_LLM_API_KEY: "test-key",
         LOCAL_LLM_MODEL_NAME: "local-model",
         TRANSLATION_MAX_ATTEMPTS: "1",
       },

--- a/tests/ts/unit/core/prompt/config.test.ts
+++ b/tests/ts/unit/core/prompt/config.test.ts
@@ -39,9 +39,11 @@ describe("loadRole1RuntimeConfig", () => {
     expect(config.localLlmServerBinary).toBe("llama-server");
     expect(config.localLlmServerHost).toBe("127.0.0.1");
     expect(config.localLlmServerPort).toBe(12370);
+    expect(config.localLlmGpuLayers).toBe("all");
     expect(config.localLlmHfRepo).toBe(
-      "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
+      "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF:Q4_K_S",
     );
+    expect(config.localLlmHfFile).toBe("gemma-4-E2B-it-heretic-ara.Q4_K_S.gguf");
   });
 
   it(".env와 legacy alias를 함께 읽는다", () => {

--- a/tests/ts/unit/core/prompt/config.test.ts
+++ b/tests/ts/unit/core/prompt/config.test.ts
@@ -32,14 +32,15 @@ describe("loadRole1RuntimeConfig", () => {
     expect(config.temperature).toBe(0);
     expect(config.localLlmApiBase).toBe("http://127.0.0.1:12370/v1");
     expect(config.localLlmApiKey).toBeUndefined();
-    expect(config.localLlmModelName).toBe(
-      "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
-    );
+    expect(config.localLlmModelName).toBe("gemma-4-E2B-it-heretic-ara-GGUF");
     expect(config.localLlmAutoStart).toBe(true);
     expect(config.localLlmServerBinary).toBe("llama-server");
     expect(config.localLlmServerHost).toBe("127.0.0.1");
     expect(config.localLlmServerPort).toBe(12370);
     expect(config.localLlmGpuLayers).toBe("all");
+    expect(config.localLlmContextSize).toBe(4096);
+    expect(config.localLlmMaxTokens).toBe(512);
+    expect(config.localLlmReasoning).toBe("off");
     expect(config.localLlmHfRepo).toBe(
       "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF:Q4_K_S",
     );

--- a/tests/ts/unit/core/prompt/config.test.ts
+++ b/tests/ts/unit/core/prompt/config.test.ts
@@ -30,9 +30,18 @@ describe("loadRole1RuntimeConfig", () => {
     expect(config.requestTimeout).toBe(30000);
     expect(config.translationMaxAttempts).toBe(5);
     expect(config.temperature).toBe(0);
-    expect(config.localLlmApiBase).toBeUndefined();
+    expect(config.localLlmApiBase).toBe("http://127.0.0.1:12370/v1");
     expect(config.localLlmApiKey).toBeUndefined();
-    expect(config.localLlmModelName).toBeUndefined();
+    expect(config.localLlmModelName).toBe(
+      "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
+    );
+    expect(config.localLlmAutoStart).toBe(true);
+    expect(config.localLlmServerBinary).toBe("llama-server");
+    expect(config.localLlmServerHost).toBe("127.0.0.1");
+    expect(config.localLlmServerPort).toBe(12370);
+    expect(config.localLlmHfRepo).toBe(
+      "mradermacher/gemma-4-E2B-it-heretic-ara-GGUF",
+    );
   });
 
   it(".env와 legacy alias를 함께 읽는다", () => {


### PR DESCRIPTION
## 요약
  - Role1 번역 경로에서 로컬 `llama-server`를 자동 준비하도록 추가했습니다.
  - GGUF 모델을 `Q4_K_S`로 고정하고, `--hf-file`, `--ctx-size`, `max_tokens`, `--reasoning off` 등 추론 지연을 줄이는 기본값을 추가했습니다.
  - Metal/GPU 시작 실패 시 CPU fallback으로 재시도하도록 처리했습니다.
  - llama.cpp 서버 설정, 문서, 테스트를 함께 갱신했습니다.

  ## 관련 이슈
  - Closes #
  - Related to #

  ## 변경 유형p
  - [x] 기능 추가
  - [x] 버그 수정
  - [ ] 리팩터링
  - [x] 문서 수정
  - [x] 테스트 추가/수정

  ## 영향 범위
  - 영향받는 모듈: `src/core/llm-client`, `src/core/prompt`, `src/core/translate`, `python/llama_server`, llama.cpp 서버 명세
  - 영향받지 않는 모듈: Role2 task graph, executor adapter, state/session 관리

  ## 테스트 방법
  1. `npm run typecheck`
  2. `npm test -- tests/ts/unit/core/prompt/config.test.ts tests/ts/unit/core/llm-client/local-runtime.test.ts tests/ts/unit/core/llm-client/client.test.ts tests/ts/unit/core/translate/translate.test.ts`
  3. `python3 -m pytest tests/python/unit/test_llama_server.py tests/python/unit/test_smoke.py`

  ## 체크리스트
  - [x] 로컬에서 테스트했습니다
  - [x] 필요한 경우 테스트를 추가하거나 수정했습니다
  - [x] 필요한 경우 문서를 수정했습니다
  - [x] 브레이킹 체인지 여부를 확인했습니다
  - [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

  ## 스크린샷 / 로그
  - `npm run typecheck`: 통과
  - 관련 TypeScript 테스트: `23 passed`
  - Python llama-server 테스트: `6 passed`

  ## 리뷰어 참고사항
  - 현재 로컬 환경에서는 Metal backend가 로드되지만 `failed to create command queue`로 GPU context 생성이 실패했습니다. 그래서 `.env`에서는 `LOCAL_LLM_DEVICE=none` CPU fallback을 사용하도록 맞췄고, 코드에서는 GPU 시작 실패 시 CPU fallback을 한 번 재시도합니다.
  - Gemma4 chat template의 thinking 모드가 번역 지연을 크게 만들 수 있어 `LOCAL_LLM_REASONING=off`를 기본값으로 추가했습니다.