### PR TITLE
Fix Codex adapter execution and document WSL Ubuntu setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,39 @@ npm run add:py:dev -- <package>
 - Python 의존성 추가는 `uv`가 설치되어 있어야 합니다.
 - TypeScript 팀원은 기존 `npm i`, `npm install -D`, `npm install`을 그대로 사용합니다.
 - Python 팀원만 `npm run add:py*` 또는 `uv add` 계열을 사용합니다.
+
+---
+
+## Windows: WSL Ubuntu 실행
+
+Windows native 실행은 지원하지 않는다. Windows 사용자는 WSL Ubuntu에서 실행한다.
+
+### 1. 최초 1회
+
+```powershell
+winget install llama.cpp
+wsl.exe -e bash -lc "curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash"
+wsl.exe -e bash -lc ". ~/.nvm/nvm.sh && nvm install v24.15.0 && nvm alias default v24.15.0"
+wsl.exe -e bash -lc "cd /mnt/c/detoks && . ~/.nvm/nvm.sh && nvm use v24.15.0 >/dev/null && npm install"
+```
+
+### 2. 실행
+
+```powershell
+$LLAMA_SERVER = (Get-Command llama-server).Source
+Start-Process -FilePath $LLAMA_SERVER -ArgumentList @("-hf","mradermacher/gemma-4-E2B-it-heretic-ara-GGUF:Q4_K_S","--hf-file","gemma-4-E2B-it-heretic-ara.Q4_K_S.gguf","--alias","gemma-4-E2B-it-heretic-ara-GGUF","--host","0.0.0.0","--port","12371","--gpu-layers","all","--ctx-size","4096","--reasoning","off") -WindowStyle Hidden
+$WSL_HOST = wsl.exe -e bash -lc "ip route | awk '/default/ {print `$3; exit}'"
+wsl.exe -e bash -lc "cd /mnt/c/detoks && . ~/.nvm/nvm.sh && nvm use v24.15.0 >/dev/null && LOCAL_LLM_API_BASE=http://$WSL_HOST:12371/v1 LOCAL_LLM_AUTO_START=0 npm run cli -- '사용자 프롬프트 입력' --execution-mode real --verbose --trace"
+```
+
+변경 파일 확인:
+
+```powershell
+wsl.exe -e bash -lc "cd /mnt/c/detoks && git status --short"
+```
+
+### 문제 확인
+
+- `bash: --execution-mode: command not found`: 명령을 한 줄로 실행한다.
+- `esbuild for another platform`: WSL에서 `npm install`을 다시 실행한다.
+- `curl: Failed to connect`: `llama-server` 실행 여부를 확인한다.

--- a/src/integrations/adapters/codex/adapter.ts
+++ b/src/integrations/adapters/codex/adapter.ts
@@ -9,7 +9,15 @@ export class CodexStubAdapter implements CliAdapter {
   buildSubprocessRequest(request: AdapterExecutionRequest) {
     return {
       command: "codex",
-      args: [],
+      args: [
+        "exec",
+        "-",
+        "--sandbox",
+        "workspace-write",
+        "--skip-git-repo-check",
+        "--color",
+        "never",
+      ],
       ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
       input: request.prompt,
     };

--- a/src/integrations/adapters/real.ts
+++ b/src/integrations/adapters/real.ts
@@ -14,7 +14,7 @@ export const executeAdapterViaSubprocess = async (
 
   return {
     success: !result.timedOut && result.exitCode === 0,
-    rawOutput: result.stdout,
+    rawOutput: result.stdout || result.stderr,
     exitCode: result.exitCode,
     ...(result.stderr.length > 0 ? { stderr: result.stderr } : {}),
   };

--- a/tests/ts/unit/integrations/adapters/adapter-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/adapter-path.test.ts
@@ -15,7 +15,15 @@ describe("adapter subprocess path", () => {
       }),
     ).toEqual({
       command: "codex",
-      args: [],
+      args: [
+        "exec",
+        "-",
+        "--sandbox",
+        "workspace-write",
+        "--skip-git-repo-check",
+        "--color",
+        "never",
+      ],
       input: "hello codex",
     });
   });
@@ -53,7 +61,9 @@ describe("adapter subprocess path", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.rawOutput).toBe("[stub:subprocess] codex");
+    expect(result.rawOutput).toBe(
+      "[stub:subprocess] codex exec - --sandbox workspace-write --skip-git-repo-check --color never",
+    );
     expect(result.exitCode).toBe(0);
   });
 });

--- a/tests/ts/unit/integrations/adapters/real-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/real-path.test.ts
@@ -39,7 +39,15 @@ describe("adapter execution modes", () => {
     expect(capturedRequests).toEqual([
       {
         command: "codex",
-        args: [],
+        args: [
+          "exec",
+          "-",
+          "--sandbox",
+          "workspace-write",
+          "--skip-git-repo-check",
+          "--color",
+          "never",
+        ],
         cwd: "/workspace",
         input: "real prompt",
       },


### PR DESCRIPTION
## 요약

- Windows native real mode를 지원 대상에서 제외하고 WSL Ubuntu 실행 경로를 README에 정리했습니다
- Codex real adapter가 interactive CLI 대신 `codex exec -` 비대화형 실행을 사용하도록 수정했습니다
- subprocess 실패 시 stdout이 비어 있으면 stderr를 raw output으로 반환하도록 보강했습니다

## 관련 이슈

- Closes #152 

## 변경 유형

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩터링
- [x] 문서 수정
- [x] 테스트 추가/수정

## 영향 범위

- 변경된 파일:
  - `src/integrations/adapters/codex/adapter.ts`  Codex real subprocess 요청을 `codex exec -` 기반으로 변경
  - `src/integrations/adapters/real.ts`  실패 시 stderr fallback을 raw output에 반영
  - `tests/ts/unit/integrations/adapters/adapter-path.test.ts`  Codex subprocess 요청 기대값 수정
  - `tests/ts/unit/integrations/adapters/real-path.test.ts`  real mode Codex 요청 검증 수정
  - `README.md`  Windows 사용자의 WSL Ubuntu 실행 절차 추가

## 수정 내용

### 1. Codex real adapter를 `codex exec -`로 변경

기존 real mode는 `codex` interactive CLI를 stdin으로 호출했습니다.
이 방식은 Windows npm shim 환경에서 안정적으로 실행되지 않고, WSL Ubuntu에서도 stdin pipe 입력 시 `stdin is not a terminal`로 실패할 수 있습니다.

**문제**: real mode adapter가 interactive CLI 경로를 subprocess로 호출

```ts
// Before
{
  command: "codex",
  args: [],
  input: request.prompt,
}
```

**수정**: Codex 공식 비대화형 실행 경로인 `codex exec -` 사용

```ts
// After
{
  command: "codex",
  args: [
    "exec",
    "-",
    "--sandbox",
    "workspace-write",
    "--skip-git-repo-check",
    "--color",
    "never",
  ],
  input: request.prompt,
}
```

| 실행 환경 | 수정 전 | 수정 후 |
|-----------|---------|---------|
| Windows native | npm shim 처리 문제 | 지원 대상 제외 |
| WSL Ubuntu + `codex` stdin | `stdin is not a terminal` 가능 | `codex exec -`로 실행 |
| macOS/Linux Codex CLI | interactive 호출 | 비대화형 `exec` 호출 |

### 2. subprocess 실패 출력 보강

실패한 subprocess가 stdout 없이 stderr만 반환하면 최종 task 결과의 `rawOutput`이 비어 원인 확인이 어려웠습니다.

**문제**: 실패 원인이 stderr에만 있는 경우 세션 상태와 trace에서 원인이 누락됨

```ts
// Before
rawOutput: result.stdout
```

**수정**: stdout이 비어 있으면 stderr를 raw output으로 사용

```ts
// After
rawOutput: result.stdout || result.stderr
```

이 변경으로 adapter 실패 시 `rawOutput`에도 실제 CLI 오류가 남습니다.

### 3. Windows WSL Ubuntu 실행 문서 추가

Windows native real mode는 지원하지 않는 것으로 정리하고, README에 WSL Ubuntu 기준 실행 절차를 추가했습니다.

문서에 포함한 항목:

```
최초 1회
- llama.cpp 설치
- WSL Node v24.15.0 설치
- WSL 기준 npm install

실행
- Windows llama-server 실행
- WSL에서 LOCAL_LLM_API_BASE 지정
- --execution-mode real 실행
```

## 테스트 방법

```bash
npm test -- tests/ts/unit/integrations/adapters/adapter-path.test.ts tests/ts/unit/integrations/adapters/real-path.test.ts
```

WSL Ubuntu에서 real mode smoke 실행:

```bash
npm run cli -- "say hello" --execution-mode real --verbose --trace
```

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] 필요한 경우 테스트를 추가하거나 수정했습니다
- [x] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 스크린샷 / 로그

```text
> detoks@0.1.0 test
> vitest run tests/ts/unit/integrations/adapters/adapter-path.test.ts tests/ts/unit/integrations/adapters/real-path.test.ts

 Test Files  2 passed (2)
      Tests  7 passed (7)
```

```text
summary: All 1 task(s) completed
rawOutput: hello
```

## 리뷰어 참고사항

- Windows native real mode는 지원 대상에서 제외했습니다. Windows 사용자는 WSL Ubuntu에서 실행해야 합니다.
- Codex CLI는 `codex exec`를 지원하는 버전이 필요합니다.
- Gemini adapter의 real mode 호출 방식은 변경하지 않았습니다.
- 실험 중 생성된 계산기 산출물은 제품 코드 변경이 아니므로 커밋하지 않았습니다.

