### PR TITLE
Harden task sentence splitting and extract role2 candidates

### DIFF
--- a/local_config/PR-md/feat-role2-task-candidate-extractor.md
+++ b/local_config/PR-md/feat-role2-task-candidate-extractor.md
@@ -1,0 +1,133 @@
+# PR: Role 2.1 태스크 후보 추출기 구현
+
+## 요약
+
+이 PR은 Role 2.1 task graph 생성 전에 실행 가능한 task sentence만 추출하는 hybrid 전처리 단계를 추가합니다.
+
+기존 구조에서는 `TaskSentenceSplitter`가 문장/절 분해를 수행한 뒤 바로 `TaskGraphProcessor`가 타입과 의존성을 분류했습니다. 하지만 실제 한국어 프롬프트를 번역/정규화/압축한 결과에는 다음과 같은 표현이 남을 수 있습니다.
+
+- `not urgent right now`
+- `if it's okay`
+- `although it seems like you are saying the same thing twice`
+- `reduce unnecessary words`
+- `maintain only the important sequence`
+
+이런 표현은 문장 경계 문제가 아니라 실행 가능한 task 후보 판정 문제이므로, `TaskSentenceSplitter`는 저수준 분해에 머물게 하고 새 `TaskCandidateExtractor`가 후보 정규화와 메타 문장 제거를 담당하도록 분리했습니다.
+
+```text
+Role 2.1 normalized input
+-> TaskSentenceSplitter
+-> TaskCandidateExtractor
+-> TaskGraphProcessor
+-> TaskGraph
+```
+
+## 관련 이슈
+
+- Closes #20
+
+## 변경 유형
+
+- [x] 기능 추가
+- [x] 버그 수정
+- [x] 테스트
+- [ ] 문서
+- [ ] 리팩터링
+
+## 변경 사항
+
+- `src/core/task-graph/TaskSentenceSplitter.ts`
+  - numbered task list 앞의 directive lead-in을 제거합니다.
+  - `After the fix, run tests...`처럼 전제절로 시작하는 comma clause가 action clause와 잘못 분리되지 않도록 보강했습니다.
+
+- `src/core/task-graph/TaskCandidateExtractor.ts`
+  - Role 2.1 입력에서 실행 가능한 task candidate만 추출하는 새 컴포넌트를 추가했습니다.
+  - polite/modal prefix를 제거합니다.
+  - discourse connector와 순서 표현을 제거합니다.
+  - `not urgent`, `reduce unnecessary words`, `same thing twice` 같은 메타 표현을 task 후보에서 제외합니다.
+  - 실행 가능한 action starter로 시작하는 문장만 task candidate로 반환합니다.
+
+- `src/core/pipeline/orchestrator.ts`
+  - TaskGraphBuilder 단계에서 `TaskSentenceSplitter.split()`을 직접 호출하지 않고 `TaskCandidateExtractor.extractSentences()`를 사용하도록 변경했습니다.
+  - Role 2.1 graph 생성 전에 담화/메타 표현을 제거한 task sentence가 `TaskGraphProcessor`로 전달됩니다.
+
+- `tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts`
+  - directive lead-in이 포함된 numbered list가 5개 작업 문장으로 분리되는지 검증합니다.
+
+- `tests/ts/unit/core/task-graph/TaskCandidateExtractor.test.ts`
+  - 담화 표현이 많은 5개 작업 입력에서 실행 가능한 5개 task sentence만 추출되는지 검증합니다.
+  - 추출된 task가 `explore -> analyze -> modify -> validate -> document`로 분류되고 순차 dependency를 갖는지 검증합니다.
+
+## 수정 전
+
+Role 2.1 graph 생성 흐름이 splitter 결과를 바로 task graph processor에 넘겼습니다.
+
+```text
+normalized input
+-> TaskSentenceSplitter
+-> TaskGraphProcessor
+```
+
+이 경우 담화 표현과 메타 지시문이 task sentence에 섞이면 task 분리, 타입 분류, dependency 생성이 흔들릴 수 있습니다.
+
+## 수정 후
+
+Role 2.1 graph 생성 전에 task candidate extraction 단계를 둡니다.
+
+```text
+normalized input
+-> TaskSentenceSplitter
+-> TaskCandidateExtractor
+-> TaskGraphProcessor
+```
+
+예상 task 흐름:
+
+```text
+find auth code
+-> analyze login flow
+-> fix duplicate validation bug
+-> run regression/unit tests
+-> document change reason and test results
+```
+
+## 검증
+
+- [x] `npm run typecheck`
+- [x] `npm test -- tests/ts/unit/core/task-graph/TaskCandidateExtractor.test.ts tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts tests/ts/unit/core/pipeline/orchestrator.test.ts`
+- [x] `npm test -- task-graph`
+
+테스트 결과:
+
+```text
+Test Files  3 passed (3)
+Tests       49 passed (49)
+```
+
+```text
+Test Files  7 passed (7)
+Tests       870 passed (870)
+```
+
+## 리스크 / 참고 사항
+
+- `TaskSentenceSplitter`에는 의미 해석을 많이 넣지 않고, list preamble 제거와 comma split 안정화처럼 저수준 분해 책임에 가까운 보강만 넣었습니다.
+- `TaskCandidateExtractor`는 현재 action starter 기반의 결정적 규칙으로 동작합니다. 번역/압축 결과 표현이 늘어나면 extractor의 discourse/meta 규칙과 action starter 사전을 확장할 수 있습니다.
+- extractor가 후보를 하나도 찾지 못하면 기존 `TaskSentenceSplitter.split()` 결과로 fallback하여 기존 동작과의 호환성을 유지합니다.
+
+## 변경 파일
+
+```text
+src/core/pipeline/orchestrator.ts
+src/core/task-graph/TaskCandidateExtractor.ts
+src/core/task-graph/TaskSentenceSplitter.ts
+tests/ts/unit/core/task-graph/TaskCandidateExtractor.test.ts
+tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
+```
+
+## 커밋
+
+```text
+ea09534 fix: harden task sentence splitting
+9adcd7a feat: extract role2 task candidates
+```

--- a/local_config/issues/[20 feat] Role 2.1 태스크 후보 추출기 구현.md
+++ b/local_config/issues/[20 feat] Role 2.1 태스크 후보 추출기 구현.md
@@ -1,0 +1,87 @@
+# Issue: Role 2.1 태스크 후보 추출기 구현
+
+## 요약
+
+Role 2.1의 문장 분해와 task graph 생성이 압축/번역 이후 남는 담화 표현, 공손 표현, 메타 지시문에 영향을 받습니다.
+
+예를 들어 다음과 같은 한국어 요청은 실행해야 할 태스크가 5개입니다.
+
+```text
+음, 지금 바로 급한 건 아니지만 그래도 가능하면 차근차근 처리해줘.
+혹시 괜찮다면 먼저 인증 관련 코드가 어디 있는지 찾아보고,
+그 다음에는 로그인 요청이 컨트롤러에서 서비스와 저장소까지 어떻게 흘러가는지 자세히 분석해줘.
+그리고 아마 중복 검증 로직 때문에 문제가 생기는 것 같으니까 그 버그를 수정해줘.
+수정이 끝나면 꼭 회귀 테스트랑 관련 단위 테스트를 실행해서 제대로 고쳐졌는지 확인해줘.
+마지막으로 같은 내용을 두 번 말하는 것 같긴 한데, 변경한 이유와 확인한 테스트 결과를 README나 작업 노트에 문서화해줘.
+불필요한 말은 줄여도 되고, 중요한 작업 순서만 유지해줘.
+```
+
+하지만 단순 sentence splitter만으로는 `급하지 않지만`, `혹시 괜찮다면`, `같은 내용을 두 번 말하는 것 같긴 한데`, `불필요한 말은 줄여도 되고` 같은 표현을 실행 가능한 작업과 안정적으로 분리하기 어렵습니다.
+
+## 재현 방법
+
+Role 2.1 입력에 담화 표현과 메타 지시문이 섞인 5개 작업 프롬프트를 전달합니다.
+
+```text
+Well, it's not urgent right now, but please handle it step-by-step if possible.
+If it's okay, first find where the authentication-related code is,
+and then analyze in detail how the login request flows from the controller to the service and repository.
+And since there seems to be a problem due to duplicate validation logic, please fix that bug.
+After the fix, be sure to run regression tests and related unit tests to confirm that it has been fixed correctly.
+Finally, although it seems like you are saying the same thing twice, document the reason for the change and the test results you confirmed in README or the work notes.
+You can reduce unnecessary words, but please maintain only the important sequence of tasks.
+```
+
+기대 결과는 다음 5개 task입니다.
+
+```text
+find -> analyze -> fix -> run tests -> document
+```
+
+## 원인
+
+`TaskSentenceSplitter`는 문장/절 경계를 나누는 저수준 컴포넌트입니다. 여기에 담화 표현 제거, 공손 표현 제거, 실행 가능한 작업 후보 판정까지 넣으면 splitter가 의미 해석을 과도하게 담당하게 됩니다.
+
+그 결과 다음 문제가 생깁니다.
+
+- 번역/압축 결과 표현이 조금만 달라져도 splitter 예외 규칙이 계속 늘어납니다.
+- 문장 경계 분리와 task 후보 판정 책임이 섞입니다.
+- Role 2.1의 `TaskGraphProcessor`가 실행 가능한 task sentence가 아닌 메타 문장을 입력으로 받을 수 있습니다.
+
+## 기대 동작
+
+- `TaskSentenceSplitter`는 저수준 문장/절 분해와 명백한 list preamble 제거만 담당합니다.
+- `TaskCandidateExtractor`가 splitter 결과를 받아 실행 가능한 작업 후보만 정규화합니다.
+- Orchestrator의 TaskGraphBuilder는 Role 2.1 graph 생성 전에 task candidate extraction을 수행합니다.
+- 담화 표현이 포함된 5개 작업 요청은 `explore -> analyze -> modify -> validate -> document` 흐름으로 분류됩니다.
+
+## 수정 방향
+
+1. `TaskSentenceSplitter`를 저수준 범위에서 보강합니다.
+   - numbered task list 앞의 directive lead-in 제거
+   - `After the fix, run tests...` 같은 전제절이 action clause와 분리되지 않도록 처리
+2. `TaskCandidateExtractor`를 추가합니다.
+   - polite/modal prefix 제거
+   - discourse connector 제거
+   - 메타 지시문 필터링
+   - 실행 가능한 action starter로 시작하는 문장만 후보로 반환
+3. `orchestrator.ts`에서 `TaskGraphProcessor.process()` 전에 `TaskCandidateExtractor.extractSentences()`를 사용합니다.
+4. 담화 표현이 많은 5개 작업 프롬프트가 5개 task graph로 생성되는 테스트를 추가합니다.
+
+## 완료 조건
+
+- [ ] 5개 작업이 포함된 담화형 Role 2.1 입력이 5개 task sentence로 정규화된다.
+- [ ] graph task type이 `explore`, `analyze`, `modify`, `validate`, `document` 순서로 분류된다.
+- [ ] task dependency가 `t1 -> t2 -> t3 -> t4 -> t5` 순서로 생성된다.
+- [ ] splitter 보강은 저수준 문장 분해 책임 안에 머문다.
+- [ ] 관련 task graph 및 orchestrator 테스트가 통과한다.
+- [ ] 타입체크가 통과한다.
+
+## 관련 파일
+
+- `src/core/task-graph/TaskSentenceSplitter.ts`
+- `src/core/task-graph/TaskCandidateExtractor.ts`
+- `src/core/pipeline/orchestrator.ts`
+- `tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts`
+- `tests/ts/unit/core/task-graph/TaskCandidateExtractor.test.ts`
+- `tests/ts/unit/core/pipeline/orchestrator.test.ts`

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -2,8 +2,8 @@ import { randomInt } from "node:crypto";
 import { DAGValidator } from "../task-graph/DAGValidator.js";
 import { DependencyResolver } from "../task-graph/DependencyResolver.js";
 import { ParallelClassifier } from "../task-graph/ParallelClassifier.js";
+import { TaskCandidateExtractor } from "../task-graph/TaskCandidateExtractor.js";
 import { TaskGraphProcessor } from "../task-graph/TaskGraphProcessor.js";
-import { TaskSentenceSplitter } from "../task-graph/TaskSentenceSplitter.js";
 import { compilePrompt, createRole2PromptInput } from "../prompt/compiler.js";
 import { ContextBuilder } from "../context/ContextBuilder.js";
 import { SessionStateManager } from "../state/SessionStateManager.js";
@@ -300,7 +300,7 @@ export const orchestratePipeline = async (
     dataType: "Role2PromptInput", data: role2PromptInput,
   });
   PipelineTracer.startStage("TaskGraphBuilder");
-  const compiledSentences = TaskSentenceSplitter.split(role2PromptInput.compiled_prompt);
+  const compiledSentences = TaskCandidateExtractor.extractSentences(role2PromptInput.compiled_prompt);
   const graph = TaskGraphProcessor.process(compiledSentences);
   await PipelineTracer.trace({
     sessionId, stage: "TaskGraphBuilder", role: "role2.1", phase: "output",

--- a/src/core/task-graph/TaskCandidateExtractor.ts
+++ b/src/core/task-graph/TaskCandidateExtractor.ts
@@ -1,0 +1,237 @@
+import {
+  CompiledSentencesSchema,
+  type CompiledSentences,
+} from "../../schemas/pipeline.js";
+import { TaskSentenceSplitter } from "./TaskSentenceSplitter.js";
+
+export interface TaskCandidate {
+  text: string;
+  orderHint?: number;
+  discardedText?: string[];
+}
+
+const ACTION_STARTERS = [
+  "find",
+  "locate",
+  "trace",
+  "track",
+  "follow",
+  "show",
+  "tell",
+  "read",
+  "search",
+  "explore",
+  "browse",
+  "inspect",
+  "analyze",
+  "investigate",
+  "explain",
+  "diagnose",
+  "review",
+  "compare",
+  "assess",
+  "evaluate",
+  "create",
+  "build",
+  "generate",
+  "scaffold",
+  "implement",
+  "add",
+  "make",
+  "draft",
+  "set up",
+  "spin up",
+  "bootstrap",
+  "modify",
+  "update",
+  "change",
+  "fix",
+  "patch",
+  "edit",
+  "refactor",
+  "rename",
+  "rewrite",
+  "remove",
+  "replace",
+  "improve",
+  "optimize",
+  "optimise",
+  "tune",
+  "correct",
+  "test",
+  "validate",
+  "verify",
+  "assert",
+  "confirm",
+  "ensure",
+  "check",
+  "lint",
+  "typecheck",
+  "run",
+  "execute",
+  "deploy",
+  "start",
+  "launch",
+  "restart",
+  "stop",
+  "install",
+  "migrate",
+  "seed",
+  "serve",
+  "document",
+  "summarize",
+  "summarise",
+  "describe",
+  "write",
+  "prepare",
+  "plan",
+  "design",
+  "organize",
+  "outline",
+  "strategize",
+  "propose",
+  "break down",
+].sort((a, b) => b.length - a.length);
+
+const ACTION_STARTER_REGEX = new RegExp(
+  `^(?:${ACTION_STARTERS.map(escapeRegex).join("|")})(?=\\s|$)`,
+  "i",
+);
+
+const ACTION_CLAUSE_REGEX = new RegExp(
+  `\\b(?:${ACTION_STARTERS.map(escapeRegex).join("|")})(?=\\s|$)`,
+  "i",
+);
+
+export class TaskCandidateExtractor {
+  static extract(rawInput: string): TaskCandidate[] {
+    const split = TaskSentenceSplitter.split(rawInput);
+    const candidates: TaskCandidate[] = [];
+
+    for (const [index, sentence] of split.sentences.entries()) {
+      const candidate = this.normalizeCandidate(sentence, index);
+      if (!candidate) {
+        continue;
+      }
+      candidates.push(candidate);
+    }
+
+    return candidates;
+  }
+
+  static extractSentences(rawInput: string): CompiledSentences {
+    const candidates = this.extract(rawInput);
+    if (candidates.length > 0) {
+      return CompiledSentencesSchema.parse({
+        sentences: candidates.map((candidate) => candidate.text),
+      });
+    }
+
+    return TaskSentenceSplitter.split(rawInput);
+  }
+
+  private static normalizeCandidate(
+    sentence: string,
+    index: number,
+  ): TaskCandidate | null {
+    const discardedText: string[] = [];
+    let text = cleanWhitespace(sentence);
+    text = stripToken(text, discardedText, /^(?:(?:can|could|would)\s+you\s+(?:please\s+)?|please\s+)/i);
+    text = stripToken(text, discardedText, /^(?:and|also|so|then)\s+/i);
+    text = stripToken(text, discardedText, /^(?:well|okay|actually|basically|honestly),?\s+/i);
+    text = stripToken(text, discardedText, /^(?:if\s+(?:it'?s\s+)?(?:okay|possible)|if\s+you\s+(?:can|could)|when\s+possible|where\s+possible),?\s+/i);
+    text = stripToken(text, discardedText, /^(?:first|second|third|fourth|fifth|next|finally|lastly),?\s+/i);
+    text = stripToken(text, discardedText, /^(?:after|before|once)\b[^,]*,\s+/i);
+    text = stripToken(text, discardedText, /^(?:be\s+sure\s+to|make\s+sure\s+to|try\s+to)\s+/i);
+
+    text = normalizeCauseAction(text);
+    text = extractActionClauseAfterDiscourse(text, discardedText);
+    text = stripToken(text, discardedText, /^(?:be\s+sure\s+to|make\s+sure\s+to|try\s+to)\s+/i);
+    text = cleanWhitespace(text);
+
+    if (!text || this.isDiscardableMeta(text)) {
+      return null;
+    }
+
+    if (!ACTION_STARTER_REGEX.test(text)) {
+      return null;
+    }
+
+    return {
+      text,
+      orderHint: index,
+      ...(discardedText.length > 0 ? { discardedText } : {}),
+    };
+  }
+
+  private static isDiscardableMeta(text: string): boolean {
+    const normalized = text.toLowerCase();
+    return (
+      /^(?:process|perform|complete|handle|do)\s+(?:the\s+)?(?:(?:following\b.*)|(?:these\b.*\btasks?\b))/i.test(text) ||
+      /\bnot urgent\b/.test(normalized) ||
+      /\breduce unnecessary words\b/.test(normalized) ||
+      /\bmaintain only the important sequence\b/.test(normalized) ||
+      /\bsame thing twice\b/.test(normalized) ||
+      /\bstep-by-step\b/.test(normalized)
+    );
+  }
+}
+
+function extractActionClauseAfterDiscourse(
+  text: string,
+  discardedText: string[],
+): string {
+  const commaParts = text.split(/,\s+/);
+  if (commaParts.length <= 1) {
+    return text;
+  }
+
+  for (let index = 1; index < commaParts.length; index += 1) {
+    const suffix = commaParts.slice(index).join(", ");
+    const match = ACTION_CLAUSE_REGEX.exec(suffix);
+    if (!match || match.index > 8) {
+      continue;
+    }
+
+    const discarded = commaParts.slice(0, index).join(", ");
+    if (discarded) {
+      discardedText.push(discarded);
+    }
+    return suffix.slice(match.index);
+  }
+
+  return text;
+}
+
+function stripToken(
+  text: string,
+  discardedText: string[],
+  pattern: RegExp,
+): string {
+  const match = pattern.exec(text);
+  if (!match?.[0]) {
+    return text;
+  }
+
+  discardedText.push(match[0].trim());
+  return text.slice(match[0].length).trim();
+}
+
+function cleanWhitespace(text: string): string {
+  return text
+    .replace(/[ \t]+/g, " ")
+    .replace(/\s+([,.;!?])/g, "$1")
+    .replace(/[,;:]+$/u, "")
+    .trim();
+}
+
+function normalizeCauseAction(text: string): string {
+  return text.replace(
+    /^(?:and\s+)?since\s+there\s+seems\s+to\s+be\s+a\s+problem\s+due\s+to\s+(.+?),\s*(?:please\s+)?fix\s+that\s+bug\.?$/i,
+    "fix the bug due to $1.",
+  );
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/core/task-graph/TaskSentenceSplitter.ts
+++ b/src/core/task-graph/TaskSentenceSplitter.ts
@@ -155,7 +155,7 @@ export class TaskSentenceSplitter {
     const restored = sentences
       .map((sentence) => this.restoreLiterals(sentence, protectedInput.tokens))
       .map((sentence) => this.cleanClause(sentence))
-      .filter(Boolean);
+      .filter((sentence) => sentence && !this.isDirectiveLeadIn(sentence));
 
     return CompiledSentencesSchema.parse({ sentences: restored });
   }
@@ -259,6 +259,10 @@ export class TaskSentenceSplitter {
       const isConditionalClause =
         /^(?:if|unless|when|until|provided|assuming)\b/i.test(current.trim());
       if (/^(?:first|second|third|fourth|fifth|next|then|finally)$/i.test(current.trim())) {
+        current = normalized;
+        continue;
+      }
+      if (/^(?:after|before|once)\b/i.test(current.trim())) {
         current = normalized;
         continue;
       }
@@ -385,6 +389,12 @@ export class TaskSentenceSplitter {
 
   private static looksLikeDescriptiveFragment(text: string): boolean {
     return /^(?:test\s+data\b|run-?time\b|runtime\b|build\s+time\b|compile\s+time\b)/i.test(
+      text.trim(),
+    );
+  }
+
+  private static isDirectiveLeadIn(text: string): boolean {
+    return /^(?:process|perform|complete|handle|do)\s+(?:the\s+)?(?:(?:following\b.*)|(?:these\b.*\btasks?\b)).*[:.]?\s*$/i.test(
       text.trim(),
     );
   }

--- a/tests/ts/unit/core/task-graph/TaskCandidateExtractor.test.ts
+++ b/tests/ts/unit/core/task-graph/TaskCandidateExtractor.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { TaskCandidateExtractor } from "../../../../../src/core/task-graph/TaskCandidateExtractor.js";
+import { TaskGraphProcessor } from "../../../../../src/core/task-graph/TaskGraphProcessor.js";
+
+describe("TaskCandidateExtractor", () => {
+  it("extracts executable tasks from discourse-heavy normalized input", () => {
+    const result = TaskCandidateExtractor.extractSentences(
+      [
+        "Well, it's not urgent right now, but please handle it step-by-step if possible.",
+        "If it's okay, first find where the authentication-related code is,",
+        "and then analyze in detail how the login request flows from the controller to the service and repository.",
+        "And since there seems to be a problem due to duplicate validation logic, please fix that bug.",
+        "After the fix, be sure to run regression tests and related unit tests to confirm that it has been fixed correctly.",
+        "Finally, although it seems like you are saying the same thing twice, document the reason for the change and the test results you confirmed in README or the work notes.",
+        "You can reduce unnecessary words, but please maintain only the important sequence of tasks.",
+      ].join(" "),
+    );
+
+    expect(result.sentences).toEqual([
+      "find where the authentication-related code is",
+      "analyze in detail how the login request flows from the controller to the service and repository.",
+      "fix the bug due to duplicate validation logic.",
+      "run regression tests and related unit tests to confirm that it has been fixed correctly.",
+      "document the reason for the change and the test results you confirmed in README or the work notes.",
+    ]);
+  });
+
+  it("builds a five-task workflow from extracted candidates", () => {
+    const sentences = TaskCandidateExtractor.extractSentences(
+      "Please process these five tasks sequentially, gradually, but reduce unnecessary words.\n" +
+        "1. Find exactly where the code related to authentication is in the project.\n" +
+        "2. Analyze in detail the flow from the login request starting on the screen to the controller, service, and repository.\n" +
+        "3. Fix the bug that appears due to redundant validation logic in the actual code.\n" +
+        "4. After the fix, run regression tests and related unit tests to confirm that it has been corrected properly.\n" +
+        "5. Finally, document the reason for the change and the test results confirmed in the work notes.",
+    );
+    const graph = TaskGraphProcessor.process(sentences);
+
+    expect(sentences.sentences).toEqual([
+      "Find exactly where the code related to authentication is in the project.",
+      "Analyze in detail the flow from the login request starting on the screen to the controller, service, and repository.",
+      "Fix the bug that appears due to redundant validation logic in the actual code.",
+      "run regression tests and related unit tests to confirm that it has been corrected properly.",
+      "document the reason for the change and the test results confirmed in the work notes.",
+    ]);
+    expect(graph.tasks.map((task) => task.type)).toEqual([
+      "explore",
+      "analyze",
+      "modify",
+      "validate",
+      "document",
+    ]);
+    expect(graph.tasks.map((task) => task.depends_on)).toEqual([
+      [],
+      ["t1"],
+      ["t2"],
+      ["t3"],
+      ["t4"],
+    ]);
+  });
+});

--- a/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
+++ b/tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
@@ -31,6 +31,20 @@ describe("TaskSentenceSplitter", () => {
     ]);
   });
 
+  it("drops directive lead-ins before numbered task lists", () => {
+    const result = TaskSentenceSplitter.split(
+      "Please process these five tasks sequentially, gradually, but reduce unnecessary words.\n1. Find exactly where the code related to authentication is in the project.\n2. Analyze in detail the flow from the login request starting on the screen to the controller, service, and repository.\n3. Fix the bug that appears due to redundant validation logic in the actual code.\n4. After the fix, run regression tests and related unit tests to confirm that it has been corrected properly.\n5. Finally, document the reason for the change and the test results confirmed in the work notes.",
+    );
+
+    expect(result.sentences).toEqual([
+      "Find exactly where the code related to authentication is in the project.",
+      "Analyze in detail the flow from the login request starting on the screen to the controller, service, and repository.",
+      "Fix the bug that appears due to redundant validation logic in the actual code.",
+      "run regression tests and related unit tests to confirm that it has been corrected properly.",
+      "document the reason for the change and the test results confirmed in the work notes.",
+    ]);
+  });
+
   it("splits create-and-validate follow-up requests", () => {
     const result = TaskSentenceSplitter.split("Create a new endpoint and test it");
 


### PR DESCRIPTION
# PR: Role 2.1 태스크 후보 추출기 구현

## 요약

이 PR은 Role 2.1 task graph 생성 전에 실행 가능한 task sentence만 추출하는 hybrid 전처리 단계를 추가합니다.

기존 구조에서는 `TaskSentenceSplitter`가 문장/절 분해를 수행한 뒤 바로 `TaskGraphProcessor`가 타입과 의존성을 분류했습니다. 하지만 실제 한국어 프롬프트를 번역/정규화/압축한 결과에는 다음과 같은 표현이 남을 수 있습니다.

- `not urgent right now`
- `if it's okay`
- `although it seems like you are saying the same thing twice`
- `reduce unnecessary words`
- `maintain only the important sequence`

이런 표현은 문장 경계 문제가 아니라 실행 가능한 task 후보 판정 문제이므로, `TaskSentenceSplitter`는 저수준 분해에 머물게 하고 새 `TaskCandidateExtractor`가 후보 정규화와 메타 문장 제거를 담당하도록 분리했습니다.

```text
Role 2.1 normalized input
-> TaskSentenceSplitter
-> TaskCandidateExtractor
-> TaskGraphProcessor
-> TaskGraph
```

## 관련 이슈

- Closes #168 

## 변경 유형

- [x] 기능 추가
- [x] 버그 수정
- [x] 테스트
- [ ] 문서
- [ ] 리팩터링

## 변경 사항

- `src/core/task-graph/TaskSentenceSplitter.ts`
  - numbered task list 앞의 directive lead-in을 제거합니다.
  - `After the fix, run tests...`처럼 전제절로 시작하는 comma clause가 action clause와 잘못 분리되지 않도록 보강했습니다.

- `src/core/task-graph/TaskCandidateExtractor.ts`
  - Role 2.1 입력에서 실행 가능한 task candidate만 추출하는 새 컴포넌트를 추가했습니다.
  - polite/modal prefix를 제거합니다.
  - discourse connector와 순서 표현을 제거합니다.
  - `not urgent`, `reduce unnecessary words`, `same thing twice` 같은 메타 표현을 task 후보에서 제외합니다.
  - 실행 가능한 action starter로 시작하는 문장만 task candidate로 반환합니다.

- `src/core/pipeline/orchestrator.ts`
  - TaskGraphBuilder 단계에서 `TaskSentenceSplitter.split()`을 직접 호출하지 않고 `TaskCandidateExtractor.extractSentences()`를 사용하도록 변경했습니다.
  - Role 2.1 graph 생성 전에 담화/메타 표현을 제거한 task sentence가 `TaskGraphProcessor`로 전달됩니다.

- `tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts`
  - directive lead-in이 포함된 numbered list가 5개 작업 문장으로 분리되는지 검증합니다.

- `tests/ts/unit/core/task-graph/TaskCandidateExtractor.test.ts`
  - 담화 표현이 많은 5개 작업 입력에서 실행 가능한 5개 task sentence만 추출되는지 검증합니다.
  - 추출된 task가 `explore -> analyze -> modify -> validate -> document`로 분류되고 순차 dependency를 갖는지 검증합니다.

## 수정 전

Role 2.1 graph 생성 흐름이 splitter 결과를 바로 task graph processor에 넘겼습니다.

```text
normalized input
-> TaskSentenceSplitter
-> TaskGraphProcessor
```

이 경우 담화 표현과 메타 지시문이 task sentence에 섞이면 task 분리, 타입 분류, dependency 생성이 흔들릴 수 있습니다.

## 수정 후

Role 2.1 graph 생성 전에 task candidate extraction 단계를 둡니다.

```text
normalized input
-> TaskSentenceSplitter
-> TaskCandidateExtractor
-> TaskGraphProcessor
```

예상 task 흐름:

```text
find auth code
-> analyze login flow
-> fix duplicate validation bug
-> run regression/unit tests
-> document change reason and test results
```

## 검증

- [x] `npm run typecheck`
- [x] `npm test -- tests/ts/unit/core/task-graph/TaskCandidateExtractor.test.ts tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts tests/ts/unit/core/pipeline/orchestrator.test.ts`
- [x] `npm test -- task-graph`

테스트 결과:

```text
Test Files  3 passed (3)
Tests       49 passed (49)
```

```text
Test Files  7 passed (7)
Tests       870 passed (870)
```

## 리스크 / 참고 사항

- `TaskSentenceSplitter`에는 의미 해석을 많이 넣지 않고, list preamble 제거와 comma split 안정화처럼 저수준 분해 책임에 가까운 보강만 넣었습니다.
- `TaskCandidateExtractor`는 현재 action starter 기반의 결정적 규칙으로 동작합니다. 번역/압축 결과 표현이 늘어나면 extractor의 discourse/meta 규칙과 action starter 사전을 확장할 수 있습니다.
- extractor가 후보를 하나도 찾지 못하면 기존 `TaskSentenceSplitter.split()` 결과로 fallback하여 기존 동작과의 호환성을 유지합니다.

## 변경 파일

```text
src/core/pipeline/orchestrator.ts
src/core/task-graph/TaskCandidateExtractor.ts
src/core/task-graph/TaskSentenceSplitter.ts
tests/ts/unit/core/task-graph/TaskCandidateExtractor.test.ts
tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
```

## 커밋

```text
ea09534 fix: harden task sentence splitting
9adcd7a feat: extract role2 task candidates
```
