### PR TITLE
Enhance sentence splitting and implement execution adapter logic

### DIFF
--- a/src/core/task-graph/TaskSentenceSplitter.ts
+++ b/src/core/task-graph/TaskSentenceSplitter.ts
@@ -206,7 +206,10 @@ export class TaskSentenceSplitter {
     const expanded = text
       .replace(/(^|\n)\s*[-*•◦]\s+/g, "$1") // 글머리 기호 제거
       .replace(/(^|\n)\s*\d+[.)]\s+/g, "$1") // "1. " / "1) " 형태 번호 제거
-      .replace(/\s+(?=\d+[.)]\s+)/g, "\n"); // 번호 앞 공백을 줄바꿈으로 변환
+      .replace(/\s+(?=\d+[.)]\s+)/g, (match, offset, source) => {
+        const previous = source.slice(0, offset).trimEnd().at(-1);
+        return previous && /[+\-*/=]/.test(previous) ? match : "\n";
+      }); // 번호 앞 공백을 줄바꿈으로 변환하되 수식은 보존
 
     return expanded
       .split(/\n+/)

--- a/src/core/task-graph/TaskSentenceSplitter.ts
+++ b/src/core/task-graph/TaskSentenceSplitter.ts
@@ -211,6 +211,8 @@ export class TaskSentenceSplitter {
         const suffix = source.slice(offset + match.length);
         const previous = prefix.at(-1);
         return (previous && /[+\-*/=]/.test(previous)) ||
+          /\b(?:plus|minus|times|over)\s*$/i.test(prefix) ||
+          /\b(?:multiplied|divided)\s+by\s*$/i.test(prefix) ||
           /\d+[.)]$/.test(prefix) ||
           /^\d+[.)]\s+\d\b/.test(suffix)
           ? match
@@ -256,6 +258,10 @@ export class TaskSentenceSplitter {
       const normalized = this.stripLeadingConnector(next);
       const isConditionalClause =
         /^(?:if|unless|when|until|provided|assuming)\b/i.test(current.trim());
+      if (/^(?:first|second|third|fourth|fifth|next|then|finally)$/i.test(current.trim())) {
+        current = normalized;
+        continue;
+      }
       if (
         this.startsWithAction(normalized) &&
         !this.looksLikeDescriptiveFragment(normalized) &&

--- a/src/core/task-graph/TaskSentenceSplitter.ts
+++ b/src/core/task-graph/TaskSentenceSplitter.ts
@@ -127,13 +127,13 @@ const FOLLOW_UP_STARTERS = [
 
 // 문자열 앞부분이 액션 동사로 시작하는지 검사하는 정규식
 const ACTION_STARTER_REGEX = new RegExp(
-  `^(?:${ACTION_STARTERS.map(escapeRegex).join("|")})\\b`,
+  `^(?:${ACTION_STARTERS.map(escapeRegex).join("|")})(?=\\s|$)`,
   "i",
 );
 
 // 문자열 앞부분이 후속 액션 동사로 시작하는지 검사하는 정규식
 const FOLLOW_UP_STARTER_REGEX = new RegExp(
-  `^(?:${FOLLOW_UP_STARTERS.map(escapeRegex).join("|")})\\b`,
+  `^(?:${FOLLOW_UP_STARTERS.map(escapeRegex).join("|")})(?=\\s|$)`,
   "i",
 );
 
@@ -206,9 +206,15 @@ export class TaskSentenceSplitter {
     const expanded = text
       .replace(/(^|\n)\s*[-*•◦]\s+/g, "$1") // 글머리 기호 제거
       .replace(/(^|\n)\s*\d+[.)]\s+/g, "$1") // "1. " / "1) " 형태 번호 제거
-      .replace(/\s+(?=\d+[.)]\s+)/g, (match, offset, source) => {
-        const previous = source.slice(0, offset).trimEnd().at(-1);
-        return previous && /[+\-*/=]/.test(previous) ? match : "\n";
+      .replace(/\s+(?=\d+[.)]\s+[A-Z])/g, (match, offset, source) => {
+        const prefix = source.slice(0, offset).trimEnd();
+        const suffix = source.slice(offset + match.length);
+        const previous = prefix.at(-1);
+        return (previous && /[+\-*/=]/.test(previous)) ||
+          /\d+[.)]$/.test(prefix) ||
+          /^\d+[.)]\s+\d\b/.test(suffix)
+          ? match
+          : "\n";
       }); // 번호 앞 공백을 줄바꿈으로 변환하되 수식은 보존
 
     return expanded
@@ -221,7 +227,9 @@ export class TaskSentenceSplitter {
   private static splitSegment(segment: string): string[] {
     const sentenceParts = segment
       // 문장 종결 부호 뒤에 대문자/숫자가 오면 분리 (lookbehind/lookahead 사용)
-      .split(/(?<=[.!?;])\s+(?=[A-Z0-9])/)
+      .split(
+        /(?<!e\.g\.)(?<!i\.e\.)(?<!etc\.)(?<!vs\.)(?<=[.!?;])\s+(?=[A-Z])|(?<=[!?;])\s+(?=\d)/,
+      )
       .map((part) => part.trim())
       .filter(Boolean);
 
@@ -248,7 +256,11 @@ export class TaskSentenceSplitter {
       const normalized = this.stripLeadingConnector(next);
       const isConditionalClause =
         /^(?:if|unless|when|until|provided|assuming)\b/i.test(current.trim());
-      if (this.startsWithAction(normalized) && !isConditionalClause) {
+      if (
+        this.startsWithAction(normalized) &&
+        !this.looksLikeDescriptiveFragment(normalized) &&
+        !isConditionalClause
+      ) {
         results.push(current);
         current = normalized;
       } else {
@@ -322,6 +334,8 @@ export class TaskSentenceSplitter {
       return [this.cleanClause(segment)].filter(Boolean);
     if (!this.startsWithFollowUpAction(right))
       return [this.cleanClause(segment)].filter(Boolean);
+    if (this.looksLikeDescriptiveFragment(right))
+      return [this.cleanClause(segment)].filter(Boolean);
     // "find and add" 같은 compound verb 방지: left에 object(동사 외 단어)가 있어야 분리
     if (left.trim().split(/\s+/).length < 2)
       return [this.cleanClause(segment)].filter(Boolean);
@@ -359,6 +373,12 @@ export class TaskSentenceSplitter {
     return (
       FOLLOW_UP_STARTER_REGEX.test(trimmed) ||
       /^run\s+\w+\s+(?:test|tests)\b/i.test(trimmed)
+    );
+  }
+
+  private static looksLikeDescriptiveFragment(text: string): boolean {
+    return /^(?:test\s+data\b|run-?time\b|runtime\b|build\s+time\b|compile\s+time\b)/i.test(
+      text.trim(),
     );
   }
 }

--- a/src/integrations/adapters/real.ts
+++ b/src/integrations/adapters/real.ts
@@ -14,7 +14,7 @@ export const executeAdapterViaSubprocess = async (
 
   return {
     success: !result.timedOut && result.exitCode === 0,
-    rawOutput: result.stdout || result.stderr,
+    rawOutput: (!result.timedOut && result.exitCode === 0) ? result.stdout : (result.stdout || result.stderr),
     exitCode: result.exitCode,
     ...(result.stderr.length > 0 ? { stderr: result.stderr } : {}),
   };

--- a/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
+++ b/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
@@ -161,6 +161,24 @@ describe("TaskSentenceSplitter", () => {
     ]);
   });
 
+  it("does not treat arithmetic results as numbered-list items", () => {
+    const result = TaskSentenceSplitter.split("Create the result of 4 + 5. Also check it.");
+
+    expect(result.sentences).toEqual([
+      "Create the result of 4 + 5.",
+      "Also check it.",
+    ]);
+  });
+
+  it("preserves arithmetic expressions while splitting follow-up tasks", () => {
+    const result = TaskSentenceSplitter.split(
+      "Make a calculator with Python. First, make it so that only addition and subtraction are possible, and then create the result of 4 + 5. Also, check if it works correctly.",
+    );
+
+    expect(result.sentences).toContain("create the result of 4 + 5.");
+    expect(result.sentences).not.toContain("create the result of 4 +");
+  });
+
   describe("integration with TaskGraphProcessor", () => {
     it("create → validate: sequential dependency", () => {
       const compiled = TaskSentenceSplitter.split("Create a new endpoint and test it");

--- a/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
+++ b/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
@@ -179,6 +179,39 @@ describe("TaskSentenceSplitter", () => {
     expect(result.sentences).not.toContain("create the result of 4 +");
   });
 
+  it("does not treat spaced decimal-like values as numbered-list items", () => {
+    const result = TaskSentenceSplitter.split("Update version 3. 10 config. Verify it.");
+
+    expect(result.sentences).toEqual([
+      "Update version 3. 10 config.",
+      "Verify it.",
+    ]);
+  });
+
+  it("keeps common abbreviations with the following phrase", () => {
+    const result = TaskSentenceSplitter.split("Document e.g. Add tests as an example. Verify it.");
+
+    expect(result.sentences).toEqual([
+      "Document e.g. Add tests as an example.",
+      "Verify it.",
+    ]);
+  });
+
+  it("keeps descriptive comma fragments that look like noun phrases", () => {
+    const result = TaskSentenceSplitter.split("Create a module, test data included, and document it");
+
+    expect(result.sentences).toEqual([
+      "Create a module, test data included",
+      "document it",
+    ]);
+  });
+
+  it("does not split hyphenated descriptors as follow-up actions", () => {
+    const result = TaskSentenceSplitter.split("Build module and run-time config");
+
+    expect(result.sentences).toEqual(["Build module and run-time config"]);
+  });
+
   describe("integration with TaskGraphProcessor", () => {
     it("create → validate: sequential dependency", () => {
       const compiled = TaskSentenceSplitter.split("Create a new endpoint and test it");

--- a/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
+++ b/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
@@ -212,6 +212,30 @@ describe("TaskSentenceSplitter", () => {
     expect(result.sentences).toEqual(["Build module and run-time config"]);
   });
 
+  it("does not treat arithmetic words before numbers as numbered-list items", () => {
+    const result = TaskSentenceSplitter.split(
+      "Calculate the result of 4 plus 5. Next, calculate the result of 10 minus 3. Finally, summarize it.",
+    );
+
+    expect(result.sentences).toEqual([
+      "Calculate the result of 4 plus 5.",
+      "calculate the result of 10 minus 3.",
+      "summarize it.",
+    ]);
+  });
+
+  it("does not emit ordering markers as standalone tasks", () => {
+    const result = TaskSentenceSplitter.split(
+      "First, create an addition design. Next, create a subtraction design. Finally, verify the result.",
+    );
+
+    expect(result.sentences).toEqual([
+      "create an addition design.",
+      "create a subtraction design.",
+      "verify the result.",
+    ]);
+  });
+
   describe("integration with TaskGraphProcessor", () => {
     it("create → validate: sequential dependency", () => {
       const compiled = TaskSentenceSplitter.split("Create a new endpoint and test it");


### PR DESCRIPTION
## 요약

- `TaskSentenceSplitter`가 산술 표현의 숫자를 번호 목록으로 오인해 문장을 잘못 자르던 문제를 수정했습니다
- `First`, `Next`, `Finally` 같은 순서 표식이 단독 task로 생성되는 문제를 보강했습니다
- 약어, 버전형 숫자, `test data`, `run-time` 같은 명사구가 task로 오분리되는 회귀 방지 테스트를 추가했습니다

## 관련 이슈

- Closes #155 

## 변경 유형

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [x] 테스트 추가/수정

## 영향 범위

- 변경된 파일:
  - `src/core/task-graph/TaskSentenceSplitter.ts`  번호 목록 pre-split 조건 보강, 산술 표현 보존, 순서 표식 병합, 설명형 fragment 보호
  - `tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts`  계산기 프롬프트 및 회귀 방지 케이스 추가

## 수정 내용

### 1. 산술 표현을 번호 목록으로 오인하는 문제 수정

`splitLines()`는 `1. task`, `2) task` 같은 인라인 번호 목록을 분리하기 위해 숫자 마커 앞 공백을 줄바꿈으로 바꿉니다.

**문제**: `4 + 5.`, `4 plus 5.`, `10 minus 3.` 같은 산술 표현의 숫자가 번호 목록처럼 처리됨

```ts
// Before
.replace(/\s+(?=\d+[.)]\s+)/g, "\n")
```

**수정**: 산술 연산자 또는 산술 단어 뒤 숫자는 줄바꿈하지 않고 수식으로 보존

```ts
// After
return (previous && /[+\-*/=]/.test(previous)) ||
  /\b(?:plus|minus|times|over)\s*$/i.test(prefix) ||
  /\b(?:multiplied|divided)\s+by\s*$/i.test(prefix)
  ? match
  : "\n";
```

| 입력 | 수정 전 | 수정 후 |
|------|---------|---------|
| `Create the result of 4 + 5. Also check it.` | `Create the result of 4 +` | `Create the result of 4 + 5.` |
| `Calculate the result of 4 plus 5.` | `Calculate the result of 4 plus` | `Calculate the result of 4 plus 5.` |
| `Calculate the result of 10 minus 3.` | `Calculate the result of 10 minus` | `Calculate the result of 10 minus 3.` |

### 2. 순서 표식 단독 task 생성 방지

실제 5개 계산기 프롬프트 실행 중 `First`, `Next`, `Finally`가 독립 task로 생성되는 문제가 확인됐습니다.

**문제**: 쉼표 분리 후 순서 표식만 남은 fragment가 `execute` task로 처리됨

```text
First, create an addition design.
```

**수정**: 순서 표식만 있는 fragment는 뒤쪽 action clause와 병합

```ts
if (/^(?:first|second|third|fourth|fifth|next|then|finally)$/i.test(current.trim())) {
  current = normalized;
  continue;
}
```

| 입력 | 수정 전 | 수정 후 |
|------|---------|---------|
| `First, create an addition design.` | `First`, `create an addition design.` | `create an addition design.` |
| `Next, create a subtraction design.` | `Next`, `create a subtraction design.` | `create a subtraction design.` |
| `Finally, verify the result.` | `Finally`, `verify the result.` | `verify the result.` |

### 3. 오분리 위험 케이스 회귀 방지

번호 목록과 action starter 휴리스틱이 너무 넓게 동작하던 케이스를 보강했습니다.

| 케이스 | 기대 동작 |
|------|-----------|
| `Update version 3. 10 config.` | 버전형 숫자 표현 보존 |
| `Document e.g. Add tests as an example.` | 약어 뒤 문장 보존 |
| `Create a module, test data included` | `test data`를 validate task로 오인하지 않음 |
| `Build module and run-time config` | `run-time`을 execute task로 오인하지 않음 |

### 4. 실제 파이프라인 분석 결과 문서화

5개 계산기 프롬프트를 WSL Ubuntu에서 `--verbose --trace`로 실행해 분석했습니다.

관련 파일:

```text
local_config/pipeline-5-task-analysis-l7nWmvgYhkzE8KGIGiY0bhr8.md
local_config/trace/l7nWmvgYhkzE8KGIGiY0bhr8-trace.json
```

분석 결과:

- 파이프라인은 최종 완료
- 최초 실행에서는 5개 요청이 10개 task로 확장됨
- 순서 표식과 산술 단어 뒤 숫자 오분리 문제가 확인되어 본 PR에서 보강

## 테스트 방법

```bash
npm test -- tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
npm test -- tests/ts/unit/core/task-graph
```

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] 필요한 경우 테스트를 추가하거나 수정했습니다
- [ ] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 스크린샷 / 로그

```text
> detoks@0.1.0 test
> vitest run tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts

Test Files  1 passed (1)
Tests  32 passed (32)
```

```text
> detoks@0.1.0 test
> vitest run tests/ts/unit/core/task-graph

Test Files  6 passed (6)
Tests  865 passed (865)
```

실제 계산기 프롬프트 산출물 직접 검증:

```text
PYTHONPATH=python python3 -m calculator.cli + 4 5
9

PYTHONPATH=python python3 -m calculator.cli - 10 3
7

PYTHONPATH=python python3 -m calculator.cli multiply 4 5
multiply_exit:2
stderr:
usage: cli.py [-h] {+,-} left right
cli.py: error: argument operation: invalid choice: 'multiply' (choose from '+', '-')
```

## 리뷰어 참고사항

- 번호 목록 인식 자체는 유지하되, 산술 표현과 버전형 숫자 표현만 보존하도록 조건을 좁혔습니다.
- `First`, `Next`, `Finally` 같은 순서 표식은 task 제목으로 의미가 없어서 뒤 action clause와 병합합니다.
- 이번 변경은 `TaskSentenceSplitter`의 휴리스틱 보강이며, dependency 의미 추론은 별도 Role2.1 개선 범위입니다.
- 전체 `npm test`에서는 `tests/ts/integration/cli-smoke.test.ts`의 세션 목록 케이스가 timeout으로 실패했지만, 단독 재실행에서도 동일했고 splitter 경로를 타지 않는 기존/환경성 이슈로 분리했습니다.
