### PR TITLE
Feat/session id base62

### DIFF
--- a/src/cli/commands/checkpoint-restore.ts
+++ b/src/cli/commands/checkpoint-restore.ts
@@ -1,4 +1,15 @@
 import { SessionStateManager } from "../../core/state/SessionStateManager.js";
+import type { TaskResult } from "../../schemas/pipeline.js";
+
+const CHECKPOINT_SEPARATOR = "_checkpoint_";
+
+function parseSessionIdFromCheckpointId(checkpointId: string): string | null {
+  const separatorIndex = checkpointId.indexOf(CHECKPOINT_SEPARATOR);
+  if (separatorIndex <= 0 || separatorIndex === checkpointId.length - CHECKPOINT_SEPARATOR.length) {
+    return null;
+  }
+  return checkpointId.slice(0, separatorIndex);
+}
 
 export interface CheckpointRestoreOutput {
   ok: boolean;
@@ -15,7 +26,18 @@ export const runCheckpointRestoreCommand = async (
 ): Promise<CheckpointRestoreOutput> => {
   try {
     const checkpoint = await SessionStateManager.loadCheckpoint(checkpointId);
-    const sessionId = checkpoint.id.split('_checkpoint_')[0] || checkpoint.id;
+    const sessionId = parseSessionIdFromCheckpointId(checkpoint.id);
+    if (!sessionId) {
+      return {
+        ok: false,
+        mode: "checkpoint-restore",
+        sessionId: "unknown",
+        checkpointId,
+        restored: false,
+        mutatesState: false,
+        message: `Checkpoint ${checkpointId} does not use <session-id>_checkpoint_<checkpoint-id>.`,
+      };
+    }
     
     // Check if session exists
     if (!(await SessionStateManager.sessionExists(sessionId))) {
@@ -48,9 +70,12 @@ export const runCheckpointRestoreCommand = async (
 
     // Truncate history to this checkpoint
     const newCompletedIds = state.completed_task_ids.slice(0, taskIndex + 1);
-    const newTaskResults: Record<string, unknown> = {};
+    const newTaskResults: Record<string, TaskResult> = {};
     for (const id of newCompletedIds) {
-        newTaskResults[id] = state.task_results[id];
+        const result = state.task_results[id];
+        if (result) {
+          newTaskResults[id] = result;
+        }
     }
 
     const newState = {

--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -4,14 +4,25 @@ import { stdin as input, stdout as output } from "node:process";
 import { formatError, formatSuccess } from "../format.js";
 import { toNormalizedRequest } from "../parse.js";
 import type { CliArgs } from "../types.js";
+import { SessionStateManager } from "../../core/state/SessionStateManager.js";
 import { runCommand } from "./run.js";
 
 const EXIT_COMMANDS = new Set(["exit", "quit", ".exit"]);
+const SESSION_ID_CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+async function allocateReplSessionId(): Promise<string> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const sessionId = `repl-${Array.from({ length: 16 }, () => SESSION_ID_CHARSET[randomInt(SESSION_ID_CHARSET.length)]!).join("")}`;
+    if (!(await SessionStateManager.sessionExists(sessionId))) {
+      return sessionId;
+    }
+  }
+  throw new Error("Unable to allocate a unique REPL session id after 10 attempts");
+}
 
 export const runReplCommand = async (baseArgs: CliArgs): Promise<void> => {
   const rl = createInterface({ input, output });
-  const SESSION_ID_CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  const sessionId = `repl-${Array.from({ length: 16 }, () => SESSION_ID_CHARSET[randomInt(SESSION_ID_CHARSET.length)]!).join("")}`;
+  const sessionId = await allocateReplSessionId();
 
   output.write(
     `detoks repl started (adapter=${baseArgs.adapter}, executionMode=${baseArgs.executionMode}, verbose=${String(baseArgs.verbose)}). stub = simulated output; real = adapter's real execution path. type "exit" to quit.\n`,

--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -1,3 +1,4 @@
+import { randomInt } from "node:crypto";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { formatError, formatSuccess } from "../format.js";
@@ -9,7 +10,8 @@ const EXIT_COMMANDS = new Set(["exit", "quit", ".exit"]);
 
 export const runReplCommand = async (baseArgs: CliArgs): Promise<void> => {
   const rl = createInterface({ input, output });
-  const sessionId = `repl-${Date.now()}`;
+  const SESSION_ID_CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const sessionId = `repl-${Array.from({ length: 16 }, () => SESSION_ID_CHARSET[randomInt(SESSION_ID_CHARSET.length)]!).join("")}`;
 
   output.write(
     `detoks repl started (adapter=${baseArgs.adapter}, executionMode=${baseArgs.executionMode}, verbose=${String(baseArgs.verbose)}). stub = simulated output; real = adapter's real execution path. type "exit" to quit.\n`,

--- a/src/core/context/ContextBuilder.ts
+++ b/src/core/context/ContextBuilder.ts
@@ -50,8 +50,14 @@ export class ContextBuilder {
   ): Record<string, unknown> {
     const selected: Record<string, unknown> = {};
     const taskResults = state.task_results || {};
+    const dependencyIds =
+      targetTask.depends_on.length > 0
+        ? targetTask.depends_on
+        : (state.completed_task_ids || [])
+            .filter((taskId) => taskId !== targetTask.id)
+            .slice(-3);
 
-    for (const depId of targetTask.depends_on || []) {
+    for (const depId of dependencyIds) {
       if (!state.completed_task_ids.includes(depId)) {
         continue;
       }

--- a/src/core/context/ContextBuilder.ts
+++ b/src/core/context/ContextBuilder.ts
@@ -1,4 +1,4 @@
-import type { SessionState, ExecutionContext, Task } from '../../schemas/pipeline.js';
+import type { SessionState, ExecutionContext, Task, TaskResult } from '../../schemas/pipeline.js';
 import { ContextCompressor } from './ContextCompressor.js';
 import { ContextProcessingError } from '../errors/StateErrors.js';
 
@@ -61,13 +61,18 @@ export class ContextBuilder {
         continue;
       }
 
-      const res = result as any;
-      selected[depId] = res.structured_output
-        ? { summary: res.summary, ...res.structured_output }
-        : { summary: res.summary || 'Summary not available' };
+      selected[depId] = this.summarizeTaskResult(result);
     }
 
     return selected;
+  }
+
+  private static summarizeTaskResult(result: TaskResult): Record<string, unknown> {
+    const summary = typeof result.summary === 'string' ? result.summary : 'Summary not available';
+    if ('structured_output' in result && result.structured_output) {
+      return { summary, ...result.structured_output };
+    }
+    return { summary };
   }
 
   private static generateContextSummary(
@@ -82,8 +87,12 @@ export class ContextBuilder {
 
     const taskSummaries = Object.entries(selected)
       .map(([id, res]) => {
-        const r = res as any;
-        return `- Task [${id}]: ${r.summary || (typeof r === 'string' ? r : JSON.stringify(r))}`;
+        const summary = typeof res === 'object' && res !== null && 'summary' in res
+          ? String(res.summary)
+          : typeof res === 'string'
+            ? res
+            : JSON.stringify(res);
+        return `- Task [${id}]: ${summary}`;
       })
       .join('\n');
 

--- a/src/core/context/ContextCompressor.ts
+++ b/src/core/context/ContextCompressor.ts
@@ -1,4 +1,4 @@
-import type { SessionState } from '../../schemas/pipeline.js';
+import type { SessionState, TaskResult } from '../../schemas/pipeline.js';
 import { ContextProcessingError } from '../errors/StateErrors.js';
 
 /**
@@ -48,10 +48,10 @@ export class ContextCompressor {
    * 오래된 결과일수록 더 공격적으로 정보를 제거합니다.
    */
   private static compressTaskResults(
-    results: Record<string, any>, 
+    results: Record<string, TaskResult>, 
     completedIds: string[]
-  ): Record<string, any> {
-    const compressed: Record<string, any> = {};
+  ): Record<string, TaskResult> {
+    const compressed: Record<string, TaskResult> = {};
     const keepDetailCount = 3; // 최근 3개 작업만 상세 정보 유지
 
     // 전체 결과에 대해 루프를 돌며 압축 여부 결정
@@ -66,10 +66,9 @@ export class ContextCompressor {
         compressed[id] = result;
       } else {
         // 오래된 완료 작업은 압축
-        const res = result as any;
         compressed[id] = {
-          summary: res.summary || 'Summary preserved after compression',
-          status: res.status || (res.success ? 'completed' : 'failed'),
+          summary: result.summary || 'Summary preserved after compression',
+          status: 'success' in result && result.success ? 'completed' : 'failed',
           _compressed: true
         };
       }
@@ -102,14 +101,13 @@ export class ContextCompressor {
     }
 
     try {
-      const compressed: Record<string, any> = {};
+      const compressed: Record<string, TaskResult> = {};
       
       for (const [id, result] of Object.entries(state.task_results)) {
         if (!result) continue;
-        const res = result as any;
         compressed[id] = {
-          summary: res.summary || 'Summary preserved after compression',
-          status: res.status || (res.success ? 'completed' : 'failed'),
+          summary: result.summary || 'Summary preserved after compression',
+          status: 'success' in result && result.success ? 'completed' : 'failed',
           _compressed: true
         };
       }

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -10,7 +10,7 @@ import { SessionStateManager } from "../state/SessionStateManager.js";
 import { executeWithAdapter } from "../executor/execute.js";
 import { logger } from "../utils/logger.js";
 import { PipelineTracer } from "../utils/PipelineTracer.js";
-import type { SessionState } from "../../schemas/pipeline.js";
+import type { SessionState, TaskResult } from "../../schemas/pipeline.js";
 import type {
   PipelineExecutionRequest,
   PipelineExecutionResult,
@@ -28,6 +28,22 @@ function generateSessionId(): string {
     { length: SESSION_ID_LENGTH },
     () => SESSION_ID_CHARSET[randomInt(SESSION_ID_CHARSET.length)]!,
   ).join("");
+}
+
+async function allocateSessionId(): Promise<string> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const sessionId = generateSessionId();
+    if (!(await SessionStateManager.sessionExists(sessionId))) {
+      return sessionId;
+    }
+  }
+  throw new Error("Unable to allocate a unique session id after 10 attempts");
+}
+
+function taskResultRawOutput(result: TaskResult | undefined): string {
+  return result && "raw_output" in result && typeof result.raw_output === "string"
+    ? result.raw_output
+    : "";
 }
 
 function initSessionState(sessionId: string, rawInput: string): SessionState {
@@ -131,7 +147,7 @@ function inferPromptFailureNextAction(errorMessage: string): string {
 export const orchestratePipeline = async (
   request: PipelineExecutionRequest,
 ): Promise<PipelineExecutionResult> => {
-  const sessionId = request.userRequest.session_id ?? generateSessionId();
+  const sessionId = request.userRequest.session_id ?? (await allocateSessionId());
   PipelineTracer.clear();
 
   // ── Step 1: Prompt compile + Role 2.1 handoff 생성 (Role 1) ──────────────
@@ -306,13 +322,37 @@ export const orchestratePipeline = async (
                   : request.userRequest.raw_input,
             },
           };
-          const loadedFailedIds = (state.shared_context.failed_task_ids as string[]) || [];
+          const loadedFailedIds = Array.isArray(state.shared_context.failed_task_ids)
+            ? state.shared_context.failed_task_ids.filter((id): id is string => typeof id === "string")
+            : [];
           loadedFailedIds.forEach((id) => failedTaskIds.add(id));
         }
       }
     } catch (error) {
-      logger.warn(`[Role 2.2] 세션 로드 실패, 새 세션으로 재시작: ${error}`);
-      state = initSessionState(sessionId, request.userRequest.raw_input);
+      const errorMessage = toErrorMessage(error);
+      logger.error(`[Role 2.2] Session load failed for [${sessionId}]: ${errorMessage}`);
+      const traceFilePath = request.trace
+        ? await PipelineTracer.saveTrace(sessionId)
+        : undefined;
+      return {
+        ok: false,
+        mode: request.mode,
+        adapter: request.adapter,
+        summary: `Session load failed: ${errorMessage}`,
+        nextAction: "Fix or reset the existing session before retrying",
+        stages: buildPipelineStages(false),
+        rawOutput: errorMessage,
+        sessionId,
+        taskRecords,
+        compiledPrompt: compiledPrompt.compressed_prompt,
+        role2Handoff: role2PromptInput.compiled_prompt,
+        promptLanguage: compiledPrompt.language,
+        promptInferenceTimeSec: compiledPrompt.inference_time_sec ?? 0,
+        promptValidationErrors: compiledPrompt.validation_errors ?? [],
+        promptRepairActions: compiledPrompt.repair_actions ?? [],
+        ...(request.trace ? { traceLog: PipelineTracer.getTrace(sessionId) } : {}),
+        ...(traceFilePath ? { traceFilePath } : {}),
+      };
     }
   } else {
     state = initSessionState(sessionId, request.userRequest.raw_input);
@@ -339,11 +379,10 @@ export const orchestratePipeline = async (
       // 이미 완료된 작업이면 스킵 (Role 2.2 / Role 3 경계)
       if (state.completed_task_ids.includes(task.id)) {
         logger.info(`Task [${task.id}] already completed in session — skipping`);
-        const previousResult = state.task_results[task.id] as any;
         taskRecords.push({
           taskId: task.id,
           status: "completed",
-          rawOutput: previousResult?.raw_output ?? "",
+          rawOutput: taskResultRawOutput(state.task_results[task.id]),
         });
         continue;
       }
@@ -352,6 +391,16 @@ export const orchestratePipeline = async (
       const blockedBy = task.depends_on.find((depId) => failedTaskIds.has(depId));
       if (blockedBy) {
         failedTaskIds.add(task.id);
+        const rawOutput = `Skipped because dependency [${blockedBy}] failed`;
+        state = markTaskFailed(state, task.id, rawOutput);
+        state = {
+          ...state,
+          shared_context: {
+            ...state.shared_context,
+            failed_task_ids: Array.from(failedTaskIds),
+          },
+        };
+        await SessionStateManager.saveSession(state);
         taskRecords.push({ taskId: task.id, status: "skipped", rawOutput: "", blockedBy });
         logger.warn(`Task [${task.id}] skipped — dependency [${blockedBy}] failed`);
         continue;

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { randomInt } from "node:crypto";
 import { DAGValidator } from "../task-graph/DAGValidator.js";
 import { DependencyResolver } from "../task-graph/DependencyResolver.js";
 import { ParallelClassifier } from "../task-graph/ParallelClassifier.js";
@@ -20,8 +20,14 @@ import type {
 
 const SESSION_VERSION = "1";
 
+const SESSION_ID_CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+const SESSION_ID_LENGTH = 24;
+
 function generateSessionId(): string {
-  return createHash("sha256").update(String(Date.now())).digest("hex").slice(0, 12);
+  return Array.from(
+    { length: SESSION_ID_LENGTH },
+    () => SESSION_ID_CHARSET[randomInt(SESSION_ID_CHARSET.length)]!,
+  ).join("");
 }
 
 function initSessionState(sessionId: string, rawInput: string): SessionState {

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -10,7 +10,7 @@ import { SessionStateManager } from "../state/SessionStateManager.js";
 import { executeWithAdapter } from "../executor/execute.js";
 import { logger } from "../utils/logger.js";
 import { PipelineTracer } from "../utils/PipelineTracer.js";
-import type { SessionState, TaskResult } from "../../schemas/pipeline.js";
+import type { SessionState, TaskGraph, TaskResult } from "../../schemas/pipeline.js";
 import type {
   PipelineExecutionRequest,
   PipelineExecutionResult,
@@ -44,6 +44,85 @@ function taskResultRawOutput(result: TaskResult | undefined): string {
   return result && "raw_output" in result && typeof result.raw_output === "string"
     ? result.raw_output
     : "";
+}
+
+function taskIdNumber(taskId: string): number | null {
+  const match = /^t(\d+)$/u.exec(taskId);
+  if (!match) {
+    return null;
+  }
+
+  const parsed = Number(match[1]);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function nextTaskIdOffset(state: SessionState): number {
+  const taskIds = new Set<string>([
+    ...state.completed_task_ids,
+    ...Object.keys(state.task_results),
+  ]);
+  if (state.current_task_id) {
+    taskIds.add(state.current_task_id);
+  }
+
+  let max = 0;
+  for (const taskId of taskIds) {
+    const number = taskIdNumber(taskId);
+    if (number && number > max) {
+      max = number;
+    }
+  }
+
+  return max;
+}
+
+function retargetTaskGraphIds(graph: TaskGraph, offset: number): TaskGraph {
+  if (offset <= 0) {
+    return graph;
+  }
+
+  const idMap = new Map<string, string>();
+  graph.tasks.forEach((task, index) => {
+    idMap.set(task.id, `t${offset + index + 1}`);
+  });
+
+  graph.tasks.forEach((task) => {
+    task.id = idMap.get(task.id) ?? task.id;
+    task.depends_on = task.depends_on.map((depId) => idMap.get(depId) ?? depId);
+  });
+
+  return graph;
+}
+
+function appendSessionInputHistory(
+  state: SessionState,
+  nextRawInput: string,
+): SessionState {
+  const existingHistory = Array.isArray(state.shared_context.input_history)
+    ? state.shared_context.input_history.filter((entry): entry is string => typeof entry === "string")
+    : [];
+  const previousRawInput =
+    typeof state.shared_context.raw_input === "string"
+      ? state.shared_context.raw_input
+      : undefined;
+  const nextHistory = [...existingHistory];
+
+  if (previousRawInput && !nextHistory.includes(previousRawInput)) {
+    nextHistory.push(previousRawInput);
+  }
+  if (!nextHistory.includes(nextRawInput)) {
+    nextHistory.push(nextRawInput);
+  }
+
+  return {
+    ...state,
+    shared_context: {
+      ...state.shared_context,
+      raw_input: nextRawInput,
+      input_history: nextHistory,
+    },
+    updated_at: new Date().toISOString(),
+  };
 }
 
 function initSessionState(sessionId: string, rawInput: string): SessionState {
@@ -293,7 +372,7 @@ export const orchestratePipeline = async (
   const failedTaskIds = new Set<string>();
 
   PipelineTracer.startStage("SessionLoader");
-  const graphTaskIds = graph.tasks.map((t) => t.id);
+  let graphTaskIds = graph.tasks.map((t) => t.id);
 
   if (await SessionStateManager.sessionExists(sessionId)) {
     try {
@@ -303,6 +382,20 @@ export const orchestratePipeline = async (
         state = initSessionState(sessionId, request.userRequest.raw_input);
         logger.info(`[Role 2.2] 새 세션 생성 (버전 불일치): ${sessionId}`);
       } else {
+        const loadedRawInput =
+          typeof loaded.shared_context.raw_input === "string"
+            ? loaded.shared_context.raw_input
+            : "";
+        const isContinuationInput =
+          loadedRawInput.trim().length > 0 &&
+          loadedRawInput.trim() !== request.userRequest.raw_input.trim();
+
+        if (isContinuationInput) {
+          retargetTaskGraphIds(graph, nextTaskIdOffset(loaded));
+          graphTaskIds = graph.tasks.map((t) => t.id);
+          logger.info(`Continuing existing session: ${sessionId}`);
+          state = appendSessionInputHistory(loaded, request.userRequest.raw_input);
+        } else {
         const orphanedTaskIds = loaded.completed_task_ids.filter((id) => !graphTaskIds.includes(id));
         if (orphanedTaskIds.length > 0) {
           logger.warn(`[Role 2.2] 세션의 Task가 현재 그래프에 없음: ${orphanedTaskIds.join(", ")}. 세션 초기화.`);
@@ -326,6 +419,7 @@ export const orchestratePipeline = async (
             ? state.shared_context.failed_task_ids.filter((id): id is string => typeof id === "string")
             : [];
           loadedFailedIds.forEach((id) => failedTaskIds.add(id));
+          }
         }
       }
     } catch (error) {

--- a/src/core/prompt/config.ts
+++ b/src/core/prompt/config.ts
@@ -164,23 +164,36 @@ export function loadRole1RuntimeConfig(
 	const overrideEnv = options.env ?? process.env;
 	const env = { ...fileEnv, ...overrideEnv };
 
-	const pickEnv = (...keys: string[]): string | undefined => {
+	const findEnv = (
+		...keys: string[]
+	): { found: true; value: string | undefined } | { found: false } => {
 		for (const key of keys) {
 			if (overrideEnv[key] !== undefined) {
-				return overrideEnv[key];
+				return { found: true, value: overrideEnv[key] };
 			}
 		}
 		for (const key of keys) {
 			if (fileEnv[key] !== undefined) {
-				return fileEnv[key];
+				return { found: true, value: fileEnv[key] };
 			}
 		}
-		return undefined;
+		return { found: false };
 	};
 
-	const pickEnvWithDefault = (keys: string[], fallback: string): string => {
-		const value = pickEnv(...keys)?.trim();
-		return value || fallback;
+	const pickEnv = (...keys: string[]): string | undefined => {
+		const result = findEnv(...keys);
+		return result.found ? result.value?.trim() || undefined : undefined;
+	};
+
+	const pickEnvWithDefault = (
+		keys: string[],
+		fallback: string,
+	): string | undefined => {
+		const result = findEnv(...keys);
+		if (!result.found) {
+			return fallback;
+		}
+		return result.value?.trim() || undefined;
 	};
 
 	const pipelineMode = env.PIPELINE_MODE ?? "safe";

--- a/src/core/prompt/config.ts
+++ b/src/core/prompt/config.ts
@@ -138,35 +138,6 @@ function parseBoolean(value: string | undefined, fallback: boolean): boolean {
 	return ["1", "true", "on", "yes"].includes(value.toLowerCase());
 }
 
-function readEnvValue(
-	env: Record<string, string | undefined>,
-	...keys: string[]
-): string | undefined {
-	for (const key of keys) {
-		const value = env[key]?.trim();
-		if (value) {
-			return value;
-		}
-	}
-
-	return undefined;
-}
-
-function readEnvValueWithDefault(
-	env: Record<string, string | undefined>,
-	keys: string[],
-	fallback: string,
-): string | undefined {
-	for (const key of keys) {
-		if (Object.prototype.hasOwnProperty.call(env, key)) {
-			const value = env[key]?.trim();
-			return value || undefined;
-		}
-	}
-
-	return fallback;
-}
-
 function readJsonFile<T>(
 	filePath: string,
 	schema: z.ZodSchema<T>,
@@ -190,34 +161,49 @@ export function loadRole1RuntimeConfig(
 ): Role1RuntimeConfig {
 	const cwd = options.cwd ?? process.cwd();
 	const fileEnv = loadDotEnv(cwd);
-	const env = { ...fileEnv, ...(options.env ?? process.env) };
+	const overrideEnv = options.env ?? process.env;
+	const env = { ...fileEnv, ...overrideEnv };
+
+	const pickEnv = (...keys: string[]): string | undefined => {
+		for (const key of keys) {
+			if (overrideEnv[key] !== undefined) {
+				return overrideEnv[key];
+			}
+		}
+		for (const key of keys) {
+			if (fileEnv[key] !== undefined) {
+				return fileEnv[key];
+			}
+		}
+		return undefined;
+	};
+
+	const pickEnvWithDefault = (keys: string[], fallback: string): string => {
+		const value = pickEnv(...keys)?.trim();
+		return value || fallback;
+	};
 
 	const pipelineMode = env.PIPELINE_MODE ?? "safe";
 
 	return Role1RuntimeConfigSchema.parse({
-		localLlmApiBase: readEnvValueWithDefault(
-			env,
+		localLlmApiBase: pickEnvWithDefault(
 			["LOCAL_LLM_API_BASE", "OPENAI_API_BASE", "LM_STUDIO_URL"],
 			DEFAULT_LOCAL_LLM_API_BASE,
 		),
-		localLlmApiKey: readEnvValue(
-			env,
+		localLlmApiKey: pickEnv(
 			"LOCAL_LLM_API_KEY",
 			"OPENAI_API_KEY",
 			"LM_STUDIO_API_KEY",
 		),
-		localLlmModelName: readEnvValueWithDefault(
-			env,
+		localLlmModelName: pickEnvWithDefault(
 			["LOCAL_LLM_MODEL_NAME", "MODEL_NAME"],
 			DEFAULT_LOCAL_LLM_MODEL_NAME,
 		),
 		localLlmAutoStart: parseBoolean(env.LOCAL_LLM_AUTO_START, true),
 		localLlmServerBinary:
-			readEnvValue(env, "LOCAL_LLM_SERVER_BINARY") ??
-			DEFAULT_LOCAL_LLM_SERVER_BINARY,
+			pickEnv("LOCAL_LLM_SERVER_BINARY") ?? DEFAULT_LOCAL_LLM_SERVER_BINARY,
 		localLlmServerHost:
-			readEnvValue(env, "LOCAL_LLM_SERVER_HOST") ??
-			DEFAULT_LOCAL_LLM_SERVER_HOST,
+			pickEnv("LOCAL_LLM_SERVER_HOST") ?? DEFAULT_LOCAL_LLM_SERVER_HOST,
 		localLlmServerPort: parseNumber(
 			env.LOCAL_LLM_SERVER_PORT,
 			DEFAULT_LOCAL_LLM_SERVER_PORT,
@@ -228,9 +214,9 @@ export function loadRole1RuntimeConfig(
 			DEFAULT_LOCAL_LLM_STARTUP_TIMEOUT,
 			"LOCAL_LLM_STARTUP_TIMEOUT",
 		),
-		localLlmDevice: readEnvValue(env, "LOCAL_LLM_DEVICE"),
+		localLlmDevice: pickEnv("LOCAL_LLM_DEVICE"),
 		localLlmGpuLayers:
-			readEnvValue(env, "LOCAL_LLM_GPU_LAYERS") ?? DEFAULT_LOCAL_LLM_GPU_LAYERS,
+			pickEnv("LOCAL_LLM_GPU_LAYERS") ?? DEFAULT_LOCAL_LLM_GPU_LAYERS,
 		localLlmContextSize: parseNumber(
 			env.LOCAL_LLM_CONTEXT_SIZE,
 			DEFAULT_LOCAL_LLM_CONTEXT_SIZE,
@@ -242,13 +228,13 @@ export function loadRole1RuntimeConfig(
 			"LOCAL_LLM_MAX_TOKENS",
 		),
 		localLlmReasoning:
-			readEnvValue(env, "LOCAL_LLM_REASONING") ?? DEFAULT_LOCAL_LLM_REASONING,
-		localLlmModelPath: readEnvValue(env, "LOCAL_LLM_MODEL_PATH"),
-		localLlmModelUrl: readEnvValue(env, "LOCAL_LLM_MODEL_URL"),
+			pickEnv("LOCAL_LLM_REASONING") ?? DEFAULT_LOCAL_LLM_REASONING,
+		localLlmModelPath: pickEnv("LOCAL_LLM_MODEL_PATH"),
+		localLlmModelUrl: pickEnv("LOCAL_LLM_MODEL_URL"),
 		localLlmHfRepo:
-			readEnvValue(env, "LOCAL_LLM_HF_REPO") ?? DEFAULT_LOCAL_LLM_HF_REPO,
+			pickEnv("LOCAL_LLM_HF_REPO") ?? DEFAULT_LOCAL_LLM_HF_REPO,
 		localLlmHfFile:
-			readEnvValue(env, "LOCAL_LLM_HF_FILE") ?? DEFAULT_LOCAL_LLM_HF_FILE,
+			pickEnv("LOCAL_LLM_HF_FILE") ?? DEFAULT_LOCAL_LLM_HF_FILE,
 		pipelineMode,
 		requestTimeout: parseNumber(
 			env.REQUEST_TIMEOUT,

--- a/src/core/state/SessionStateManager.ts
+++ b/src/core/state/SessionStateManager.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
+import { randomUUID } from 'crypto';
 import { ZodError } from 'zod';
-import type { SessionState, Checkpoint } from '../../schemas/pipeline.js';
+import type { SessionState, Checkpoint, TaskResult } from '../../schemas/pipeline.js';
 import { SessionStateSchema, CheckpointSchema } from '../../schemas/pipeline.js';
 import { StateValidator } from './StateValidator.js';
 import { ExecutionResultNormalizer } from './ExecutionResultNormalizer.js';
@@ -15,6 +16,18 @@ const CHECKPOINTS_DIR = join(STATE_DIR, 'checkpoints');
 
 const LOCK_TIMEOUT_MS = 5000;
 const LOCK_RETRY_MS = 100;
+const CHECKPOINT_SEPARATOR = '_checkpoint_';
+
+function checkpointBelongsToSession(checkpointId: string, sessionId: string): boolean {
+  return checkpointId.startsWith(`${sessionId}${CHECKPOINT_SEPARATOR}`);
+}
+
+function hasFailed(result: TaskResult): boolean {
+  if ('success' in result) {
+    return result.success === false;
+  }
+  return result.status === 'failed';
+}
 
 export class SessionStateManager {
   private static lockPath(sessionId: string): string {
@@ -37,13 +50,27 @@ export class SessionStateManager {
     }
 
     // 타임아웃 — 스테일 락으로 간주하고 강제 제거 후 재시도
-    logger.warn(`[SessionStateManager] Stale lock detected for session [${sessionId}], removing.`);
     try {
-      await fs.unlink(lockPath);
+      const stat = await fs.stat(lockPath);
+      if (Date.now() - stat.mtimeMs < LOCK_TIMEOUT_MS) {
+        throw new StateIOError(`Failed to acquire lock for session [${sessionId}]`, { sessionId });
+      }
+
+      const stalePath = `${lockPath}.stale-${process.pid}-${randomUUID()}`;
+      logger.warn(`[SessionStateManager] Stale lock detected for session [${sessionId}], moving aside.`);
+      await fs.rename(lockPath, stalePath);
       const fd = await fs.open(lockPath, 'wx');
       await fd.close();
-    } catch {
-      throw new StateIOError(`Failed to acquire lock for session [${sessionId}]`, { sessionId });
+      await fs.unlink(stalePath).catch(() => undefined);
+    } catch (error: any) {
+      if (error.code === 'ENOENT' || error.code === 'EEXIST') {
+        return this.acquireLock(sessionId);
+      }
+      if (error instanceof StateIOError) throw error;
+      throw new StateIOError(`Failed to acquire lock for session [${sessionId}]`, {
+        sessionId,
+        originalError: error.message,
+      });
     }
   }
 
@@ -74,19 +101,24 @@ export class SessionStateManager {
     try {
       // 1. 자동 정규화: task_results의 원시 데이터를 표준 스키마로 보정
       for (const [taskId, result] of Object.entries(state.task_results)) {
-        const res = result as any;
+        const res = result as Record<string, unknown>;
         // 이미 정규화된 데이터가 아니라면(예: summary가 없거나 raw_output만 있다면) 보정 시도
-        if (!res.task_id || !res.summary) {
+        if (!('_compressed' in res) && (!res.task_id || !res.summary)) {
           state.task_results[taskId] = ExecutionResultNormalizer.normalize(taskId, res);
         }
       }
 
       // 2. 자동 실패 트래킹: shared_context.failed_task_ids 동기화
-      const failedIds = new Set<string>();
+      const failedIds = new Set<string>(
+        Array.isArray(state.shared_context.failed_task_ids)
+          ? state.shared_context.failed_task_ids.filter((id): id is string => typeof id === 'string')
+          : [],
+      );
       for (const [taskId, result] of Object.entries(state.task_results)) {
-        const res = result as any;
-        if (res.success === false) {
+        if (hasFailed(result)) {
           failedIds.add(taskId);
+        } else {
+          failedIds.delete(taskId);
         }
       }
       state.shared_context.failed_task_ids = Array.from(failedIds);
@@ -181,7 +213,18 @@ export class SessionStateManager {
     });
 
     await this.saveSession(forked);
+    await this.copyCheckpointsForFork(sourceSessionId, newSessionId);
     return forked;
+  }
+
+  private static async copyCheckpointsForFork(sourceSessionId: string, newSessionId: string): Promise<void> {
+    const checkpoints = await this.listCheckpoints(sourceSessionId);
+    for (const checkpoint of checkpoints) {
+      await this.createCheckpoint({
+        ...checkpoint,
+        id: `${newSessionId}${checkpoint.id.slice(sourceSessionId.length)}`,
+      });
+    }
   }
 
   static async listSessions(): Promise<Array<{
@@ -191,6 +234,8 @@ export class SessionStateManager {
     completedTaskCount: number;
     taskResultCount: number;
     nextAction: string | null;
+    failedTaskCount: number;
+    checkpointCount: number;
   }>> {
     try {
       const files = await fs.readdir(SESSIONS_DIR);
@@ -201,6 +246,8 @@ export class SessionStateManager {
         completedTaskCount: number;
         taskResultCount: number;
         nextAction: string | null;
+        failedTaskCount: number;
+        checkpointCount: number;
       }> = [];
 
       for (const file of files) {
@@ -209,13 +256,18 @@ export class SessionStateManager {
         try {
           const data = await fs.readFile(join(SESSIONS_DIR, file), 'utf-8');
           const state = SessionStateSchema.parse(JSON.parse(data));
+          const sessionId = file.slice(0, -'.json'.length);
           sessions.push({
-            id: file.slice(0, -'.json'.length),
+            id: sessionId,
             updatedAt: state.updated_at ?? null,
             currentTaskId: state.current_task_id ?? null,
             completedTaskCount: state.completed_task_ids.length,
             taskResultCount: Object.keys(state.task_results).length,
             nextAction: state.next_action ?? null,
+            failedTaskCount: Array.isArray(state.shared_context.failed_task_ids)
+              ? state.shared_context.failed_task_ids.filter((id) => typeof id === 'string').length
+              : Object.values(state.task_results).filter(hasFailed).length,
+            checkpointCount: (await this.listCheckpoints(sessionId)).length,
           });
         } catch (e) {
           logger.info(`Failed to load session file [${file}], skipping.`, e);
@@ -295,7 +347,7 @@ export class SessionStateManager {
             const data = await fs.readFile(join(CHECKPOINTS_DIR, file), 'utf-8');
             const parsed = JSON.parse(data);
             const checkpoint = CheckpointSchema.parse(parsed);
-            if (checkpoint.id.startsWith(sessionId)) {
+            if (checkpointBelongsToSession(checkpoint.id, sessionId)) {
               checkpoints.push(checkpoint);
             }
           } catch (e) {

--- a/src/integrations/subprocess/runner.ts
+++ b/src/integrations/subprocess/runner.ts
@@ -1,5 +1,7 @@
 import type { SubprocessRequest, SubprocessResult, SubprocessRunner } from "./types.js";
 import { spawn } from "node:child_process";
+import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
+import { extname, join } from "node:path";
 
 const formatCommand = (request: SubprocessRequest): string => {
   const args = request.args.length > 0 ? ` ${request.args.join(" ")}` : "";
@@ -17,12 +19,99 @@ export const createStubSubprocessRunner = (): SubprocessRunner => ({
   },
 });
 
+const splitPathEntries = (pathValue: string): string[] => {
+  if (process.platform !== "win32") {
+    return pathValue.split(":").filter(Boolean);
+  }
+
+  const entries: string[] = [];
+  let start = 0;
+  for (let i = 0; i < pathValue.length; i += 1) {
+    const char = pathValue[i];
+    const next = pathValue[i + 1];
+    const afterNext = pathValue[i + 2];
+    const afterDrive = pathValue[i + 3];
+    const isSemicolon = char === ";";
+    const isColonSeparator =
+      char === ":" &&
+      next !== undefined &&
+      afterNext === ":" &&
+      (afterDrive === "\\" || afterDrive === "/");
+
+    if (isSemicolon || isColonSeparator) {
+      const entry = pathValue.slice(start, i);
+      if (entry) entries.push(entry);
+      start = i + 1;
+    }
+  }
+
+  const finalEntry = pathValue.slice(start);
+  if (finalEntry) entries.push(finalEntry);
+  return entries;
+};
+
+const resolveCommandFromPath = (command: string, env: NodeJS.ProcessEnv): string | undefined => {
+  if (command.includes("/") || command.includes("\\")) {
+    return existsSync(command) ? command : undefined;
+  }
+
+  const pathValue = env.PATH ?? env.Path ?? "";
+  const extensions = process.platform === "win32"
+    ? ["", ...(env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";")]
+    : [""];
+
+  for (const pathEntry of splitPathEntries(pathValue)) {
+    for (const extension of extensions) {
+      const candidate = join(pathEntry, `${command}${extension.toLowerCase()}`);
+      if (existsSync(candidate) && statSync(candidate).isFile()) {
+        return candidate;
+      }
+      const upperCandidate = join(pathEntry, `${command}${extension.toUpperCase()}`);
+      if (existsSync(upperCandidate) && statSync(upperCandidate).isFile()) {
+        return upperCandidate;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const isNodeShebangScript = (filePath: string): boolean => {
+  const executableExtensions = new Set([".exe", ".cmd", ".bat", ".com"]);
+  if (executableExtensions.has(extname(filePath).toLowerCase())) {
+    return false;
+  }
+
+  let fd: number | undefined;
+  try {
+    fd = openSync(filePath, "r");
+    const buffer = Buffer.alloc(64);
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead).toString("utf8").startsWith("#!/usr/bin/env node");
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      closeSync(fd);
+    }
+  }
+};
+
 export const createRealSubprocessRunner = (): SubprocessRunner => ({
   async run(request: SubprocessRequest): Promise<SubprocessResult> {
     return await new Promise<SubprocessResult>((resolve) => {
-      const child = spawn(request.command, request.args, {
+      const env = request.env ? { ...process.env, ...request.env } : process.env;
+      const resolvedCommand = resolveCommandFromPath(request.command, env);
+      const runViaNode = resolvedCommand !== undefined && isNodeShebangScript(resolvedCommand);
+      const command = runViaNode
+        ? process.execPath
+        : resolvedCommand ?? request.command;
+      const args = runViaNode
+        ? [resolvedCommand, ...request.args]
+        : request.args;
+      const child = spawn(command, args, {
         cwd: request.cwd,
-        env: request.env ? { ...process.env, ...request.env } : process.env,
+        env,
         shell: false,
         stdio: ["pipe", "pipe", "pipe"],
       });

--- a/src/schemas/pipeline.ts
+++ b/src/schemas/pipeline.ts
@@ -65,6 +65,10 @@ export const UserRequestSchema = z.object({
   timestamp: z.string().optional(),
 });
 
+export const SessionUserRequestSchema = UserRequestSchema.extend({
+  session_id: z.string().min(1),
+});
+
 export const PromptCompressionProviderValues = [
   "nlp_adapter",
   "llm",
@@ -206,10 +210,37 @@ export const ExecutionResultSchema = z.object({
     })
     .optional(),
   next_action: z.string().optional(),
-});
+}).passthrough();
+
+export const CompressedExecutionResultSchema = z.object({
+  summary: z.string(),
+  status: z.enum(["completed", "failed"]).optional(),
+  _compressed: z.literal(true),
+}).passthrough();
+
+export const LegacyExecutionResultSchema = z.object({
+  success: z.boolean(),
+  summary: z.string().optional(),
+  raw_output: z.string().optional(),
+  structured_output: z.record(z.string(), z.unknown()).optional(),
+  next_action: z.string().optional(),
+}).passthrough();
+
+export const SummaryOnlyTaskResultSchema = z.object({
+  summary: z.string(),
+}).passthrough();
+
+export const TaskResultSchema = z.union([
+  ExecutionResultSchema,
+  LegacyExecutionResultSchema,
+  SummaryOnlyTaskResultSchema,
+  CompressedExecutionResultSchema,
+]);
 
 export const CheckpointSchema = z.object({
-  id: z.string().min(1),
+  id: z.string().regex(/^(.+_checkpoint_.+|checkpoint_.+)$/, {
+    message: "Checkpoint id must use <session-id>_checkpoint_<checkpoint-id> or legacy checkpoint_<id>",
+  }),
   title: z.string().min(1),
   task_id: z.string(),
   summary: z.string(),
@@ -221,7 +252,7 @@ export const CheckpointSchema = z.object({
 export const SessionStateSchema = z.object({
   version: z.string().optional(),
   shared_context: z.record(z.string(), z.unknown()).default({}),
-  task_results: z.record(z.string(), z.unknown()).default({}),
+  task_results: z.record(z.string(), TaskResultSchema).default({}),
   current_task_id: z.string().optional().nullable(),
   completed_task_ids: z.array(z.string()).default([]),
   last_summary: z.string().optional(),
@@ -238,6 +269,7 @@ export const CompiledSentencesSchema = z.object({
 export type CompiledSentences = z.infer<typeof CompiledSentencesSchema>;
 
 export type UserRequest = z.infer<typeof UserRequestSchema>;
+export type SessionUserRequest = z.infer<typeof SessionUserRequestSchema>;
 export type RequestCategory = z.infer<typeof RequestCategorySchema>;
 export type PromptCompressionProvider = z.infer<
   typeof PromptCompressionProviderSchema
@@ -258,4 +290,5 @@ export type TaskGraph = z.infer<typeof TaskGraphSchema>;
 export type Checkpoint = z.infer<typeof CheckpointSchema>;
 export type ExecutionContext = z.infer<typeof ExecutionContextSchema>;
 export type ExecutionResult = z.infer<typeof ExecutionResultSchema>;
+export type TaskResult = z.infer<typeof TaskResultSchema>;
 export type SessionState = z.infer<typeof SessionStateSchema>;

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { TaskResultSchema, type TaskResult } from '../schemas/pipeline.js';
 
 export interface SharedContext {
   project_info: string;
@@ -43,13 +44,13 @@ export const OptimizedContextSchema = z.object({
 export interface CompressedState {
   shared_context: SharedContext;
   task_context: TaskContext;
-  task_results: Record<string, unknown>;
+  task_results: Record<string, TaskResult>;
   token_estimate: number;
 }
 
 export const CompressedStateSchema = z.object({
   shared_context: SharedContextSchema,
   task_context: TaskContextSchema,
-  task_results: z.record(z.string(), z.unknown()),
+  task_results: z.record(z.string(), TaskResultSchema),
   token_estimate: z.number().positive(),
 });

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -3,11 +3,15 @@ import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it, vi } from "vitest";
 
 const repoRoot = process.cwd();
 const cliEntry = resolve(repoRoot, "src/cli/index.ts");
 const tsxLoader = resolve(repoRoot, "node_modules/tsx/dist/loader.mjs");
+const tsxLoaderUrl = pathToFileURL(tsxLoader).href;
+
+vi.setConfig({ testTimeout: 30_000 });
 
 const runCli = (args: string[]) =>
   spawnSync(process.execPath, ["--import", "tsx", cliEntry, ...args], {
@@ -42,7 +46,7 @@ const runCliWithEnvAndTimeout = (
   });
 
 const runCliFromCwd = (cwd: string, args: string[]) =>
-  spawnSync(process.execPath, ["--import", tsxLoader, cliEntry, ...args], {
+  spawnSync(process.execPath, ["--import", tsxLoaderUrl, cliEntry, ...args], {
     cwd,
     encoding: "utf8",
   });

--- a/tests/ts/unit/cli/checkpoint-restore.test.ts
+++ b/tests/ts/unit/cli/checkpoint-restore.test.ts
@@ -8,6 +8,28 @@ describe("runCheckpointRestoreCommand", () => {
     vi.useRealTimers();
   });
 
+  it("rejects checkpoint ids that cannot identify a non-empty session id", async () => {
+    vi.spyOn(SessionStateManager, "loadCheckpoint").mockResolvedValue({
+      id: "_checkpoint_001",
+      title: "Invalid checkpoint",
+      task_id: "task_001",
+      summary: "Invalid",
+      changed_files: [],
+      next_action: "None",
+      created_at: "2026-04-27T00:00:00.000Z",
+    } as any);
+
+    await expect(runCheckpointRestoreCommand("_checkpoint_001")).resolves.toEqual({
+      ok: false,
+      mode: "checkpoint-restore",
+      sessionId: "unknown",
+      checkpointId: "_checkpoint_001",
+      restored: false,
+      mutatesState: false,
+      message: "Checkpoint _checkpoint_001 does not use <session-id>_checkpoint_<checkpoint-id>.",
+    });
+  });
+
   it("returns an explicit not-found contract when the target session is missing", async () => {
     vi.spyOn(SessionStateManager, "loadCheckpoint").mockResolvedValue({
       id: "session_restore_checkpoint_001",

--- a/tests/ts/unit/cli/session-list.test.ts
+++ b/tests/ts/unit/cli/session-list.test.ts
@@ -35,6 +35,8 @@ describe("runSessionListCommand", () => {
         currentTaskId: "task_001",
         completedTaskCount: 1,
         taskResultCount: 2,
+        failedTaskCount: 1,
+        checkpointCount: 3,
         nextAction: "Review saved session",
       },
     ]);

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -263,6 +263,34 @@ describe("orchestratePipeline", () => {
     );
   });
 
+  it("does not overwrite an existing session when loading it fails", async () => {
+    vi.spyOn(SessionStateManager, "sessionExists").mockResolvedValue(true);
+    vi.spyOn(SessionStateManager, "loadSession").mockRejectedValue(
+      new Error("Session file is corrupted"),
+    );
+    const saveSessionSpy = vi
+      .spyOn(SessionStateManager, "saveSession")
+      .mockResolvedValue(undefined);
+
+    const result = await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "stub",
+      verbose: false,
+      userRequest: {
+        raw_input: "hello detoks",
+        session_id: "corrupt_session",
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.sessionId).toBe("corrupt_session");
+    expect(result.summary).toBe("Session load failed: Session file is corrupted");
+    expect(result.nextAction).toBe("Fix or reset the existing session before retrying");
+    expect(saveSessionSpy).not.toHaveBeenCalled();
+    expect(executeWithAdapterMock).not.toHaveBeenCalled();
+  });
+
   it("retries a previously failed task and unblocks its dependent task on success", async () => {
     vi.spyOn(SessionStateManager, "sessionExists").mockResolvedValue(true);
     vi.spyOn(SessionStateManager, "loadSession").mockResolvedValue({

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -263,6 +263,72 @@ describe("orchestratePipeline", () => {
     );
   });
 
+  it("continues a REPL session with new task ids and previous context for new input", async () => {
+    vi.spyOn(SessionStateManager, "sessionExists").mockResolvedValue(true);
+    vi.spyOn(SessionStateManager, "loadSession").mockResolvedValue({
+      version: "1",
+      shared_context: {
+        session_id: "repl_session",
+        raw_input: "Compare JavaScript array sorting methods",
+      },
+      task_results: {
+        t1: {
+          task_id: "t1",
+          success: true,
+          summary: "sort is fastest but mutates the source array",
+          raw_output: "sort is fastest but mutates the source array",
+        },
+      },
+      current_task_id: null,
+      completed_task_ids: ["t1"],
+      updated_at: "2026-04-27T00:00:00.000Z",
+    });
+    const saveSessionSpy = vi
+      .spyOn(SessionStateManager, "saveSession")
+      .mockResolvedValue(undefined);
+    executeWithAdapterMock.mockResolvedValueOnce({
+      ok: true,
+      adapter: "gemini",
+      rawOutput: "[mock-repl] follow-up",
+      exitCode: 0,
+    });
+
+    const result = await orchestratePipeline({
+      mode: "repl",
+      adapter: "gemini",
+      executionMode: "stub",
+      verbose: false,
+      userRequest: {
+        raw_input: "What is the downside of the fastest method?",
+        session_id: "repl_session",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.taskRecords).toEqual([
+      { taskId: "t2", status: "completed", rawOutput: "[mock-repl] follow-up" },
+    ]);
+    expect(executeWithAdapterMock).toHaveBeenCalledTimes(1);
+    expect(executeWithAdapterMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("Task [t1]: sort is fastest"),
+        sessionId: "repl_session",
+      }),
+    );
+    expect(saveSessionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        completed_task_ids: ["t1", "t2"],
+        shared_context: expect.objectContaining({
+          raw_input: "What is the downside of the fastest method?",
+          input_history: [
+            "Compare JavaScript array sorting methods",
+            "What is the downside of the fastest method?",
+          ],
+        }),
+      }),
+    );
+  });
+
   it("does not overwrite an existing session when loading it fails", async () => {
     vi.spyOn(SessionStateManager, "sessionExists").mockResolvedValue(true);
     vi.spyOn(SessionStateManager, "loadSession").mockRejectedValue(


### PR DESCRIPTION
# 세션 이슈 개선 및 REPL 세션 유지 수정

## 요약

- 이전 세션 감사에서 식별된 세션 관련 11개 이슈를 수정했습니다
- 기존 세션 로드 실패 시 새 세션으로 overwrite될 수 있는 고위험 문제를 차단했습니다
- 세션 ID 충돌 방지, checkpoint restore/fork 안정성, lock race condition, 실패 task 동기화, 세션 스키마 타입 안정성을 보강했습니다
- REPL에서 같은 세션을 유지해야 하는 후속 입력이 기존 `t1`과 충돌해 실행되지 않는 문제를 수정했습니다
- 검증 과정에서 발견된 Role 1 env 우선순위 문제, 명시 빈 local LLM env override 문제, Windows CLI smoke subprocess 안정성 문제도 함께 수정했습니다

## 관련 이슈

- Closes #141 

## 변경 유형

- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩터링
- [ ] 문서 수정
- [x] 테스트 추가/수정

## 영향 범위

- 변경된 파일:
  - `orchestrator.ts`  세션 ID 중복 방지, 세션 로드 실패 시 overwrite 차단, dependency 실패 task 저장, failed task id 추출 안정화, REPL continuation task id 재번호 부여
  - `repl.ts`  REPL 세션 ID 중복 방지
  - `SessionStateManager.ts`  stale lock atomic 처리, fork checkpoint 복사, failed_task_ids 동기화, listSessions metadata 확장
  - `checkpoint-restore.ts`  checkpoint id에서 session id를 명시적으로 파싱하고 invalid id 방어
  - `src/schemas/pipeline.ts`  checkpoint id 형식, session user request, task result schema 강화
  - `src/core/context/ContextBuilder.ts`  continuation task가 최근 완료 task 결과를 context로 받을 수 있도록 보강
  - `src/core/context/ContextCompressor.ts`, `src/types/context.ts`  TaskResult 타입 정리 및 `as any` 축소
  - `src/core/prompt/config.ts`  Role 1 명시 env override 우선순위 수정, 명시 빈 local LLM env가 default로 되살아나는 문제 수정
  - `src/integrations/subprocess/runner.ts`  Windows PATH/shebang 실행 안정화
  - `tests/ts/unit/core/pipeline/orchestrator.test.ts`  세션 load 보호, 실패 task 재시도, REPL continuation 테스트 추가
  - `tests/ts/integration/cli-smoke.test.ts`  Windows ESM loader URL 및 timeout 안정화

## 수정 내용

### 1. 세션 ID 충돌 방지

`orchestrator.ts`와 `repl.ts`에서 새 세션 ID를 만들 때 기존 세션과 충돌하는지 확인하도록 bounded allocation 루프를 추가했습니다.

**문제**: base62 충돌 확률은 낮지만, 충돌 시 기존 세션을 덮어쓸 수 있음

| 상황 | 수정 전 | 수정 후 |
|------|---------|---------|
| 신규 session id가 기존 id와 충돌 | 기존 세션 overwrite 가능 | 다른 id 재생성 |
| 충돌이 반복되는 비정상 상황 | 방어 없음 | 명시적 실패 반환 |

### 2. 세션 로드 실패 시 overwrite 차단

기존 세션을 resume/load하는 과정에서 로드에 실패하면 새 세션으로 초기화하지 않고 구조화된 실패 결과를 반환하도록 변경했습니다.

**문제**: 손상, 권한, race condition 등으로 세션 로드에 실패해도 새 세션으로 이어서 저장되어 기존 파일을 덮어쓸 위험

| 상황 | 수정 전 | 수정 후 |
|------|---------|---------|
| 기존 session load 실패 | 새 세션으로 overwrite 가능 | 저장 중단 |
| 손상된 session 파일 | 원인 보존 어려움 | 실패 원인 반환 |

### 3. REPL 세션 continuation task id 충돌 수정

같은 REPL 세션에서 후속 입력을 넣으면 TaskGraph가 매번 `t1`부터 생성되었습니다. 기존 세션에는 이미 `completed_task_ids: ["t1"]`가 있으므로, 새 입력의 `t1`이 “이미 완료됨”으로 판단되어 실제 실행되지 않고 이전 응답만 반환되는 문제가 있었습니다.

**문제**: 세션은 로드되지만 새 입력이 기존 task id와 충돌해 skip됨

```ts
// Before
// 1번째 입력 -> t1 실행 및 저장
// 2번째 입력 -> 다시 t1 생성 -> completed_task_ids에 t1 존재 -> skip

// After
// 1번째 입력 -> t1 실행 및 저장
// 2번째 입력 -> t2로 재번호 부여 -> t1 context를 참고하며 실행
```

| 상황 | 수정 전 | 수정 후 |
|------|---------|---------|
| REPL 후속 입력 | 새 `t1`이 기존 `t1`과 충돌해 skip | 기존 최대 task id 다음 번호로 실행 |
| 후속 질문 context | 명시 dependency가 없어 이전 결과 미사용 | 최근 완료 task 결과를 context로 제공 |
| 세션 raw input | 최초 입력 중심 | `input_history`에 입력 흐름 보존 |

### 4. checkpoint restore session id 파싱 강화

`split("_checkpoint_")[0]` 방식 대신 checkpoint id parser를 두고 빈 session id나 잘못된 id를 명시적으로 거부하도록 수정했습니다.

| checkpoint id | 수정 전 | 수정 후 |
|---------------|---------|---------|
| `_checkpoint_abc` | 빈 session id 가능 | invalid id로 실패 |
| `session_checkpoint_abc` | session 추출 | session 추출 |

### 5. SessionStateManager 안정성 보강

stale lock 처리에서 `unlink -> open` 사이 race window를 줄이기 위해 atomic rename 기반 처리를 적용했습니다. 또한 fork 시 source checkpoint를 target session id 기준으로 복사하고, `failed_task_ids` 동기화와 내부 metadata를 보강했습니다.

| 항목 | 수정 전 | 수정 후 |
|------|---------|---------|
| stale lock 처리 | unlink/open 사이 gap 존재 | atomic rename으로 획득 |
| session fork | checkpoint 미복사 | checkpoint 복사 |
| failed_task_ids | skipped/cascade 실패 반영 부족 | 실패 id 보존 및 성공 task 제거 |
| listSessions metadata | 실패/checkpoint 수 없음 | `failedTaskCount`, `checkpointCount` 추가 |

### 6. 세션 스키마와 타입 안정성 강화

`pipeline.ts`에 checkpoint id 형식 검증, session 전용 user request schema, task result union schema를 추가했습니다. context 관련 경로에서는 schema 기반 타입을 사용해 `as any` 사용을 줄였습니다.

| 데이터 | 수정 전 | 수정 후 |
|--------|---------|---------|
| checkpoint id | 형식 제약 없음 | canonical/legacy 형식 검증 |
| task_results | `z.unknown()` | 명시적 union schema |
| session request | `session_id` optional | session 명령용 필수 schema 추가 |

### 7. 검증 중 발견한 추가 안정성 수정

세션 감사 수정 검증 중 Role 1 runtime env override와 Windows CLI smoke subprocess 실행 문제가 발견되어 함께 수정했습니다.

| 영역 | 문제 | 수정 후 |
|------|------|---------|
| Role 1 config | 명시 env가 `.env` alias보다 약할 수 있음 | 명시 env 우선 |
| local LLM env | 명시 빈 값이 default local LLM 설정으로 되살아남 | 빈 env는 default를 막고 설정 오류 반환 |
| Windows subprocess | extensionless node shebang fake adapter 실행 불안정 | PATH/shebang 처리 강화 |
| Windows ESM loader | loader path URL 처리 문제 | `file://` URL 사용 |
| CLI smoke timeout | Windows 병렬 테스트에서 5초 초과 가능 | 30초 timeout 적용 |

## 테스트 방법

```bash
npm run build
npm test -- tests/ts/unit/core/pipeline/orchestrator.test.ts
npm test -- tests/ts/unit/cli/session-continue.test.ts tests/ts/unit/core/pipeline/orchestrator.test.ts
npm test -- tests/ts/integration/cli-smoke.test.ts
npm test -- --passWithNoTests
```

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] 필요한 경우 테스트를 추가하거나 수정했습니다
- [x] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 스크린샷 / 로그

```text
> npm run build

passed

> npm test -- --passWithNoTests

Test Files  38 passed (38)
Tests       1061 passed, 1 skipped
```

## 리뷰어 참고사항

- `SessionStateManager.listSessions()`는 내부 metadata에 `failedTaskCount`, `checkpointCount`를 추가하지만 CLI `session list` 출력 계약은 유지했습니다.
- checkpoint id schema는 신규 canonical 형식인 `<session-id>_checkpoint_<id>`와 기존 legacy 형식인 `checkpoint_<id>`를 모두 허용합니다.
- 세션 로드 실패 시 새 세션으로 복구하지 않고 실패시키는 동작은 의도된 변경입니다. 기존 데이터를 보호하는 쪽을 우선했습니다.
- REPL 후속 입력은 기존 세션의 raw input과 다르면 continuation으로 보고 새 task id를 기존 최대 id 다음으로 부여합니다.
- continuation task가 명시 dependency를 갖지 않아도 최근 완료 task 결과 최대 3개를 context로 제공합니다.
- 검증 안정화를 위해 Role 1 env 우선순위, 명시 빈 local LLM env 처리, Windows CLI smoke subprocess 수정 커밋이 같은 PR에 포함되어 있습니다.
