### PR TITLE
fix: use normalized prompt for role2 handoff

### DIFF
--- a/src/core/prompt/compiler.ts
+++ b/src/core/prompt/compiler.ts
@@ -126,6 +126,6 @@ export function createRole2PromptInput(
   compiledPrompt: PromptCompileResponse,
 ): Role2PromptInput {
   return Role2PromptInputSchema.parse({
-    compiled_prompt: compiledPrompt.compressed_prompt,
+    compiled_prompt: compiledPrompt.normalized_input,
   });
 }

--- a/src/core/task-graph/TaskSentenceSplitter.ts
+++ b/src/core/task-graph/TaskSentenceSplitter.ts
@@ -361,7 +361,7 @@ export class TaskSentenceSplitter {
   private static cleanClause(text: string): string {
     return text
       .trim()
-      .replace(/^(?:can you please|could you please|would you please|please)\s+/i, "")
+      .replace(/^(?:(?:can|could|would)\s+you\s+(?:please\s+)?|please\s+)/i, "")
       .replace(/^\d+[.)]\s*/, "") // "1. " / "1) " 제거
       .replace(/^[,;:\-]+/, "") // 선행 구두점 제거
       .replace(/[ \t]+/g, " ") // 중복 공백 제거

--- a/src/core/task-graph/TaskSentenceSplitter.ts
+++ b/src/core/task-graph/TaskSentenceSplitter.ts
@@ -361,6 +361,7 @@ export class TaskSentenceSplitter {
   private static cleanClause(text: string): string {
     return text
       .trim()
+      .replace(/^(?:can you please|could you please|would you please|please)\s+/i, "")
       .replace(/^\d+[.)]\s*/, "") // "1. " / "1) " 제거
       .replace(/^[,;:\-]+/, "") // 선행 구두점 제거
       .replace(/[ \t]+/g, " ") // 중복 공백 제거

--- a/tests/ts/unit/core/pipeline/batch.test.ts
+++ b/tests/ts/unit/core/pipeline/batch.test.ts
@@ -12,7 +12,7 @@ describe("runBatchPromptPipeline", () => {
     expect(result.run_metadata.pipeline_mode).toBe("safe");
     expect(result.results).toHaveLength(1);
     expect(result.results[0]?.compiled_prompt).toBe("Create a new file");
-    expect(result.results[0]?.role2_handoff).toBe("Create a new file");
+    expect(result.results[0]?.role2_handoff).toBe("Please create a new file");
     expect(result.results[0]?.status).toBe("completed");
     expect(result.results[0]?.inference_time_sec).toBe(0);
   });

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -213,6 +213,30 @@ describe("orchestratePipeline", () => {
     expect(result.promptRepairActions).toContain("compressed_with_kompress");
   });
 
+  it("builds the Role 2.1 graph from normalized input before compression", async () => {
+    const result = await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "stub",
+      verbose: false,
+      userRequest: {
+        raw_input: "Please create a new file and test it",
+      },
+      compressionImplementation: vi.fn(async (text: string) => ({
+        compressed: text.replace(/^Please /i, ""),
+        compression_ratio: 0.55,
+        tokens_saved: 1,
+      })),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compiledPrompt).toBe("Create a new file and test it");
+    expect(result.role2Handoff).toBe("Please create a new file and test it");
+    expect(result.taskRecords).toHaveLength(2);
+    expect(result.rawOutput).toContain("[CREATE] create a new file");
+    expect(result.rawOutput).toContain("[VALIDATE] test it");
+  });
+
   it("bridges Korean input through the local LLM request contract when runtime overrides are provided", async () => {
     const fetchImplementation = vi.fn(async () => {
       return new Response(

--- a/tests/ts/unit/core/prompt/compiler.test.ts
+++ b/tests/ts/unit/core/prompt/compiler.test.ts
@@ -21,7 +21,7 @@ describe("compilePrompt", () => {
     expect(Role2PromptInputSchema.parse(handoff)).toEqual(handoff);
     expect(compiled.normalized_input).toBe("Find the auth module.\n\nAnalyze the flow.");
     expect(compiled.compression_provider).toBe("kompress");
-    expect(handoff.compiled_prompt).toBe(compiled.compressed_prompt);
+    expect(handoff.compiled_prompt).toBe(compiled.normalized_input);
   });
 
   it("영문 입력은 en으로 판정한다", async () => {
@@ -49,6 +49,23 @@ describe("compilePrompt", () => {
       "Update src/api/user.ts and run npm test -- --runInBand 2 times?",
     );
     expect(compiled.repair_actions ?? []).toContain("compressed_with_kompress");
+  });
+
+  it("Role 2.1 handoff uses normalized input before compression", async () => {
+    const compiled = await compilePrompt({
+      raw_input: "Please create a new file and test it",
+    }, {
+      compressionImplementation: vi.fn(async (text: string) => ({
+        compressed: text.replace(/^Please /i, ""),
+        compression_ratio: 0.55,
+        tokens_saved: 1,
+      })),
+    });
+    const handoff = createRole2PromptInput(compiled);
+
+    expect(compiled.normalized_input).toBe("Please create a new file and test it");
+    expect(compiled.compressed_prompt).toBe("Create a new file and test it");
+    expect(handoff.compiled_prompt).toBe("Please create a new file and test it");
   });
 
   it("지원하지 않는 압축 provider는 오류를 반환한다", async () => {

--- a/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
+++ b/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
@@ -40,6 +40,15 @@ describe("TaskSentenceSplitter", () => {
     ]);
   });
 
+  it("splits polite create-and-validate follow-up requests", () => {
+    const result = TaskSentenceSplitter.split("Can you create a new file and test it");
+
+    expect(result.sentences).toEqual([
+      "create a new file",
+      "test it",
+    ]);
+  });
+
   it("splits analyze-and-plan follow-up requests", () => {
     const result = TaskSentenceSplitter.split("Analyze the issue and propose a plan");
 
@@ -239,6 +248,14 @@ describe("TaskSentenceSplitter", () => {
   describe("integration with TaskGraphProcessor", () => {
     it("create → validate: sequential dependency", () => {
       const compiled = TaskSentenceSplitter.split("Create a new endpoint and test it");
+      const graph = TaskGraphProcessor.process(compiled);
+
+      expect(graph.tasks.map((t) => t.type)).toEqual(["create", "validate"]);
+      expect(graph.tasks[1]!.depends_on).toEqual(["t1"]);
+    });
+
+    it("polite create → validate: sequential dependency", () => {
+      const compiled = TaskSentenceSplitter.split("Can you create a new file and test it");
       const graph = TaskGraphProcessor.process(compiled);
 
       expect(graph.tasks.map((t) => t.type)).toEqual(["create", "validate"]);


### PR DESCRIPTION
## 요약

- Role 2.1 handoff가 압축 후 `compressed_prompt` 대신 압축 전 `normalized_input`을 사용하도록 변경했습니다.
  - Role 2.1의 문장 분리와 task type 분류가 filler 제거/문장 재구성 이후 텍스트에 의존하지 않게 됩니다.
  - `compiledPrompt`는 계속 압축 결과를 나타내고, `role2Handoff`는 Role 2.1이 실제로 받은 정규화 입력을 나타냅니다.
- Role 2.1이 정규화 입력을 직접 보게 되면서 `Please`, `Can you please`, `Could you please`, `Would you please` prefix를 task clause 정리 단계에서 제거하도록 보강했습니다.
- 압축 전 입력 기준으로 `Please create a new file and test it`이 `create` + `validate` 작업으로 분리되는 회귀 테스트를 추가했습니다.

## 관련 이슈

- Closes #162 

## 변경 유형

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [x] 테스트 추가/수정

## 영향 범위

- 변경된 파일:
  - `src/core/prompt/compiler.ts`
    - `createRole2PromptInput()`이 `compiledPrompt.normalized_input`을 Role 2.1 handoff로 전달하도록 변경
  - `src/core/task-graph/TaskSentenceSplitter.ts`
    - polite prefix 제거를 `cleanClause()`에 추가
  - `tests/ts/unit/core/prompt/compiler.test.ts`
    - Role 2.1 handoff가 `normalized_input`을 사용하는지 검증
  - `tests/ts/unit/core/pipeline/batch.test.ts`
    - batch 결과의 `role2_handoff` 기대값을 정규화 입력 기준으로 갱신
  - `tests/ts/unit/core/pipeline/orchestrator.test.ts`
    - 압축 전 Role 2.1 graph 생성 회귀 테스트 추가

## 테스트 커버리지

| 모듈 | 테스트 수 | 커버 항목 |
|------|-----------|-----------|
| Prompt compiler | 8 | Role 2.1 handoff 스키마, normalized input handoff, compression metadata |
| Pipeline batch | 3 | batch 결과의 compiled prompt / role2 handoff 기록 |
| Pipeline orchestrator | 12 | Role 2.1 graph 생성, 실행 결과 메타데이터, 세션/실패 처리 |
| Task graph | 865 | sentence splitter, processor, DAG, dependency, parallel classification |
| **합계** | **888** | |

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] 필요한 경우 테스트를 추가하거나 수정했습니다
- [ ] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 나누었습니다

## 스크린샷 / 로그

```text
> detoks@0.1.0 test
> vitest run tests/ts/unit/core/prompt/compiler.test.ts tests/ts/unit/core/pipeline/orchestrator.test.ts tests/ts/unit/core/pipeline/batch.test.ts

Test Files  3 passed (3)
Tests       23 passed (23)
```

```text
> detoks@0.1.0 test
> vitest run task-graph

Test Files  6 passed (6)
Tests       865 passed (865)
```

## 리뷰 참고사항

- `Role2PromptInputSchema`의 필드명은 여전히 `compiled_prompt`입니다. 이번 변경은 최소 변경으로 handoff 값의 소스만 `normalized_input`으로 바꿉니다.
- `compiledPrompt`와 `role2Handoff`는 이제 의도적으로 다를 수 있습니다.
- 압축 로직의 action signal fallback은 유지하지만, Role 2.1 분류의 기본 입력은 압축 전 정규화 텍스트가 됩니다.
- polite prefix 제거는 Role 2.1이 정규화 입력을 직접 받는 경로에서 action starter 인식을 안정화하기 위한 보강입니다.
