### PR TITLE
feat: add repl slash menu and adapter prompt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,26 +1,33 @@
-# LOCAL_LLM_API_BASE=http://127.0.0.1:12370/v1
-LOCAL_LLM_API_BASE=http://
-LOCAL_LLM_API_KEY=
-LOCAL_LLM_MODEL_NAME=set your model name here, e.g. mradermacher/supergemma4-e4b-abliterated-GGUF:Q4_K_S
-# LOCAL_LLM_MODEL_NAME=mradermacher/supergemma4-e4b-abliterated-GGUF:Q4_K_S
+# Role 1 local LLM connection
+LOCAL_LLM_API_BASE=http://127.0.0.1:12370/v1
+LOCAL_LLM_API_KEY=your-local-llm-api-key
+LOCAL_LLM_MODEL_NAME=your-model-name
+
+# Role 1 local runtime
 LOCAL_LLM_AUTO_START=1
 LOCAL_LLM_SERVER_BINARY=llama-server
 LOCAL_LLM_SERVER_HOST=127.0.0.1
 LOCAL_LLM_SERVER_PORT=12370
-# Set to none if Metal fails with "failed to create command queue".
+# Set to none if your local backend needs a specific device selector.
 # LOCAL_LLM_DEVICE=none
 LOCAL_LLM_GPU_LAYERS=all
 LOCAL_LLM_CONTEXT_SIZE=4096
 LOCAL_LLM_MAX_TOKENS=512
 LOCAL_LLM_REASONING=off
-# LOCAL_LLM_HF_REPO=mradermacher/gemma-4-E2B-it-heretic-ara-GGUF:Q4_K_S
-LOCAL_LLM_HF_REPO=hf-author-name/hf-repo-name:hf-revision
-# LOCAL_LLM_HF_FILE=gemma-4-E2B-it-heretic-ara.Q4_K_S.gguf
-LOCAL_LLM_HF_FILE=model-file-name.gguf
+LOCAL_LLM_STARTUP_TIMEOUT=600000
+
+# Model source
+LOCAL_LLM_HF_REPO=your-hf-repo-name/your-model-repo:revision
+LOCAL_LLM_HF_FILE=your-model-file.gguf
 # LOCAL_LLM_MODEL_PATH=/absolute/path/to/model.gguf
 # LOCAL_LLM_MODEL_URL=https://example.com/model.gguf
 
-# Optional runtime tuning
+# Kompress runtime
+KOMPRESS_PYTHON_BIN=python3
+KOMPRESS_MODEL_ID=your-kompress-model-id
+KOMPRESS_STARTUP_TIMEOUT=120000
+
+# Pipeline tuning
 PIPELINE_MODE=safe
 REQUEST_TIMEOUT=30000
 TRANSLATION_MAX_ATTEMPTS=5

--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -19,9 +19,12 @@ const SESSION_ID_CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
 const LOGIN_MENU_OPTIONS = ["codex", "gemini"] as const;
 const VERBOSE_MENU_OPTIONS = ["on", "off"] as const;
 const RESUME_SESSION_MENU_OPTIONS = ["continue", "new"] as const;
+const DEFAULT_REPL_ADAPTER: ReplAdapter = "codex";
+type ReplAdapter = NonNullable<CliArgs["adapter"]>;
 const terminal = createTerminalStyle({ isTTY: Boolean(output.isTTY), env: process.env });
 
 export type ReplBuiltinCommand =
+  | { kind: "menu" }
   | { kind: "help" }
   | { kind: "exit" }
   | { kind: "login" }
@@ -31,7 +34,7 @@ export type ReplBuiltinCommand =
   | { kind: "verbose"; value?: boolean };
 
 export interface ReplRuntimeState {
-  adapter: CliArgs["adapter"];
+  adapter: ReplAdapter;
   model?: string;
   executionMode: CliArgs["executionMode"];
   verbose: boolean;
@@ -49,6 +52,10 @@ export const shouldEmitReplSourceBadge = (
 ): boolean => getReplSourceBadgeKey(state) !== lastBadgeKey;
 
 export const getReplBuiltinCommand = (line: string): ReplBuiltinCommand | null => {
+  if (line === "/") {
+    return { kind: "menu" };
+  }
+
   if (HELP_COMMANDS.has(line)) {
     return { kind: "help" };
   }
@@ -71,8 +78,8 @@ export const getReplBuiltinCommand = (line: string): ReplBuiltinCommand | null =
 
   if (line.startsWith("/adapter ")) {
     const adapter = line.slice("/adapter ".length).trim();
-    if (AdapterValues.includes(adapter as CliArgs["adapter"])) {
-      return { kind: "adapter", adapter: adapter as CliArgs["adapter"] };
+    if (adapter && AdapterValues.includes(adapter as ReplAdapter)) {
+      return { kind: "adapter", adapter: adapter as ReplAdapter };
     }
     return { kind: "adapter" };
   }
@@ -213,8 +220,8 @@ async function promptForArrowSelection<const T extends string>(
 }
 
 async function promptForLoginAdapterSelection(
-  currentAdapter: CliArgs["adapter"] = LOGIN_MENU_OPTIONS[0],
-): Promise<CliArgs["adapter"] | null> {
+  currentAdapter: ReplAdapter = LOGIN_MENU_OPTIONS[0],
+): Promise<ReplAdapter | null> {
   return await promptForArrowSelection(
     "로그인할 어댑터를 선택하세요:",
     LOGIN_MENU_OPTIONS,
@@ -223,13 +230,94 @@ async function promptForLoginAdapterSelection(
 }
 
 async function promptForReplAdapterSelection(
-  currentAdapter: CliArgs["adapter"],
-): Promise<CliArgs["adapter"] | null> {
+  currentAdapter: ReplAdapter = DEFAULT_REPL_ADAPTER,
+): Promise<ReplAdapter | null> {
   return await promptForArrowSelection(
     "REPL 어댑터를 선택하세요:",
     LOGIN_MENU_OPTIONS,
     Math.max(0, LOGIN_MENU_OPTIONS.indexOf(currentAdapter)),
   );
+}
+
+function formatReplCommandMenu(state: ReplRuntimeState): string {
+  const commands = [
+    ["/help", "REPL 도움말 표시"],
+    ["/login", "Codex/Gemini 로그인 흐름 시작"],
+    ["/session", "현재 REPL 세션과 런타임 정보 확인"],
+    ["/adapter", "어댑터 선택 UI 표시"],
+    ["/adapter codex", "이후 프롬프트의 어댑터를 codex로 변경"],
+    ["/adapter gemini", "이후 프롬프트의 어댑터를 gemini로 변경"],
+    ["/model", "모델 변경 안내 표시"],
+    ["/model <이름>", "이후 프롬프트의 모델을 변경"],
+    ["/verbose", "상세 출력 선택 UI 표시"],
+    ["/verbose on", "상세 출력 켜기"],
+    ["/verbose off", "상세 출력 끄기"],
+    ["/exit", "REPL 종료"],
+    ["/quit", "REPL 종료"],
+    [".exit", "REPL 종료"],
+  ] as const;
+
+  const lines = [
+    terminal.title("REPL 명령어 목록"),
+    terminal.muted(`현재 소스: ${getReplPromptLabel(state).trimEnd()}`),
+    "",
+    ...commands.map(([command, description]) =>
+      `${terminal.emphasis(command.padEnd(18))} ${terminal.muted(description)}`,
+    ),
+    "",
+    terminal.muted("명령을 입력하거나 /help를 입력해 자세한 도움말을 볼 수 있습니다."),
+  ];
+
+  return `${lines.join("\n")}\n`;
+}
+
+function renderReplCommandMenuInline(state: ReplRuntimeState): string {
+  return `\n${formatReplCommandMenu(state)}`;
+}
+
+function renderInlineSlashMenu(state: ReplRuntimeState): void {
+  output.write("\x1b[s");
+  output.write(renderReplCommandMenuInline(state));
+  output.write("\x1b[u");
+}
+
+function clearInlineSlashMenu(): void {
+  output.write("\x1b[s");
+  output.write("\x1b[J");
+  output.write("\x1b[u");
+}
+
+function refreshReadlineLine(rl: {
+  _refreshLine?: () => void;
+}): void {
+  rl._refreshLine?.();
+}
+
+async function resolveInitialReplAdapter(
+  baseAdapter: ReplAdapter | undefined,
+  lastSession: ReplSession | null,
+): Promise<ReplAdapter> {
+  if (baseAdapter !== undefined) {
+    return baseAdapter;
+  }
+
+  if (lastSession && AdapterValues.includes(lastSession.adapter as ReplAdapter)) {
+    return lastSession.adapter as ReplAdapter;
+  }
+
+  if (!input.isTTY || !output.isTTY || typeof input.setRawMode !== "function") {
+    return DEFAULT_REPL_ADAPTER;
+  }
+
+  const selected = await promptForReplAdapterSelection(DEFAULT_REPL_ADAPTER);
+  if (selected) {
+    return selected;
+  }
+
+  output.write(
+    `${terminal.warning(`! 어댑터 선택이 취소되어 ${DEFAULT_REPL_ADAPTER}를 기본값으로 사용합니다.`)}\n`,
+  );
+  return DEFAULT_REPL_ADAPTER;
 }
 
 async function promptForVerboseSelection(currentVerbose: boolean): Promise<boolean | null> {
@@ -297,6 +385,14 @@ export const runReplBuiltinCommand = (
   state: ReplRuntimeState,
   sessionId: string,
 ): { shouldExit: boolean; output: string; nextState: ReplRuntimeState } => {
+  if (command.kind === "menu") {
+    return {
+      shouldExit: false,
+      output: formatReplCommandMenu(state),
+      nextState: state,
+    };
+  }
+
   if (command.kind === "help") {
     return {
       shouldExit: false,
@@ -528,27 +624,59 @@ export const runReplCommand = async (baseArgs: CliArgs): Promise<void> => {
     promptToResume: promptForResumeSessionSelection,
     updateLastResumed: () => ReplRegistry.updateLastResumed(cwd),
   });
+  const initialAdapter = await resolveInitialReplAdapter(baseArgs.adapter, lastSession);
 
   output.write(
-    `${terminal.title("detoks repl 시작됨")} (adapter=${terminal.emphasis(baseArgs.adapter)}, executionMode=${terminal.emphasis(baseArgs.executionMode)}, verbose=${terminal.emphasis(String(baseArgs.verbose))}, session=${terminal.emphasis(sessionId)}). ${terminal.muted('stub = 시뮬레이션 출력; real = 어댑터 실제 실행 경로.')} ${terminal.muted('"/help" 입력 시 REPL 도움말, "exit" 입력 시 종료.')}\n`,
+    `${terminal.title("detoks repl 시작됨")} (adapter=${terminal.emphasis(initialAdapter)}, executionMode=${terminal.emphasis(baseArgs.executionMode)}, verbose=${terminal.emphasis(String(baseArgs.verbose))}, session=${terminal.emphasis(sessionId)}). ${terminal.muted('stub = 시뮬레이션 출력; real = 어댑터 실제 실행 경로.')} ${terminal.muted('"/help" 입력 시 REPL 도움말, "exit" 입력 시 종료.')}\n`,
   );
   let replState: ReplRuntimeState = {
-    adapter: baseArgs.adapter,
+    adapter: initialAdapter,
     ...(baseArgs.model !== undefined ? { model: baseArgs.model } : {}),
     executionMode: baseArgs.executionMode,
     verbose: baseArgs.verbose,
   };
   let lastSourceBadgeKey: string | null = null;
+  let inlineSlashMenuVisible = false;
 
   const isTTY = Boolean(input.isTTY && output.isTTY);
+  if (isTTY) {
+    emitKeypressEvents(input);
+  }
 
   try {
     while (true) {
       let line: string;
+      let onMainPromptKeypress:
+        | ((_: string, key: { name?: string; sequence?: string; ctrl?: boolean }) => void)
+        | null = null;
       try {
         const promptLabel = terminal.prompt(getReplPromptLabel(replState));
         if (!isTTY) {
           output.write(promptLabel);
+        }
+        if (isTTY) {
+          if (typeof input.setRawMode === "function") {
+            input.setRawMode(true);
+          }
+          onMainPromptKeypress = (_: string, key: { name?: string; sequence?: string; ctrl?: boolean }) => {
+            if (key.ctrl && key.name === "c") {
+              return;
+            }
+
+            if (rl.line !== "/" && inlineSlashMenuVisible) {
+              clearInlineSlashMenu();
+              inlineSlashMenuVisible = false;
+              refreshReadlineLine(rl as unknown as { _refreshLine?: () => void });
+              return;
+            }
+
+            if (!inlineSlashMenuVisible && rl.line === "/") {
+              inlineSlashMenuVisible = true;
+              renderInlineSlashMenu(replState);
+              refreshReadlineLine(rl as unknown as { _refreshLine?: () => void });
+            }
+          };
+          input.on("keypress", onMainPromptKeypress);
         }
         line = (await rl.question(isTTY ? promptLabel : "")).trim();
       } catch (error) {
@@ -556,8 +684,21 @@ export const runReplCommand = async (baseArgs: CliArgs): Promise<void> => {
           break;
         }
         throw error;
+      } finally {
+        if (onMainPromptKeypress) {
+          input.off("keypress", onMainPromptKeypress);
+        }
+        if (isTTY && typeof input.setRawMode === "function") {
+          input.setRawMode(false);
+        }
       }
       if (!line) {
+        if (inlineSlashMenuVisible) {
+          clearInlineSlashMenu();
+          inlineSlashMenuVisible = false;
+        }
+        inlineSlashMenuVisible = false;
+        refreshReadlineLine(rl as unknown as { _refreshLine?: () => void });
         continue;
       }
       const builtinCommand = getReplBuiltinCommand(line);
@@ -581,12 +722,38 @@ export const runReplCommand = async (baseArgs: CliArgs): Promise<void> => {
           continue;
         }
 
+        if (builtinCommand.kind === "menu") {
+          if (inlineSlashMenuVisible) {
+            clearInlineSlashMenu();
+            inlineSlashMenuVisible = false;
+            refreshReadlineLine(rl as unknown as { _refreshLine?: () => void });
+            continue;
+          }
+
+          const menuResult = runReplBuiltinCommand(builtinCommand, replState, sessionId);
+          if (menuResult.output) {
+            rl.pause();
+            await new Promise<void>((resolve, reject) => {
+              output.write(menuResult.output, (error) => {
+                if (error) {
+                  reject(error);
+                  return;
+                }
+                resolve();
+              });
+            });
+            rl.resume();
+          }
+          continue;
+        }
+
         let resolvedBuiltinCommand = builtinCommand;
 
         if (builtinCommand.kind === "adapter" && builtinCommand.adapter === undefined) {
           const selectedAdapter = await promptForReplAdapterSelection(replState.adapter);
           if (!selectedAdapter) {
             output.write(`${terminal.warning("! 어댑터 선택이 취소되었습니다.")}\n`);
+            refreshReadlineLine(rl as unknown as { _refreshLine?: () => void });
             continue;
           }
           resolvedBuiltinCommand = { kind: "adapter", adapter: selectedAdapter };
@@ -596,6 +763,7 @@ export const runReplCommand = async (baseArgs: CliArgs): Promise<void> => {
           const selectedVerbose = await promptForVerboseSelection(replState.verbose);
           if (selectedVerbose === null) {
             output.write(`${terminal.warning("! 상세 출력 선택이 취소되었습니다.")}\n`);
+            refreshReadlineLine(rl as unknown as { _refreshLine?: () => void });
             continue;
           }
           resolvedBuiltinCommand = { kind: "verbose", value: selectedVerbose };
@@ -609,12 +777,20 @@ export const runReplCommand = async (baseArgs: CliArgs): Promise<void> => {
         if (builtinResult.shouldExit) {
           break;
         }
+        refreshReadlineLine(rl as unknown as { _refreshLine?: () => void });
         continue;
       }
 
       try {
+        const requestArgs = {
+          ...baseArgs,
+          ...replState,
+          mode: "run" as const,
+          prompt: line,
+          adapter: replState.adapter,
+        };
         const request = toNormalizedRequest(
-          { ...baseArgs, ...replState, mode: "run", prompt: line },
+          requestArgs,
           { mode: "repl", sessionId },
         );
         const spinner = startSpinner(isTTY);
@@ -646,17 +822,21 @@ export const runReplCommand = async (baseArgs: CliArgs): Promise<void> => {
           );
         }
       } catch (error) {
+        inlineSlashMenuVisible = false;
+        clearInlineSlashMenu();
         if (shouldEmitReplSourceBadge(replState, lastSourceBadgeKey)) {
           output.write(
             `${terminal.adapterBadge(replState.adapter, {
               ...(replState.model !== undefined ? { model: replState.model } : {}),
               executionMode: replState.executionMode,
-            })}\n`,
+          })}\n`,
           );
           lastSourceBadgeKey = getReplSourceBadgeKey(replState);
         }
         output.write(`${formatError(error, baseArgs.verbose)}\n`);
       }
+      inlineSlashMenuVisible = false;
+      refreshReadlineLine(rl as unknown as { _refreshLine?: () => void });
     }
   } finally {
     await ReplRegistry.saveSession(

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -206,6 +206,8 @@ const CLI_USAGE_REPL = [
   "REPL 안내:",
   "  - 프롬프트를 입력하고 Enter를 눌러 실행합니다",
   "  - 프롬프트에 현재 소스가 detoks[<어댑터>[:<모델>]] 형태로 표시됩니다",
+  "  - / 입력 시 REPL 명령어 목록 UI를 표시합니다",
+  "  - --adapter를 지정하지 않으면 시작 시 어댑터 선택 UI를 표시합니다",
   "  - 프로젝트에 저장된 REPL 세션이 있으면 시작 시 화살표 키 선택기로 재개하거나 새로 시작할 수 있습니다",
   "  - /help 입력 시 REPL 내부 도움말 표시",
   "  - /login 입력 시 화살표 키 어댑터 선택기와 로그인 흐름 시작",
@@ -259,7 +261,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
   }
 
   const positionals: string[] = [];
-  let adapter: CliArgs["adapter"] = DEFAULT_ADAPTER;
+  let adapter: CliArgs["adapter"] | undefined;
   let executionMode: CliArgs["executionMode"] = DEFAULT_EXECUTION_MODE;
   let sessionId: string | undefined;
   let inputFile: string | undefined;
@@ -304,7 +306,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
               : "main";
       return {
         mode: "run",
-        adapter,
+        adapter: adapter ?? DEFAULT_ADAPTER,
         executionMode,
         verbose,
         trace,
@@ -444,7 +446,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
       return {
         mode: "run",
         command: "session-list",
-        adapter,
+        adapter: adapter ?? DEFAULT_ADAPTER,
         executionMode,
         verbose,
         trace,
@@ -462,7 +464,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
         mode: "run",
         command: "session-continue",
         sessionId: sessionIdFromPos,
-        adapter,
+        adapter: adapter ?? DEFAULT_ADAPTER,
         executionMode,
         verbose,
         trace,
@@ -480,7 +482,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
         mode: "run",
         command: "session-reset",
         sessionId: sessionIdToReset,
-        adapter,
+        adapter: adapter ?? DEFAULT_ADAPTER,
         executionMode,
         verbose,
         trace,
@@ -500,7 +502,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
         command: "session-fork",
         sessionId: sourceSessionId,
         newSessionId,
-        adapter,
+        adapter: adapter ?? DEFAULT_ADAPTER,
         executionMode,
         verbose,
         trace,
@@ -526,7 +528,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
         mode: "run",
         command: "checkpoint-list",
         sessionId,
-        adapter,
+        adapter: adapter ?? DEFAULT_ADAPTER,
         executionMode,
         verbose,
         trace,
@@ -544,7 +546,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
         mode: "run",
         command: "checkpoint-show",
         checkpointId,
-        adapter,
+        adapter: adapter ?? DEFAULT_ADAPTER,
         executionMode,
         verbose,
         trace,
@@ -562,7 +564,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
         mode: "run",
         command: "checkpoint-restore",
         checkpointId,
-        adapter,
+        adapter: adapter ?? DEFAULT_ADAPTER,
         executionMode,
         verbose,
         trace,
@@ -585,7 +587,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     }
     return {
       mode: "repl",
-      adapter,
+      ...(adapter !== undefined ? { adapter } : {}),
       ...(model !== undefined ? { model } : {}),
       executionMode,
       verbose,
@@ -602,7 +604,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     return {
       mode: "run",
       inputFile,
-      adapter,
+      adapter: adapter ?? DEFAULT_ADAPTER,
       ...(model !== undefined ? { model } : {}),
       executionMode,
       verbose,
@@ -617,7 +619,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     mode: "run",
     prompt,
     ...(sessionId !== undefined ? { sessionId } : {}),
-    adapter,
+    adapter: adapter ?? DEFAULT_ADAPTER,
     ...(model !== undefined ? { model } : {}),
     executionMode,
     verbose,
@@ -677,7 +679,7 @@ export const toNormalizedRequest = (
 
   return {
     mode,
-    adapter: args.adapter,
+    adapter: args.adapter ?? DEFAULT_ADAPTER,
     ...(args.model !== undefined ? { model: args.model } : {}),
     executionMode: args.executionMode,
     verbose: args.verbose,

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -32,7 +32,7 @@ export interface CliArgs {
   checkpointId?: string;
   inputFile?: string;
   model?: string;
-  adapter: Adapter;
+  adapter?: Adapter;
   executionMode: ExecutionMode;
   verbose: boolean;
   trace: boolean;

--- a/tests/ts/unit/cli/parse.test.ts
+++ b/tests/ts/unit/cli/parse.test.ts
@@ -52,6 +52,18 @@ describe("parseCliArgs", () => {
     });
   });
 
+  it("parses repl mode without an adapter so startup can prompt for one", () => {
+    const parsed = parseCliArgs(["repl"]);
+    expect(parsed).toEqual({
+      mode: "repl",
+      executionMode: "stub",
+      verbose: false,
+      trace: false,
+      showHelp: false,
+      helpTopic: "repl",
+    });
+  });
+
   it("parses batch file mode", () => {
     const parsed = parseCliArgs(["--file", "tests/data/row_data.json", "--verbose"]);
     expect(parsed).toEqual({

--- a/tests/ts/unit/cli/repl.test.ts
+++ b/tests/ts/unit/cli/repl.test.ts
@@ -22,6 +22,10 @@ const lastSession: ReplSession = {
 };
 
 describe("repl builtin command routing", () => {
+  it("routes / to the repl command menu builtin", () => {
+    expect(getReplBuiltinCommand("/")).toEqual({ kind: "menu" });
+  });
+
   it("routes /help to the repl help builtin", () => {
     expect(getReplBuiltinCommand("/help")).toEqual({ kind: "help" });
   });
@@ -134,6 +138,28 @@ describe("repl builtin command routing", () => {
     expect(verboseResult.shouldExit).toBe(false);
     expect(verboseResult.nextState.verbose).toBe(true);
     expect(verboseResult.output).toContain("REPL 상세 출력이 true(으)로 설정되었습니다.");
+  });
+
+  it("renders the repl command menu for /", () => {
+    const initialState = {
+      adapter: "codex" as const,
+      model: "gpt-5",
+      executionMode: "stub" as const,
+      verbose: false,
+    };
+
+    const menuResult = runReplBuiltinCommand(
+      { kind: "menu" },
+      initialState,
+      "repl-session-123",
+    );
+    expect(menuResult.shouldExit).toBe(false);
+    expect(menuResult.output).toContain("REPL 명령어 목록");
+    expect(menuResult.output).toContain("/help");
+    expect(menuResult.output).toContain("/adapter gemini");
+    expect(menuResult.output).toContain("/verbose off");
+    expect(menuResult.output).toContain("/quit");
+    expect(menuResult.output).not.toContain("이 명령어 목록 표시");
   });
 
   it("keeps non-interactive guidance for /adapter and /verbose without args", () => {


### PR DESCRIPTION
## Summary
- Allow REPL to start without `--adapter` and prompt interactively when needed.
- Typing `/` at the main REPL prompt now shows an inline builtin command menu.
- Keep CLI parsing/types aligned and add unit tests for the new routing.
- Refresh `.env.example` for the local LLM runtime settings.

## Changes
- REPL now resolves an initial adapter from the last session or prompts interactively when no adapter is provided.
- Added a new `/` builtin route that renders the inline command menu.
- Updated CLI argument parsing so REPL can omit the adapter at startup.
- Added unit coverage for the new parsing and REPL command behavior.
- Cleaned up `.env.example` to reflect the current local LLM config.

## Verification
- `npm run typecheck`
- `npm test -- tests/ts/unit/cli/parse.test.ts tests/ts/unit/cli/repl.test.ts`