### PR TITLE
Add task type persistence and documentation notes

### DIFF
--- a/local_config/issue-task-type-persistence-phase-7-4.md
+++ b/local_config/issue-task-type-persistence-phase-7-4.md
@@ -1,0 +1,91 @@
+# Issue: Orchestrator 실행 결과에 task type이 저장되지 않음
+
+## 요약
+
+Phase 7.1-7.3에서 `ExecutionResult`와 session state 계층은 `type` 필드를 받을 수 있게 준비되었지만, Orchestrator가 실제 task 실행 결과를 저장할 때 `task.type`을 넘기지 않아 `.state/sessions/*.json`의 `task_results`에 type 정보가 남지 않습니다.
+
+이로 인해 Role 2.1에서 분류한 작업 타입이 Role 2.2의 session persistence까지 이어지지 않습니다.
+
+## 현재 동작
+
+`src/core/pipeline/orchestrator.ts`의 상태 갱신 함수는 실행 결과를 저장하지만 `type`을 포함하지 않습니다.
+
+```ts
+function markTaskCompleted(
+  state: SessionState,
+  taskId: string,
+  rawOutput: string,
+): SessionState
+```
+
+```ts
+function markTaskFailed(
+  state: SessionState,
+  taskId: string,
+  rawOutput: string,
+): SessionState
+```
+
+저장되는 `task_results` 예시:
+
+```json
+{
+  "t1": {
+    "task_id": "t1",
+    "success": true,
+    "summary": "...",
+    "raw_output": "..."
+  }
+}
+```
+
+## 문제점
+
+- `TaskGraphProcessor`가 만든 `task.type`이 실행 결과에 반영되지 않습니다.
+- 실패한 task와 dependency 실패로 skip된 task도 타입 정보를 잃습니다.
+- Session file만 보면 각 task가 `analyze`, `create`, `validate` 중 어떤 타입이었는지 알 수 없습니다.
+- Phase 7.1-7.3에서 준비된 `ExecutionResultSchema.type`과 normalizer 흐름이 실제 Orchestrator 경로에서 완성되지 않습니다.
+
+## 기대 동작
+
+성공, 실패, dependency skip 모든 경로에서 `task_results[*].type`이 저장되어야 합니다.
+
+```json
+{
+  "t1": {
+    "task_id": "t1",
+    "success": true,
+    "summary": "Analyzed the codebase",
+    "raw_output": "...",
+    "type": "analyze"
+  }
+}
+```
+
+## 수정 방향
+
+1. `markTaskCompleted()`에 선택적 `taskType` 파라미터를 추가합니다.
+2. `markTaskFailed()`에 선택적 `taskType` 파라미터를 추가합니다.
+3. 다음 세 경로에서 `task.type`을 전달합니다.
+   - task 성공
+   - task 실패
+   - dependency 실패로 인한 skip
+4. `PipelineTracer`의 `ExecutionResult` trace에도 `type`을 포함합니다.
+5. 성공/실패/skip 경로에 대한 단위 테스트를 추가합니다.
+
+## 완료 조건
+
+- [ ] 성공한 task의 session `task_results[*].type`이 저장된다.
+- [ ] 실패한 task의 session `task_results[*].type`이 저장된다.
+- [ ] dependency 실패로 skip된 task의 session `task_results[*].type`이 저장된다.
+- [ ] `PipelineTracer`의 `ExecutionResult` 출력에 `type`이 포함된다.
+- [ ] `npm run build`가 통과한다.
+- [ ] `npm run test`가 통과한다.
+
+## 관련 파일
+
+- `src/core/pipeline/orchestrator.ts`
+- `tests/ts/unit/core/pipeline/orchestrator.test.ts`
+- `src/schemas/pipeline.ts`
+- `src/core/state/SessionStateManager.ts`
+

--- a/local_config/pr-task-type-persistence-phase-7-4.md
+++ b/local_config/pr-task-type-persistence-phase-7-4.md
@@ -1,0 +1,102 @@
+# PR: Orchestrator 실행 결과에 task type 저장
+
+## 요약
+
+이 PR은 Phase 7.4 작업으로, Role 2.1에서 생성한 `task.type`이 Orchestrator 실행 결과를 거쳐 session state의 `task_results`에 저장되도록 합니다.
+
+Phase 7.1-7.3에서 schema와 state persistence 계층은 `type` 필드를 수용할 수 있게 준비되어 있었습니다. 이번 변경은 Orchestrator가 성공, 실패, dependency skip 경로에서 실제 `task.type`을 전달하도록 해 Task Type Persistence 흐름을 완성합니다.
+
+```text
+task.type -> ExecutionResult/TaskResult -> SessionState -> Session File
+```
+
+## 관련 이슈
+
+- Closes #
+
+## 변경 유형
+
+- [x] 기능 추가
+- [x] 버그 수정
+- [x] 테스트
+- [ ] 문서
+- [ ] 리팩터링
+
+## 변경 사항
+
+- `src/core/pipeline/orchestrator.ts`
+  - `markTaskCompleted()`에 `taskType?: RequestCategory` 파라미터를 추가했습니다.
+  - `markTaskFailed()`에 `taskType?: RequestCategory` 파라미터를 추가했습니다.
+  - 성공 경로에서 `markTaskCompleted(..., task.type)`을 호출합니다.
+  - 실패 경로에서 `markTaskFailed(..., task.type)`을 호출합니다.
+  - dependency 실패로 skip되는 경로에서도 `markTaskFailed(..., task.type)`을 호출합니다.
+  - `PipelineTracer.trace()`의 `ExecutionResult` data에 `type: task.type`을 포함했습니다.
+
+- `tests/ts/unit/core/pipeline/orchestrator.test.ts`
+  - 성공한 task의 `type`이 session state에 저장되는지 검증합니다.
+  - 실패한 task의 `type`이 session state에 저장되는지 검증합니다.
+  - dependency 실패로 skip된 task의 `type`이 session state에 저장되는지 검증합니다.
+
+## 수정 전
+
+session file의 `task_results`에는 실행 성공 여부와 출력만 저장되고 타입 정보가 빠졌습니다.
+
+```json
+{
+  "task_results": {
+    "t1": {
+      "task_id": "t1",
+      "success": true,
+      "summary": "...",
+      "raw_output": "..."
+    }
+  }
+}
+```
+
+## 수정 후
+
+각 task result에 Role 2.1에서 분류한 type이 함께 저장됩니다.
+
+```json
+{
+  "task_results": {
+    "t1": {
+      "task_id": "t1",
+      "success": true,
+      "summary": "...",
+      "raw_output": "...",
+      "type": "analyze"
+    }
+  }
+}
+```
+
+실패 또는 skip된 task도 동일하게 `type`을 보존합니다.
+
+## 검증
+
+- [x] `npm run build`
+- [x] `npm run test -- tests/ts/unit/core/pipeline/orchestrator.test.ts`
+- [x] `npm run test`
+
+전체 테스트 결과:
+
+```text
+Test Files  37 passed | 1 skipped (38)
+Tests       323 passed | 1 skipped (324)
+```
+
+## 리스크 / 참고 사항
+
+- `taskType` 파라미터는 optional로 추가해 기존 호출 형태와 호환되게 했습니다.
+- `type` 값은 `RequestCategory`로 제한되며 기존 `TaskSchema.type`과 동일한 enum을 사용합니다.
+- 기존 session 파일 중 type이 없는 task result도 schema상 계속 허용됩니다.
+
+## 변경 파일
+
+```text
+src/core/pipeline/orchestrator.ts
+tests/ts/unit/core/pipeline/orchestrator.test.ts
+```
+

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -10,7 +10,7 @@ import { SessionStateManager } from "../state/SessionStateManager.js";
 import { executeWithAdapter } from "../executor/execute.js";
 import { logger } from "../utils/logger.js";
 import { PipelineTracer } from "../utils/PipelineTracer.js";
-import type { SessionState, TaskGraph, TaskResult } from "../../schemas/pipeline.js";
+import type { RequestCategory, SessionState, TaskGraph, TaskResult } from "../../schemas/pipeline.js";
 import type {
   PipelineExecutionRequest,
   PipelineExecutionResult,
@@ -140,6 +140,7 @@ function markTaskCompleted(
   state: SessionState,
   taskId: string,
   rawOutput: string,
+  taskType?: RequestCategory,
 ): SessionState {
   return {
     ...state,
@@ -152,6 +153,7 @@ function markTaskCompleted(
         success: true,
         summary: rawOutput.slice(0, 200),
         raw_output: rawOutput,
+        ...(taskType ? { type: taskType } : {}),
       },
     },
     updated_at: new Date().toISOString(),
@@ -162,6 +164,7 @@ function markTaskFailed(
   state: SessionState,
   taskId: string,
   rawOutput: string,
+  taskType?: RequestCategory,
 ): SessionState {
   return {
     ...state,
@@ -173,6 +176,7 @@ function markTaskFailed(
         success: false,
         summary: rawOutput.slice(0, 200),
         raw_output: rawOutput,
+        ...(taskType ? { type: taskType } : {}),
       },
     },
     updated_at: new Date().toISOString(),
@@ -486,7 +490,7 @@ export const orchestratePipeline = async (
       if (blockedBy) {
         failedTaskIds.add(task.id);
         const rawOutput = `Skipped because dependency [${blockedBy}] failed`;
-        state = markTaskFailed(state, task.id, rawOutput);
+        state = markTaskFailed(state, task.id, rawOutput, task.type);
         state = {
           ...state,
           shared_context: {
@@ -534,12 +538,12 @@ export const orchestratePipeline = async (
       if (!execResult.ok) {
         // 실패 — Strict 모드에 따라 후속 의존 Task도 차단됨
         failedTaskIds.add(task.id);
-        state = markTaskFailed(state, task.id, execResult.rawOutput);
+        state = markTaskFailed(state, task.id, execResult.rawOutput, task.type);
         await SessionStateManager.saveSession(state);
         taskRecords.push({ taskId: task.id, status: "failed", rawOutput: execResult.rawOutput });
         await PipelineTracer.trace({
           sessionId, stage: `Executor:${task.id}`, role: "role3", phase: "output",
-          dataType: "ExecutionResult", data: { task_id: task.id, success: false, raw_output: execResult.rawOutput },
+          dataType: "ExecutionResult", data: { task_id: task.id, type: task.type, success: false, raw_output: execResult.rawOutput },
           durationMs: PipelineTracer.endStage(`Executor:${task.id}`),
         });
         logger.error(`Task [${task.id}] failed (exit ${execResult.exitCode}) — dependent tasks will be skipped`);
@@ -547,11 +551,11 @@ export const orchestratePipeline = async (
         // 성공 — 세션 상태 갱신 및 저장 (Role 2.2)
         await PipelineTracer.trace({
           sessionId, stage: `Executor:${task.id}`, role: "role3", phase: "output",
-          dataType: "ExecutionResult", data: { task_id: task.id, success: true, raw_output: execResult.rawOutput },
+          dataType: "ExecutionResult", data: { task_id: task.id, type: task.type, success: true, raw_output: execResult.rawOutput },
           durationMs: PipelineTracer.endStage(`Executor:${task.id}`),
         });
         failedTaskIds.delete(task.id);
-        state = markTaskCompleted(state, task.id, execResult.rawOutput);
+        state = markTaskCompleted(state, task.id, execResult.rawOutput, task.type);
         await SessionStateManager.saveSession(state);
         taskRecords.push({ taskId: task.id, status: "completed", rawOutput: execResult.rawOutput });
         logger.info(`Task [${task.id}] completed`);

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -82,6 +82,81 @@ describe("orchestratePipeline", () => {
     );
   });
 
+  it("persists task type when a task completes successfully", async () => {
+    const saveSessionSpy = vi
+      .spyOn(SessionStateManager, "saveSession")
+      .mockResolvedValue(undefined);
+
+    const result = await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "stub",
+      verbose: false,
+      userRequest: {
+        raw_input: "Analyze the codebase",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(saveSessionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task_results: expect.objectContaining({
+          t1: expect.objectContaining({
+            task_id: "t1",
+            success: true,
+            type: "analyze",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("persists task type when a task fails or is skipped by dependency failure", async () => {
+    const saveSessionSpy = vi
+      .spyOn(SessionStateManager, "saveSession")
+      .mockResolvedValue(undefined);
+    executeWithAdapterMock.mockResolvedValueOnce({
+      ok: false,
+      adapter: "codex",
+      rawOutput: "[mock-failure] t1",
+      exitCode: 1,
+    });
+
+    const result = await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "stub",
+      verbose: false,
+      userRequest: {
+        raw_input: "Find the auth module. Test the auth module.",
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(saveSessionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task_results: expect.objectContaining({
+          t1: expect.objectContaining({
+            task_id: "t1",
+            success: false,
+            type: "explore",
+          }),
+        }),
+      }),
+    );
+    expect(saveSessionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task_results: expect.objectContaining({
+          t2: expect.objectContaining({
+            task_id: "t2",
+            success: false,
+            type: "validate",
+          }),
+        }),
+      }),
+    );
+  });
+
   it("returns a structured failure when prompt compilation cannot start translation", async () => {
     const result = await orchestratePipeline({
       mode: "run",


### PR DESCRIPTION
## 요약
  - 무엇을 변경했나요?
  - 왜 이 변경이 필요한가요?

  ## 관련 이슈
  - Closes #146 

## 요약

이 PR은 Phase 7.4 작업으로, Role 2.1에서 생성한 `task.type`이 Orchestrator 실행 결과를 거쳐 session state의 `task_results`에 저장되도록 합니다.

Phase 7.1-7.3에서 schema와 state persistence 계층은 `type` 필드를 수용할 수 있게 준비되어 있었습니다. 이번 변경은 Orchestrator가 성공, 실패, dependency skip 경로에서 실제 `task.type`을 전달하도록 해 Task Type Persistence 흐름을 완성합니다.

```text
task.type -> ExecutionResult/TaskResult -> SessionState -> Session File
```

## 관련 이슈

- Closes #

## 변경 유형

- [x] 기능 추가
- [x] 버그 수정
- [x] 테스트
- [ ] 문서
- [ ] 리팩터링

## 변경 사항

- `src/core/pipeline/orchestrator.ts`
  - `markTaskCompleted()`에 `taskType?: RequestCategory` 파라미터를 추가했습니다.
  - `markTaskFailed()`에 `taskType?: RequestCategory` 파라미터를 추가했습니다.
  - 성공 경로에서 `markTaskCompleted(..., task.type)`을 호출합니다.
  - 실패 경로에서 `markTaskFailed(..., task.type)`을 호출합니다.
  - dependency 실패로 skip되는 경로에서도 `markTaskFailed(..., task.type)`을 호출합니다.
  - `PipelineTracer.trace()`의 `ExecutionResult` data에 `type: task.type`을 포함했습니다.

- `tests/ts/unit/core/pipeline/orchestrator.test.ts`
  - 성공한 task의 `type`이 session state에 저장되는지 검증합니다.
  - 실패한 task의 `type`이 session state에 저장되는지 검증합니다.
  - dependency 실패로 skip된 task의 `type`이 session state에 저장되는지 검증합니다.

## 수정 전

session file의 `task_results`에는 실행 성공 여부와 출력만 저장되고 타입 정보가 빠졌습니다.

```json
{
  "task_results": {
    "t1": {
      "task_id": "t1",
      "success": true,
      "summary": "...",
      "raw_output": "..."
    }
  }
}
```

## 수정 후

각 task result에 Role 2.1에서 분류한 type이 함께 저장됩니다.

```json
{
  "task_results": {
    "t1": {
      "task_id": "t1",
      "success": true,
      "summary": "...",
      "raw_output": "...",
      "type": "analyze"
    }
  }
}
```

실패 또는 skip된 task도 동일하게 `type`을 보존합니다.

## 검증

- [x] `npm run build`
- [x] `npm run test -- tests/ts/unit/core/pipeline/orchestrator.test.ts`
- [x] `npm run test`

전체 테스트 결과:

```text
Test Files  37 passed | 1 skipped (38)
Tests       323 passed | 1 skipped (324)
```

## 리스크 / 참고 사항

- `taskType` 파라미터는 optional로 추가해 기존 호출 형태와 호환되게 했습니다.
- `type` 값은 `RequestCategory`로 제한되며 기존 `TaskSchema.type`과 동일한 enum을 사용합니다.
- 기존 session 파일 중 type이 없는 task result도 schema상 계속 허용됩니다.

## 변경 파일

```text
src/core/pipeline/orchestrator.ts
tests/ts/unit/core/pipeline/orchestrator.test.ts
```



  ## 변경 유형p
  - [ ] 기능 추가
  - [ ] 버그 수정
  - [ ] 리팩터링
  - [ ] 문서 수정
  - [ ] 테스트 추가/수정

  ## 영향 범위
  - 영향받는 모듈:
  - 영향받지 않는 모듈:

  ## 테스트 방법
  1.
  2.
  3.

  ## 체크리스트
  - [ ] 로컬에서 테스트했습니다
  - [ ] 필요한 경우 테스트를 추가하거나 수정했습니다
  - [ ] 필요한 경우 문서를 수정했습니다
  - [ ] 브레이킹 체인지 여부를 확인했습니다
  - [ ] 리뷰하기 좋은 크기로 PR을 유지했습니다

  ## 스크린샷 / 로그
  <!-- 필요한 경우 스크린샷, 터미널 출력, 로그 등을 첨부하세요 -->

  ## 리뷰어 참고사항
  <!-- 리뷰어가 특히 봐야 할 부분이나 참고해야 할 내용을 적어주세요 -->