### PR TITLE
Enhance DAG connectivity documentation and translation

### DIFF
--- a/docs/TYPE_DEFINITION.md
+++ b/docs/TYPE_DEFINITION.md
@@ -117,7 +117,7 @@ Typical natural flows:
 - `validate -> modify`
 - `validate -> document`
 
-`document` is typically a terminal stage.
+`document` is typically a terminal stage, but an explicitly ordered follow-up can continue into implementation, validation, execution, analysis, or planning.
 
 ## Notes
 

--- a/local_config/issue-dag-validation-isolated-node.md
+++ b/local_config/issue-dag-validation-isolated-node.md
@@ -1,20 +1,20 @@
-# Issue: DAG validation fails on ordered document follow-up workflow
+# Issue: 문서화 후속 작업에서 DAG 연결성 검증 실패
 
-## Summary
+## 요약
 
-Long multi-step requests can fail during DAG validation with `DISCONNECTED_NODE` when a `document` task appears in the middle of an explicitly ordered workflow.
+명시적으로 순서가 있는 긴 다중 작업 요청에서 중간에 `document` 작업이 포함되면 DAG 검증 단계가 `DISCONNECTED_NODE`로 실패할 수 있습니다.
 
-Observed failure:
+관측된 실패 메시지:
 
 ```text
 DAG validation failed: DISCONNECTED_NODE - Task "t3" has no dependencies and no dependents - isolated from the graph
 ```
 
-This is a Role 2.1 TaskGraph construction issue, not a DAGValidator issue. `DAGValidator` is correctly rejecting a partially connected graph. The graph becomes partially connected because `TaskGraphProcessor` currently treats `document` as a hard terminal type.
+이 문제는 `DAGValidator` 자체의 오류가 아니라 Role 2.1의 TaskGraph 생성 문제입니다. `DAGValidator`는 부분적으로만 연결된 그래프를 올바르게 거부하고 있습니다. 문제는 `TaskGraphProcessor`가 `document` 타입을 절대적인 종료 노드로 처리해, 명시적 후속 작업까지 그래프에서 끊어 버리는 데 있습니다.
 
-## Reproduction
+## 재현 방법
 
-Use a long request that splits into ordered task sentences:
+다음처럼 순서가 있는 작업 문장으로 분리되는 긴 요청을 사용합니다.
 
 ```ts
 [
@@ -25,13 +25,13 @@ Use a long request that splits into ordered task sentences:
 ]
 ```
 
-Expected task flow:
+기대하는 작업 흐름:
 
 ```text
 t1 analyze -> t2 document -> t3 create -> t4 validate
 ```
 
-Current behavior before fix:
+수정 전 동작:
 
 ```text
 t1 analyze -> t2 document
@@ -39,62 +39,62 @@ t3 create
 t4 validate
 ```
 
-`t3` can become isolated from the connected component, causing `DAGValidator.validate()` to fail with `DISCONNECTED_NODE`.
+이 상태에서는 `t3`가 연결된 컴포넌트에서 고립될 수 있고, `DAGValidator.validate()`가 `DISCONNECTED_NODE`를 반환합니다.
 
-## Root Cause
+## 원인
 
-### 1. Documentation creation classification is incomplete
+### 1. 문서 산출물 생성 표현의 분류가 부족함
 
-`TaskGraphProcessor.TYPE_PATTERNS` classifies obvious documentation verbs such as `write documentation` or `update docs`, but phrases like `create comprehensive documentation` can be classified as `create`.
+`TaskGraphProcessor.TYPE_PATTERNS`는 `write documentation`, `update docs` 같은 명확한 문서화 동사는 `document`로 분류합니다. 하지만 `create comprehensive documentation` 같은 표현은 일반 `create` 패턴에 걸릴 수 있습니다.
 
-That classification is unstable for documentation artifacts.
+문서 산출물에 대해 분류가 안정적이지 않았습니다.
 
-### 2. `document` is treated as an absolute terminal node
+### 2. `document`가 절대적인 종료 노드로 처리됨
 
-`TaskGraphProcessor.FLOWS_TO.document` is currently empty:
+기존 `TaskGraphProcessor.FLOWS_TO.document`는 비어 있습니다.
 
 ```ts
 document: []
 ```
 
-That means any task after `document` is forced into `depends_on: []`, even when the splitter produced the tasks from explicit ordering signals such as comma order, `and then`, or repeated imperative steps.
+따라서 `document` 뒤에 어떤 작업이 오더라도 `depends_on: []`이 됩니다. 이는 splitter가 comma 순서, `and then`, 반복 명령형 문장 같은 명시적 순서 신호를 통해 작업을 만들었을 때도 동일하게 적용됩니다.
 
-## Expected Behavior
+## 기대 동작
 
-- Documentation artifacts should classify as `document` even when the verb is `create`, `generate`, `draft`, or `produce`.
-- `document` should remain usually terminal, but explicit follow-up tasks should be allowed to continue the ordered workflow.
-- The reproduction should produce one connected sequential graph:
+- 문서 산출물은 동사가 `create`, `generate`, `draft`, `produce`여도 `document`로 분류되어야 합니다.
+- `document`는 보통 종료 단계로 남아야 하지만, 명시적인 후속 작업은 순서 있는 workflow로 이어질 수 있어야 합니다.
+- 재현 케이스는 하나의 연결된 순차 그래프를 만들어야 합니다.
 
 ```text
 analyze -> document -> create -> validate
 ```
 
-## Proposed Fix
+## 수정 방향
 
-1. Add documentation artifact patterns before generic `create` patterns:
+1. 일반 `create` 패턴보다 앞에서 문서 산출물 패턴을 처리합니다.
 
 ```ts
 /\b(create|generate|draft|produce)\s+(a\s+|an\s+|the\s+)?(comprehensive\s+)?(documentation|docs|readme|guide|docstring|comment[s]?)\b/
 ```
 
-2. Allow `document` to flow into follow-up task types:
+2. `document` 뒤의 명시적 후속 작업을 연결할 수 있게 합니다.
 
 ```ts
 document: ["analyze", "modify", "validate", "execute", "create", "plan"]
 ```
 
-3. Keep `DAGValidator` unchanged. It should continue to reject genuinely disconnected graphs.
+3. `DAGValidator`는 변경하지 않습니다. 실제로 끊어진 그래프는 계속 거부해야 합니다.
 
-## Acceptance Criteria
+## 완료 조건
 
-- [ ] `Create comprehensive documentation` classifies as `document`.
-- [ ] `document -> validate` creates a sequential dependency when represented as ordered task sentences.
-- [ ] `analyze -> document -> create -> validate` creates a connected sequential graph.
-- [ ] Existing disconnected-node validation behavior remains intact.
-- [ ] `npm run build` passes.
-- [ ] `npm run test` passes.
+- [ ] `Create comprehensive documentation`이 `document`로 분류된다.
+- [ ] 순서 있는 작업 문장에서 `document -> validate`가 순차 의존성을 만든다.
+- [ ] `analyze -> document -> create -> validate`가 연결된 순차 그래프를 만든다.
+- [ ] 기존 disconnected-node 검증 동작은 유지된다.
+- [ ] `npm run build`가 통과한다.
+- [ ] `npm run test`가 통과한다.
 
-## Related Files
+## 관련 파일
 
 - `src/core/task-graph/TaskGraphProcessor.ts`
 - `src/core/task-graph/DAGValidator.ts`

--- a/local_config/issue-dag-validation-isolated-node.md
+++ b/local_config/issue-dag-validation-isolated-node.md
@@ -1,0 +1,104 @@
+# Issue: DAG validation fails on ordered document follow-up workflow
+
+## Summary
+
+Long multi-step requests can fail during DAG validation with `DISCONNECTED_NODE` when a `document` task appears in the middle of an explicitly ordered workflow.
+
+Observed failure:
+
+```text
+DAG validation failed: DISCONNECTED_NODE - Task "t3" has no dependencies and no dependents - isolated from the graph
+```
+
+This is a Role 2.1 TaskGraph construction issue, not a DAGValidator issue. `DAGValidator` is correctly rejecting a partially connected graph. The graph becomes partially connected because `TaskGraphProcessor` currently treats `document` as a hard terminal type.
+
+## Reproduction
+
+Use a long request that splits into ordered task sentences:
+
+```ts
+[
+  "Analyze the entire codebase",
+  "create a comprehensive documentation with examples",
+  "implement all suggested improvements",
+  "validate everything",
+]
+```
+
+Expected task flow:
+
+```text
+t1 analyze -> t2 document -> t3 create -> t4 validate
+```
+
+Current behavior before fix:
+
+```text
+t1 analyze -> t2 document
+t3 create
+t4 validate
+```
+
+`t3` can become isolated from the connected component, causing `DAGValidator.validate()` to fail with `DISCONNECTED_NODE`.
+
+## Root Cause
+
+### 1. Documentation creation classification is incomplete
+
+`TaskGraphProcessor.TYPE_PATTERNS` classifies obvious documentation verbs such as `write documentation` or `update docs`, but phrases like `create comprehensive documentation` can be classified as `create`.
+
+That classification is unstable for documentation artifacts.
+
+### 2. `document` is treated as an absolute terminal node
+
+`TaskGraphProcessor.FLOWS_TO.document` is currently empty:
+
+```ts
+document: []
+```
+
+That means any task after `document` is forced into `depends_on: []`, even when the splitter produced the tasks from explicit ordering signals such as comma order, `and then`, or repeated imperative steps.
+
+## Expected Behavior
+
+- Documentation artifacts should classify as `document` even when the verb is `create`, `generate`, `draft`, or `produce`.
+- `document` should remain usually terminal, but explicit follow-up tasks should be allowed to continue the ordered workflow.
+- The reproduction should produce one connected sequential graph:
+
+```text
+analyze -> document -> create -> validate
+```
+
+## Proposed Fix
+
+1. Add documentation artifact patterns before generic `create` patterns:
+
+```ts
+/\b(create|generate|draft|produce)\s+(a\s+|an\s+|the\s+)?(comprehensive\s+)?(documentation|docs|readme|guide|docstring|comment[s]?)\b/
+```
+
+2. Allow `document` to flow into follow-up task types:
+
+```ts
+document: ["analyze", "modify", "validate", "execute", "create", "plan"]
+```
+
+3. Keep `DAGValidator` unchanged. It should continue to reject genuinely disconnected graphs.
+
+## Acceptance Criteria
+
+- [ ] `Create comprehensive documentation` classifies as `document`.
+- [ ] `document -> validate` creates a sequential dependency when represented as ordered task sentences.
+- [ ] `analyze -> document -> create -> validate` creates a connected sequential graph.
+- [ ] Existing disconnected-node validation behavior remains intact.
+- [ ] `npm run build` passes.
+- [ ] `npm run test` passes.
+
+## Related Files
+
+- `src/core/task-graph/TaskGraphProcessor.ts`
+- `src/core/task-graph/DAGValidator.ts`
+- `tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts`
+- `tests/ts/unit/core/task-graph/DAGValidator.test.ts`
+- `docs/TYPE_DEFINITION.md`
+

--- a/local_config/pr-dag-validation-isolated-node.md
+++ b/local_config/pr-dag-validation-isolated-node.md
@@ -1,0 +1,93 @@
+# PR: Fix document follow-up DAG connectivity
+
+## Summary
+
+This PR fixes a TaskGraph construction regression where ordered multi-step requests could fail DAG validation with `DISCONNECTED_NODE` after a `document` task.
+
+The failure was caused by two gaps:
+
+- Documentation artifacts such as `create comprehensive documentation` could be classified as `create` instead of `document`.
+- `document` was treated as an absolute terminal type, so explicit follow-up tasks were disconnected from the prior workflow.
+
+`DAGValidator` is left unchanged. Its disconnected-node check is still correct; the graph builder now avoids producing a disconnected graph for explicitly ordered follow-up workflows.
+
+## Related Issue
+
+- Closes #
+
+## Change Type
+
+- [x] Bug fix
+- [ ] Feature
+- [x] Tests
+- [x] Docs
+- [ ] Refactor
+
+## Changes
+
+- `src/core/task-graph/TaskGraphProcessor.ts`
+  - Added a `document` pattern for `create/generate/draft/produce documentation/docs/readme/guide/docstring/comments`.
+  - Updated `FLOWS_TO.document` so explicit follow-up work can continue into `analyze`, `modify`, `validate`, `execute`, `create`, or `plan`.
+
+- `tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts`
+  - Added coverage for `Create comprehensive documentation -> document`.
+  - Updated `document -> validate` expectation to sequential.
+  - Added regression coverage for `analyze -> document -> create -> validate`.
+
+- `docs/TYPE_DEFINITION.md`
+  - Clarified that `document` is typically terminal, but explicitly ordered follow-up work can continue the workflow.
+
+## Before
+
+```text
+Analyze the entire codebase
+create a comprehensive documentation with examples
+implement all suggested improvements
+validate everything
+```
+
+Could produce a partially connected graph:
+
+```text
+t1 analyze -> t2 document
+t3 create
+t4 validate
+```
+
+`DAGValidator` then rejected `t3` as disconnected.
+
+## After
+
+The same ordered workflow produces a connected graph:
+
+```text
+t1 analyze -> t2 document -> t3 create -> t4 validate
+```
+
+## Validation
+
+- [x] `npm run build`
+- [x] `npm run test -- tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts tests/ts/unit/core/task-graph/DAGValidator.test.ts`
+- [x] `npm run test`
+
+Full test result:
+
+```text
+Test Files  37 passed | 1 skipped (38)
+Tests       321 passed | 1 skipped (322)
+```
+
+## Risk / Notes
+
+- This changes the old assumption that `document` always terminates dependency flow.
+- The updated behavior is intentionally limited to graph construction for ordered task sentences.
+- Genuine disconnected graphs are still rejected by `DAGValidator`.
+
+## Files Changed
+
+```text
+docs/TYPE_DEFINITION.md
+src/core/task-graph/TaskGraphProcessor.ts
+tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts
+```
+

--- a/local_config/pr-dag-validation-isolated-node.md
+++ b/local_config/pr-dag-validation-isolated-node.md
@@ -1,43 +1,43 @@
-# PR: Fix document follow-up DAG connectivity
+# PR: 문서화 후속 작업의 DAG 연결성 수정
 
-## Summary
+## 요약
 
-This PR fixes a TaskGraph construction regression where ordered multi-step requests could fail DAG validation with `DISCONNECTED_NODE` after a `document` task.
+이 PR은 순서가 있는 다중 작업 요청에서 `document` 작업 이후 DAG 검증이 `DISCONNECTED_NODE`로 실패할 수 있는 TaskGraph 생성 회귀를 수정합니다.
 
-The failure was caused by two gaps:
+실패 원인은 두 가지입니다.
 
-- Documentation artifacts such as `create comprehensive documentation` could be classified as `create` instead of `document`.
-- `document` was treated as an absolute terminal type, so explicit follow-up tasks were disconnected from the prior workflow.
+- `create comprehensive documentation` 같은 문서 산출물이 `document`가 아니라 `create`로 분류될 수 있었습니다.
+- `document`가 절대적인 종료 타입으로 처리되어, 명시적 후속 작업이 이전 workflow에서 끊겼습니다.
 
-`DAGValidator` is left unchanged. Its disconnected-node check is still correct; the graph builder now avoids producing a disconnected graph for explicitly ordered follow-up workflows.
+`DAGValidator`는 변경하지 않았습니다. disconnected-node 검사는 올바른 동작이며, 이번 수정은 graph builder가 명시적으로 순서가 있는 후속 작업에 대해 끊어진 그래프를 만들지 않도록 하는 것입니다.
 
-## Related Issue
+## 관련 이슈
 
 - Closes #
 
-## Change Type
+## 변경 유형
 
-- [x] Bug fix
-- [ ] Feature
-- [x] Tests
-- [x] Docs
-- [ ] Refactor
+- [x] 버그 수정
+- [ ] 기능 추가
+- [x] 테스트
+- [x] 문서
+- [ ] 리팩터링
 
-## Changes
+## 변경 사항
 
 - `src/core/task-graph/TaskGraphProcessor.ts`
-  - Added a `document` pattern for `create/generate/draft/produce documentation/docs/readme/guide/docstring/comments`.
-  - Updated `FLOWS_TO.document` so explicit follow-up work can continue into `analyze`, `modify`, `validate`, `execute`, `create`, or `plan`.
+  - `create/generate/draft/produce documentation/docs/readme/guide/docstring/comments` 표현을 `document`로 분류하는 패턴을 추가했습니다.
+  - `FLOWS_TO.document`를 업데이트해 명시적 후속 작업이 `analyze`, `modify`, `validate`, `execute`, `create`, `plan`으로 이어질 수 있게 했습니다.
 
 - `tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts`
-  - Added coverage for `Create comprehensive documentation -> document`.
-  - Updated `document -> validate` expectation to sequential.
-  - Added regression coverage for `analyze -> document -> create -> validate`.
+  - `Create comprehensive documentation -> document` 분류 테스트를 추가했습니다.
+  - `document -> validate` 기대값을 순차 의존성으로 갱신했습니다.
+  - `analyze -> document -> create -> validate` 회귀 테스트를 추가했습니다.
 
 - `docs/TYPE_DEFINITION.md`
-  - Clarified that `document` is typically terminal, but explicitly ordered follow-up work can continue the workflow.
+  - `document`는 보통 종료 단계지만, 명시적으로 순서가 있는 후속 작업은 workflow를 이어갈 수 있다고 설명을 보강했습니다.
 
-## Before
+## 수정 전
 
 ```text
 Analyze the entire codebase
@@ -46,7 +46,7 @@ implement all suggested improvements
 validate everything
 ```
 
-Could produce a partially connected graph:
+부분적으로만 연결된 그래프가 만들어질 수 있었습니다.
 
 ```text
 t1 analyze -> t2 document
@@ -54,36 +54,36 @@ t3 create
 t4 validate
 ```
 
-`DAGValidator` then rejected `t3` as disconnected.
+이후 `DAGValidator`가 `t3`를 고립 노드로 판단해 거부했습니다.
 
-## After
+## 수정 후
 
-The same ordered workflow produces a connected graph:
+같은 순서 있는 workflow가 하나의 연결된 그래프로 생성됩니다.
 
 ```text
 t1 analyze -> t2 document -> t3 create -> t4 validate
 ```
 
-## Validation
+## 검증
 
 - [x] `npm run build`
 - [x] `npm run test -- tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts tests/ts/unit/core/task-graph/DAGValidator.test.ts`
 - [x] `npm run test`
 
-Full test result:
+전체 테스트 결과:
 
 ```text
 Test Files  37 passed | 1 skipped (38)
 Tests       321 passed | 1 skipped (322)
 ```
 
-## Risk / Notes
+## 리스크 / 참고 사항
 
-- This changes the old assumption that `document` always terminates dependency flow.
-- The updated behavior is intentionally limited to graph construction for ordered task sentences.
-- Genuine disconnected graphs are still rejected by `DAGValidator`.
+- 기존의 `document`는 항상 dependency flow를 종료한다는 가정이 바뀝니다.
+- 변경된 동작은 순서 있는 작업 문장으로부터 그래프를 생성하는 경우에 초점을 둡니다.
+- 실제로 끊어진 그래프는 여전히 `DAGValidator`가 거부합니다.
 
-## Files Changed
+## 변경 파일
 
 ```text
 docs/TYPE_DEFINITION.md

--- a/src/core/task-graph/TaskGraphProcessor.ts
+++ b/src/core/task-graph/TaskGraphProcessor.ts
@@ -47,8 +47,9 @@ export class TaskGraphProcessor {
   ];
 
   // Dependency transitions should stay aligned with docs/TYPE_DEFINITION.md.
-  // In particular, explore means discovery, analyze means interpretation,
-  // and document is typically treated as a terminal stage.
+  // In particular, explore means discovery, analyze means interpretation.
+  // Document is often terminal, but an explicit follow-up action can still
+  // continue the user's ordered workflow.
   private static readonly TYPE_PATTERNS: ReadonlyArray<{
     type: RequestCategory;
     patterns: readonly RegExp[];
@@ -69,6 +70,7 @@ export class TaskGraphProcessor {
     {
       type: "document",
       patterns: [
+        /\b(create|generate|draft|produce)\s+(a\s+|an\s+|the\s+)?(comprehensive\s+)?(documentation|docs|readme|guide|docstring|comment[s]?)\b/,
         /\b(write|update|add)\s+(the\s+)?(documentation|docs|readme|guide|docstring|comment[s]?)\b/,
         /\b(write|prepare)\s+(a\s+)?(summary|overview|note[s]?|guide)\b/,
         /\bdocument\b.*\b(api|module|system|workflow|changes?)\b/,
@@ -175,7 +177,7 @@ export class TaskGraphProcessor {
     modify:   ["analyze", "validate", "document", "execute"],
     validate: ["explore", "analyze", "document", "execute", "modify"],
     execute:  ["explore", "analyze", "validate", "document", "plan", "create"],
-    document: [],
+    document: ["analyze", "modify", "validate", "execute", "create", "plan"],
   };
 
   /**

--- a/tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts
+++ b/tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts
@@ -79,6 +79,7 @@ describe("TaskGraphProcessor", () => {
       ["Write the README",                 "document", "readme"],
       ["Prepare a summary",                "document", "summary"],
       ["Update the docs",                  "document", "update docs"],
+      ["Create comprehensive documentation","document","create documentation"],
       ["Plan the architecture",            "plan",     "plan"],
       ["Break down the migration steps",   "plan",     "break down"],
       ["Outline the rollout approach",     "plan",     "outline/approach"],
@@ -226,7 +227,7 @@ describe("TaskGraphProcessor", () => {
       expect(result.tasks[1]!.depends_on).toEqual([]);
     });
 
-    it("document → 어떤 type이든 독립 처리된다 (FLOWS_TO[document] = [])", () => {
+    it("document → validate 흐름은 sequential이다", () => {
       const result = TaskGraphProcessor.process({
         sentences: [
           "Document the API",        // document
@@ -234,7 +235,29 @@ describe("TaskGraphProcessor", () => {
         ],
       });
 
-      expect(result.tasks[1]!.depends_on).toEqual([]);
+      expect(result.tasks[1]!.depends_on).toEqual(["t1"]);
+    });
+
+    it("analyze → document → create → validate follow-up workflow는 sequential이다", () => {
+      const result = TaskGraphProcessor.process({
+        sentences: [
+          "Analyze the entire codebase",
+          "create a comprehensive documentation with examples",
+          "implement all suggested improvements",
+          "validate everything",
+        ],
+      });
+
+      expect(result.tasks.map((task) => task.type)).toEqual([
+        "analyze",
+        "document",
+        "create",
+        "validate",
+      ]);
+      expect(result.tasks[0]!.depends_on).toEqual([]);
+      expect(result.tasks[1]!.depends_on).toEqual(["t1"]);
+      expect(result.tasks[2]!.depends_on).toEqual(["t2"]);
+      expect(result.tasks[3]!.depends_on).toEqual(["t3"]);
     });
   });
 });


### PR DESCRIPTION
# PR: 문서화 후속 작업의 DAG 연결성 수정

## 요약

이 PR은 순서가 있는 다중 작업 요청에서 `document` 작업 이후 DAG 검증이 `DISCONNECTED_NODE`로 실패할 수 있는 TaskGraph 생성 회귀를 수정합니다.

실패 원인은 두 가지입니다.

- `create comprehensive documentation` 같은 문서 산출물이 `document`가 아니라 `create`로 분류될 수 있었습니다.
- `document`가 절대적인 종료 타입으로 처리되어, 명시적 후속 작업이 이전 workflow에서 끊겼습니다.

`DAGValidator`는 변경하지 않았습니다. disconnected-node 검사는 올바른 동작이며, 이번 수정은 graph builder가 명시적으로 순서가 있는 후속 작업에 대해 끊어진 그래프를 만들지 않도록 하는 것입니다.

## 관련 이슈

- Closes #144 

## 변경 유형

- [x] 버그 수정
- [ ] 기능 추가
- [x] 테스트
- [x] 문서
- [ ] 리팩터링

## 변경 사항

- `src/core/task-graph/TaskGraphProcessor.ts`
  - `create/generate/draft/produce documentation/docs/readme/guide/docstring/comments` 표현을 `document`로 분류하는 패턴을 추가했습니다.
  - `FLOWS_TO.document`를 업데이트해 명시적 후속 작업이 `analyze`, `modify`, `validate`, `execute`, `create`, `plan`으로 이어질 수 있게 했습니다.

- `tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts`
  - `Create comprehensive documentation -> document` 분류 테스트를 추가했습니다.
  - `document -> validate` 기대값을 순차 의존성으로 갱신했습니다.
  - `analyze -> document -> create -> validate` 회귀 테스트를 추가했습니다.

- `docs/TYPE_DEFINITION.md`
  - `document`는 보통 종료 단계지만, 명시적으로 순서가 있는 후속 작업은 workflow를 이어갈 수 있다고 설명을 보강했습니다.

## 수정 전

```text
Analyze the entire codebase
create a comprehensive documentation with examples
implement all suggested improvements
validate everything
```

부분적으로만 연결된 그래프가 만들어질 수 있었습니다.

```text
t1 analyze -> t2 document
t3 create
t4 validate
```

이후 `DAGValidator`가 `t3`를 고립 노드로 판단해 거부했습니다.

## 수정 후

같은 순서 있는 workflow가 하나의 연결된 그래프로 생성됩니다.

```text
t1 analyze -> t2 document -> t3 create -> t4 validate
```

## 검증

- [x] `npm run build`
- [x] `npm run test -- tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts tests/ts/unit/core/task-graph/DAGValidator.test.ts`
- [x] `npm run test`

전체 테스트 결과:

```text
Test Files  37 passed | 1 skipped (38)
Tests       321 passed | 1 skipped (322)
```

## 리스크 / 참고 사항

- 기존의 `document`는 항상 dependency flow를 종료한다는 가정이 바뀝니다.
- 변경된 동작은 순서 있는 작업 문장으로부터 그래프를 생성하는 경우에 초점을 둡니다.
- 실제로 끊어진 그래프는 여전히 `DAGValidator`가 거부합니다.

## 변경 파일

```text
docs/TYPE_DEFINITION.md
src/core/task-graph/TaskGraphProcessor.ts
tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts
```

