### PR TITLE
feat: add claude adapter

### DIFF
--- a/src/cli/adapter-info/claude.ts
+++ b/src/cli/adapter-info/claude.ts
@@ -1,0 +1,48 @@
+import { execSync } from "node:child_process";
+
+export interface ClaudeLoginStatus {
+  authenticated: boolean;
+  authType: string | undefined;
+  apiProvider: string | undefined;
+}
+
+export const getClaudeLoginStatus = (): ClaudeLoginStatus => {
+  try {
+    const output = execSync("claude auth status --json 2>&1", { encoding: "utf-8" }).trim();
+    const status = JSON.parse(output) as {
+      loggedIn?: boolean;
+      authMethod?: string;
+      apiProvider?: string;
+    };
+
+    return {
+      authenticated: Boolean(status.loggedIn),
+      authType: status.loggedIn
+        ? [status.authMethod, status.apiProvider].filter(Boolean).join(" / ") || "authenticated"
+        : undefined,
+      apiProvider: status.apiProvider,
+    };
+  } catch {
+    return {
+      authenticated: false,
+      authType: undefined,
+      apiProvider: undefined,
+    };
+  }
+};
+
+export interface ClaudeModel {
+  slug: string;
+  display_name: string;
+}
+
+export const getClaudeAvailableModels = (): ClaudeModel[] => [];
+
+export const claudeLogout = (): boolean => {
+  try {
+    execSync("claude auth logout 2>&1", { encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/src/cli/adapter-info/index.ts
+++ b/src/cli/adapter-info/index.ts
@@ -1,3 +1,10 @@
+import type { Adapter } from "../../core/pipeline/types.js";
+import { getAdapterModel } from "../config/config-manager.js";
+import {
+  getClaudeLoginStatus,
+  getClaudeAvailableModels,
+  claudeLogout,
+} from "./claude.js";
 import {
   getCodexLoginStatus,
   getCodexAvailableModels,
@@ -27,37 +34,54 @@ export interface AdapterModel {
 }
 
 export const getAdapterStatus = (
-  adapter: "codex" | "gemini",
+  adapter: Adapter,
 ): AdapterStatus => {
+  const currentModel = getAdapterModel(adapter);
+
   if (adapter === "codex") {
     const status = getCodexLoginStatus();
     return {
       authenticated: status.authenticated,
       account: status.account,
       authType: undefined,
-      currentModel: undefined,
+      currentModel,
     };
-  } else {
+  }
+
+  if (adapter === "gemini") {
     const status = getGeminiLoginStatus();
     const config = getGeminiConfig();
     return {
       authenticated: status.authenticated,
       account: undefined,
       authType: status.authType,
-      currentModel: config.currentModel,
+      currentModel: config.currentModel ?? currentModel,
     };
   }
+
+  const status = getClaudeLoginStatus();
+  return {
+    authenticated: status.authenticated,
+    account: undefined,
+    authType: status.authType,
+    currentModel,
+  };
 };
 
 export const getAdapterModels = (
-  adapter: "codex" | "gemini",
+  adapter: Adapter,
 ): AdapterModel[] => {
   if (adapter === "codex") {
     return getCodexAvailableModels();
-  } else {
+  }
+
+  if (adapter === "gemini") {
     return getGeminiAvailableModels();
   }
+
+  return getClaudeAvailableModels();
 };
 
 export { getCodexLoginStatus, getCodexAvailableModels, codexLogout };
 export { getGeminiLoginStatus, getGeminiAvailableModels, getGeminiConfig, geminiLogout };
+export { getClaudeLoginStatus, getClaudeAvailableModels, claudeLogout };

--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -16,7 +16,7 @@ import { startSpinner } from "../terminal-spinner.js";
 
 const EXIT_COMMANDS = new Set(["exit", "quit", ".exit"]);
 const EXIT_BUILTIN_COMMANDS = new Set(["exit", "quit", ".exit", "/exit", "/quit"]);
-const LOGIN_MENU_OPTIONS = ["codex", "gemini"] as const;
+const LOGIN_MENU_OPTIONS = ["codex", "gemini", "claude"] as const;
 const VERBOSE_MENU_OPTIONS = ["on", "off"] as const;
 
 export type ReplBuiltinCommand =
@@ -140,7 +140,7 @@ export const getNextSelectionIndex = (
 export const getNextLoginSelectionIndex = (
   currentIndex: number,
   direction: "up" | "down",
-  optionCount = LOGIN_MENU_OPTIONS.length,
+  optionCount: number = LOGIN_MENU_OPTIONS.length,
 ): number => getNextSelectionIndex(currentIndex, direction, optionCount);
 
 export const getLoginCommandSpec = (
@@ -150,17 +150,22 @@ export const getLoginCommandSpec = (
     return { command: "codex", args: ["login"] };
   }
 
-  return { command: "gemini", args: [] };
+  if (adapter === "gemini") {
+    return { command: "gemini", args: [] };
+  }
+
+  return { command: "claude", args: ["auth", "login"] };
 };
 
 function formatReplCommandMenu(state: ReplRuntimeState): string {
   const commands = [
     ["/help", "REPL 도움말 표시"],
-    ["/login", "Codex/Gemini 로그인 흐름 시작"],
+    ["/login", "Codex/Gemini/Claude Code 로그인 흐름 시작"],
     ["/session", "현재 REPL 세션과 런타임 정보 확인"],
     ["/adapter", "어댑터 선택 UI 표시"],
     ["/adapter codex", "이후 프롬프트의 어댑터를 codex로 변경"],
     ["/adapter gemini", "이후 프롬프트의 어댑터를 gemini로 변경"],
+    ["/adapter claude", "이후 프롬프트의 어댑터를 claude로 변경"],
     ["/codex-models (/cms)", "Codex 모델 및 추론 강도 선택"],
     ["/gemini-models (/gms)", "Gemini 모델 선택 및 변경"],
     ["/model", "모델 변경 안내 표시"],
@@ -249,15 +254,16 @@ export const runReplBuiltinCommand = (
         shouldExit: false,
         output:
           JSON.stringify(
-            {
-              ok: true,
-              mode: "repl",
-              adapter: state.adapter,
-              message: "/adapter codex 또는 /adapter gemini 를 입력해 어댑터를 변경하세요.",
-            },
-            null,
-            2,
-          ) + "\n",
+              {
+                ok: true,
+                mode: "repl",
+                adapter: state.adapter,
+                message:
+                  "/adapter codex, /adapter gemini, 또는 /adapter claude 를 입력해 어댑터를 변경하세요.",
+              },
+              null,
+              2,
+            ) + "\n",
         nextState: state,
       };
     }
@@ -403,14 +409,14 @@ export const resolveReplSessionId = async ({
 
 export const runReplCommand = async (baseArgs: CliArgs): Promise<void> => {
   // 저장된 설정 로드 및 환경변수 적용 (CLI adapter에 맞는 모델만 로드)
-  loadAndApplyConfig(baseArgs.adapter as "codex" | "gemini");
+  loadAndApplyConfig(baseArgs.adapter);
 
   await runModelSetupIfNeeded();
 
   const rl = createInterface({ input, output });
   const sessionId = `repl-${Date.now()}`;
   let verbose = baseArgs.verbose;
-  let currentAdapter = baseArgs.adapter as "codex" | "gemini";
+  let currentAdapter = baseArgs.adapter;
 
   const startMessage = [
     colors.title("detoks repl 시작"),

--- a/src/cli/config/config-manager.ts
+++ b/src/cli/config/config-manager.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import type { Adapter } from "../../core/pipeline/types.js";
 import type { DetoksConfig } from "./types.js";
 import {
   CODEX_REASONING_EFFORT_VALUES,
@@ -52,7 +53,7 @@ export const saveConfig = (config: DetoksConfig): void => {
 };
 
 export const updateAdapterModel = (
-  adapter: "codex" | "gemini",
+  adapter: Adapter,
   model: string,
 ): void => {
   const config = loadConfig();
@@ -104,7 +105,7 @@ export const resetTranslationModel = (): boolean => {
   return true;
 };
 
-export const getAdapterModel = (adapter: "codex" | "gemini"): string | undefined => {
+export const getAdapterModel = (adapter: Adapter): string | undefined => {
   const config = loadConfig();
   return config.adapter.models[adapter];
 };
@@ -114,12 +115,12 @@ export const getTranslationModel = (): string | undefined => {
   return config.translation.model;
 };
 
-export const getSelectedAdapter = (): "codex" | "gemini" => {
+export const getSelectedAdapter = (): Adapter => {
   const config = loadConfig();
   return config.adapter.selected;
 };
 
-export const updateSelectedAdapter = (adapter: "codex" | "gemini"): void => {
+export const updateSelectedAdapter = (adapter: Adapter): void => {
   const config = loadConfig();
   config.adapter.selected = adapter;
   saveConfig(config);

--- a/src/cli/config/loader.ts
+++ b/src/cli/config/loader.ts
@@ -1,6 +1,7 @@
+import type { Adapter } from "../../core/pipeline/types.js";
 import { loadConfig, getAdapterModel, getTranslationModel } from "./config-manager.js";
 
-export const applyConfigToEnv = (adapter: "codex" | "gemini"): void => {
+export const applyConfigToEnv = (adapter: Adapter): void => {
   const config = loadConfig();
 
   // CLI adapter에 해당하는 모델만 로드
@@ -18,6 +19,6 @@ export const applyConfigToEnv = (adapter: "codex" | "gemini"): void => {
   }
 };
 
-export const loadAndApplyConfig = (adapter: "codex" | "gemini"): void => {
+export const loadAndApplyConfig = (adapter: Adapter): void => {
   applyConfigToEnv(adapter);
 };

--- a/src/cli/config/types.ts
+++ b/src/cli/config/types.ts
@@ -1,3 +1,5 @@
+import type { Adapter } from "../../core/pipeline/types.js";
+
 export const CODEX_REASONING_EFFORT_VALUES = ["low", "medium", "high", "xhigh"] as const;
 export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORT_VALUES)[number];
 
@@ -5,11 +7,8 @@ export interface DetoksConfig {
   version: string;
   lastUpdated: string;
   adapter: {
-    selected: "codex" | "gemini";
-    models: {
-      codex: string | undefined;
-      gemini: string | undefined;
-    };
+    selected: Adapter;
+    models: Record<Adapter, string | undefined>;
     codexReasoningEffort?: CodexReasoningEffort;
   };
   translation: {
@@ -25,6 +24,7 @@ export const DEFAULT_CONFIG: DetoksConfig = {
     models: {
       codex: undefined,
       gemini: undefined,
+      "claude": undefined,
     },
   },
   translation: {

--- a/src/cli/interactive/prompt-builder.ts
+++ b/src/cli/interactive/prompt-builder.ts
@@ -1,7 +1,8 @@
+import type { Adapter } from "../../core/pipeline/types.js";
 import { colors } from "../colors.js";
 
 export interface PromptState {
-  adapter: "codex" | "gemini";
+  adapter: Adapter;
   adapterModel: string | undefined;
   translationModel: string | undefined;
 }

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -8,6 +8,7 @@ import {
 } from "./types.js";
 
 const DEFAULT_ADAPTER = "codex";
+const ADAPTER_HELP = "codex|gemini|claude";
 const DEFAULT_EXECUTION_MODE = "real";
 const MAIN_HELP_HINT = "사용법은 `detoks --help`를 확인하세요.";
 const topicHelpHint = (topic: string): string => `사용법은 \`${topic}\`를 확인하세요.`;
@@ -29,7 +30,7 @@ const SESSION_SHOW_VERBOSE_HELP =
 const CLI_USAGE_MAIN = [
   "사용법:",
   "  detoks                         인자 없이 실행하면 대화형 REPL로 진입합니다",
-  "  detoks repl [--adapter codex|gemini] [--execution-mode stub|real] [--session <id>] [--verbose]",
+  `  detoks repl [--adapter ${ADAPTER_HELP}] [--execution-mode stub|real] [--session <id>] [--verbose]`,
   "  detoks --file <path> [--verbose]",
   "  detoks session list [--human]",
   "  detoks session show <session-id> [--human]",
@@ -61,7 +62,7 @@ const CLI_USAGE_MAIN = [
   "  detoks checkpoint restore session_2026_04_27_checkpoint_001",
   "",
   "옵션:",
-  "  --adapter codex|gemini        대상 어댑터(기본값: codex)",
+  `  --adapter ${ADAPTER_HELP}        대상 어댑터(기본값: codex)`,
   "  --execution-mode stub|real    실행 모드(기본값: real)",
   "  --file <path>                 JSON 파일로 일괄 프롬프트 컴파일을 실행합니다",
   SESSION_FLAG_HELP,
@@ -235,7 +236,7 @@ const CLI_USAGE_CHECKPOINT_RESTORE = [
 
 const CLI_USAGE_REPL = [
   "사용법:",
-  "  detoks repl [--adapter codex|gemini] [--execution-mode stub|real] [--session <id>] [--verbose]",
+  `  detoks repl [--adapter ${ADAPTER_HELP}] [--execution-mode stub|real] [--session <id>] [--verbose]`,
   "  detoks repl --help",
   "",
   "예시:",
@@ -248,7 +249,7 @@ const CLI_USAGE_REPL = [
   "  - execution-mode는 프롬프트를 모의 실행으로 할지 실제 실행으로 할지 결정합니다",
   "",
   "옵션:",
-  "  --adapter codex|gemini        대상 어댑터(기본값: codex)",
+  `  --adapter ${ADAPTER_HELP}        대상 어댑터(기본값: codex)`,
   "  --execution-mode stub|real    실행 모드(기본값: real)",
   SESSION_FLAG_HELP,
   EXECUTION_MODE_HELP,
@@ -338,10 +339,10 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     if (current === "--adapter") {
       const next = argv[i + 1];
       if (!next) {
-        throw new Error(`--adapter에는 codex|gemini 값이 필요합니다. ${MAIN_HELP_HINT}`);
+        throw new Error(`--adapter에는 ${ADAPTER_HELP} 값이 필요합니다. ${MAIN_HELP_HINT}`);
       }
       if (!isAdapter(next)) {
-        throw new Error(`지원하지 않는 adapter: ${next}. codex 또는 gemini를 사용하세요.`);
+        throw new Error(`지원하지 않는 adapter: ${next}. codex, gemini, 또는 claude를 사용하세요.`);
       }
       adapter = next;
       i += 1;
@@ -351,7 +352,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     if (current.startsWith("--adapter=")) {
       const inline = current.split("=")[1] ?? "";
       if (!isAdapter(inline)) {
-        throw new Error(`지원하지 않는 adapter: ${inline}. codex 또는 gemini를 사용하세요.`);
+        throw new Error(`지원하지 않는 adapter: ${inline}. codex, gemini, 또는 claude를 사용하세요.`);
       }
       adapter = inline;
       continue;

--- a/src/cli/repl-commands/index.ts
+++ b/src/cli/repl-commands/index.ts
@@ -2,8 +2,10 @@ import { stdout as output } from "node:process";
 import { createInterface } from "node:readline/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import type { Adapter } from "../../core/pipeline/types.js";
 import { colors } from "../colors.js";
 import {
+  claudeLogout,
   getAdapterStatus,
   getAdapterModels,
   codexLogout,
@@ -55,7 +57,7 @@ const BASE_COMMANDS: SlashCommand[] = [
   {
     name: "adapter",
     aliases: ["a"],
-    description: "현재 설정된 어댑터 확인 (codex/gemini)",
+    description: "현재 설정된 어댑터 확인 (codex/gemini/claude)",
     usage: "/adapter",
   },
   {
@@ -79,7 +81,7 @@ const BASE_COMMANDS: SlashCommand[] = [
 ];
 
 const getAuthenticatedCommands = (
-  adapter: "codex" | "gemini",
+  adapter: Adapter,
 ): SlashCommand[] => {
   if (adapter === "codex") {
     return [
@@ -96,7 +98,9 @@ const getAuthenticatedCommands = (
         usage: "/logout",
       },
     ];
-  } else {
+  }
+
+  if (adapter === "gemini") {
     return [
       {
         name: "gemini-models",
@@ -112,15 +116,24 @@ const getAuthenticatedCommands = (
       },
     ];
   }
+
+  return [
+    {
+      name: "logout",
+      aliases: ["out"],
+      description: "현재 어댑터에서 로그아웃",
+      usage: "/logout",
+    },
+  ];
 };
 
-const isAuthenticated = (adapter: "codex" | "gemini"): boolean => {
+const isAuthenticated = (adapter: Adapter): boolean => {
   const status = getAdapterStatus(adapter);
   return status.authenticated;
 };
 
 export const getActiveSlashCommands = (
-  adapter: "codex" | "gemini",
+  adapter: Adapter,
 ): SlashCommand[] => {
   const authCommands = isAuthenticated(adapter)
     ? getAuthenticatedCommands(adapter)
@@ -130,7 +143,7 @@ export const getActiveSlashCommands = (
 
 export const getSlashCommand = (
   input: string,
-  adapter: "codex" | "gemini",
+  adapter: Adapter,
 ): SlashCommand | null => {
   if (!input.startsWith("/")) return null;
 
@@ -147,12 +160,18 @@ export const getSlashCommand = (
 
 export const isSlashCommand = (
   input: string,
-  adapter: "codex" | "gemini",
+  adapter: Adapter,
 ): boolean => {
   return input.startsWith("/") && getSlashCommand(input, adapter) !== null;
 };
 
-export const showHelpMessage = (adapter: "codex" | "gemini"): void => {
+const getLoginHint = (adapter: Adapter): string =>
+  adapter === "claude" ? "claude auth login" : `${adapter} login`;
+
+const getLogoutHint = (adapter: Adapter): string =>
+  adapter === "claude" ? "claude auth logout" : `${adapter} logout`;
+
+export const showHelpMessage = (adapter: Adapter): void => {
   output.write(`\n${colors.title("사용 가능한 명령어\n")}`);
 
   const activeCommands = getActiveSlashCommands(adapter);
@@ -181,7 +200,7 @@ export const showHelpMessage = (adapter: "codex" | "gemini"): void => {
     );
     output.write(
       colors.muted(
-        `   외부에서 '${adapter} login' 명령어를 실행한 후 사용하세요.\n`,
+        `   외부에서 '${getLoginHint(adapter)}' 명령어를 실행한 후 사용하세요.\n`,
       ),
     );
   } else {
@@ -206,13 +225,13 @@ export const handleSlashCommand = async (
     modelName: string | undefined;
     verbose: boolean;
     onVerboseToggle: (enabled: boolean) => void;
-    onAdapterChange: (newAdapter: "codex" | "gemini") => Promise<void>;
+    onAdapterChange: (newAdapter: Adapter) => Promise<void>;
     onExit: () => Promise<void>;
     onInteractiveStart?: () => void;
     onInteractiveEnd?: () => void;
   },
 ): Promise<boolean> => {
-  const adapter = state.adapter as "codex" | "gemini";
+  const adapter = state.adapter as Adapter;
   const selectStreams: SelectWithArrowsStreams = {
     ...(state.onInteractiveStart ? { onOpen: state.onInteractiveStart } : {}),
     ...(state.onInteractiveEnd ? { onClose: state.onInteractiveEnd } : {}),
@@ -444,10 +463,15 @@ const handleGeminiModels = async (streams?: SelectWithArrowsStreams): Promise<bo
   return true;
 };
 
-const handleLogout = async (adapter: "codex" | "gemini"): Promise<boolean> => {
+const handleLogout = async (adapter: Adapter): Promise<boolean> => {
   output.write(`\n${colors.title(`${adapter.toUpperCase()} 로그아웃\n`)}`);
 
-  const success = adapter === "codex" ? codexLogout() : geminiLogout();
+  const success =
+    adapter === "codex"
+      ? codexLogout()
+      : adapter === "gemini"
+        ? geminiLogout()
+        : claudeLogout();
 
   if (success) {
     output.write(
@@ -456,7 +480,7 @@ const handleLogout = async (adapter: "codex" | "gemini"): Promise<boolean> => {
   } else {
     output.write(
       colors.error(
-        `✗ 로그아웃 실패. 외부에서 '${adapter} logout' 명령어를 실행해주세요.\n\n`,
+        `✗ 로그아웃 실패. 외부에서 '${getLogoutHint(adapter)}' 명령어를 실행해주세요.\n\n`,
       ),
     );
   }
@@ -581,13 +605,13 @@ const handleTranslationModel = async (streams?: SelectWithArrowsStreams): Promis
 };
 
 const handleAdapterSwitch = async (
-  currentAdapter: "codex" | "gemini",
-  onAdapterChange: (newAdapter: "codex" | "gemini") => Promise<void>,
+  currentAdapter: Adapter,
+  onAdapterChange: (newAdapter: Adapter) => Promise<void>,
   streams?: SelectWithArrowsStreams,
 ): Promise<boolean> => {
   output.write(`\n${colors.title("어댑터 선택")}\n\n`);
 
-  const adapters = ["codex", "gemini"] as const;
+  const adapters: Adapter[] = ["codex", "gemini", "claude"];
   const options = adapters.map((a) => {
     const status = getAdapterStatus(a);
     const statusStr = status.authenticated
@@ -605,7 +629,7 @@ const handleAdapterSwitch = async (
     return true;
   }
 
-  const newAdapter = selected as "codex" | "gemini";
+  const newAdapter = selected as Adapter;
 
   if (newAdapter === currentAdapter) {
     output.write(colors.info(`\n현재 어댑터: ${currentAdapter}\n\n`));
@@ -625,7 +649,7 @@ const handleAdapterSwitch = async (
         `다른 터미널에서 다음 명령을 실행한 후 다시 시도하세요:\n`,
       ),
     );
-    output.write(colors.info(`  ${newAdapter} login\n\n`));
+    output.write(colors.info(`  ${getLoginHint(newAdapter)}\n\n`));
     return true;
   }
 

--- a/src/cli/terminal-style.ts
+++ b/src/cli/terminal-style.ts
@@ -1,3 +1,5 @@
+import type { Adapter } from "../core/pipeline/types.js";
+
 const ANSI = {
   reset: "\x1b[0m",
   bold: "\x1b[1m",
@@ -14,7 +16,7 @@ export interface TerminalStyleOptions {
   env: NodeJS.ProcessEnv;
 }
 
-type AdapterName = "codex" | "gemini";
+type AdapterName = Adapter;
 
 export const shouldUseTerminalColor = ({ isTTY, env }: TerminalStyleOptions): boolean => {
   if (!isTTY) {
@@ -42,7 +44,11 @@ const wrap = (enabled: boolean, text: string, ...codes: string[]): string =>
 export const createTerminalStyle = (options: TerminalStyleOptions) => {
   const enabled = shouldUseTerminalColor(options);
   const adapterAccent = (adapter: AdapterName): string =>
-    adapter === "gemini" ? ANSI.magenta : ANSI.cyan;
+    adapter === "gemini"
+      ? ANSI.magenta
+      : adapter === "claude"
+        ? ANSI.yellow
+        : ANSI.cyan;
 
   return {
     enabled,

--- a/src/core/executor/execute.ts
+++ b/src/core/executor/execute.ts
@@ -2,6 +2,7 @@ import type { Adapter } from "../pipeline/types.js";
 import type { ExecutorRequest, ExecutorResult } from "./types.js";
 import type { CliAdapter } from "../../integrations/adapters/interface.js";
 import { CodexStubAdapter } from "../../integrations/adapters/codex/adapter.js";
+import { ClaudeStubAdapter } from "../../integrations/adapters/claude/adapter.js";
 import { GeminiStubAdapter } from "../../integrations/adapters/gemini/adapter.js";
 import {
   createRealSubprocessRunner,
@@ -11,6 +12,7 @@ import {
 const adapterRegistry: Record<Adapter, CliAdapter> = {
   codex: new CodexStubAdapter(),
   gemini: new GeminiStubAdapter(),
+  "claude": new ClaudeStubAdapter(),
 };
 
 export const getAdapter = (adapter: Adapter): CliAdapter => adapterRegistry[adapter];

--- a/src/core/pipeline/types.ts
+++ b/src/core/pipeline/types.ts
@@ -4,7 +4,7 @@ import type { CompressTextImplementation } from "../prompt/compression.js";
 import type { TraceLog } from "../utils/PipelineTracer.js";
 import type { TokenMetricsSnapshot } from "../utils/tokenMetrics.js";
 
-export const AdapterValues = ["codex", "gemini"] as const;
+export const AdapterValues = ["codex", "gemini", "claude"] as const;
 export type Adapter = (typeof AdapterValues)[number];
 export type InteractionMode = "run" | "repl";
 export const ExecutionModeValues = ["stub", "real"] as const;

--- a/src/integrations/adapters/claude/adapter.ts
+++ b/src/integrations/adapters/claude/adapter.ts
@@ -1,0 +1,41 @@
+import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../../core/executor/types.js";
+import type { AdapterExecutionContext, CliAdapter } from "../interface.js";
+import { executeAdapterViaSubprocess } from "../real.js";
+import { buildStubRawOutput } from "../stub.js";
+
+const CLAUDE_PERMISSION_MODE = "default" as const;
+
+export class ClaudeStubAdapter implements CliAdapter {
+  readonly target = "claude" as const;
+
+  buildSubprocessRequest(request: AdapterExecutionRequest) {
+    return {
+      command: "claude",
+      args: [
+        "-p",
+        "--output-format",
+        "text",
+        "--permission-mode",
+        CLAUDE_PERMISSION_MODE,
+        ...(request.model ? ["--model", request.model] : []),
+      ],
+      ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+      input: request.prompt,
+    };
+  }
+
+  async execute(
+    request: AdapterExecutionRequest,
+    context?: AdapterExecutionContext,
+  ): Promise<AdapterExecutionResult> {
+    if (context?.executionMode === "real") {
+      return executeAdapterViaSubprocess(this, request, context);
+    }
+
+    return {
+      success: true,
+      rawOutput: buildStubRawOutput(this.target, request.prompt),
+      exitCode: 0,
+    };
+  }
+}

--- a/tests/ts/unit/cli/parse.test.ts
+++ b/tests/ts/unit/cli/parse.test.ts
@@ -20,19 +20,33 @@ describe("parseCliArgs", () => {
     const parsed = parseCliArgs([
       "repl",
       "--adapter",
-      "gemini",
+      "claude",
       "--execution-mode",
       "real",
       "--verbose",
     ]);
     expect(parsed).toEqual({
       mode: "repl",
-      adapter: "gemini",
+      adapter: "claude",
       executionMode: "real",
       verbose: true,
       trace: false,
       showHelp: false,
       helpTopic: "repl",
+    });
+  });
+
+  it("accepts claude as a direct adapter flag", () => {
+    const parsed = parseCliArgs(["--adapter", "claude", "hello detoks"]);
+    expect(parsed).toMatchObject({
+      mode: "run",
+      prompt: "hello detoks",
+      adapter: "claude",
+      executionMode: "real",
+      verbose: false,
+      trace: false,
+      showHelp: false,
+      helpTopic: "main",
     });
   });
 
@@ -331,7 +345,9 @@ describe("parseCliArgs", () => {
     expect(usage).toContain("예시:");
     expect(usage).toContain("detoks");
     expect(usage).toContain("detoks                         인자 없이 실행하면 대화형 REPL로 진입합니다");
-    expect(usage).toContain("detoks repl [--adapter codex|gemini] [--execution-mode stub|real] [--session <id>] [--verbose]");
+    expect(usage).toContain(
+      "detoks repl [--adapter codex|gemini|claude] [--execution-mode stub|real] [--session <id>] [--verbose]",
+    );
     expect(usage).toContain("detoks --file tests/data/row_data.json --verbose");
     expect(usage).toContain("--file <path>");
     expect(usage).toContain("detoks repl --adapter codex --execution-mode stub");

--- a/tests/ts/unit/cli/repl-cms-flow.test.ts
+++ b/tests/ts/unit/cli/repl-cms-flow.test.ts
@@ -15,10 +15,12 @@ const mocks = vi.hoisted(() => {
     currentModel: undefined,
   }));
 
-  const getAdapterModels = vi.fn((adapter: "codex" | "gemini") =>
+  const getAdapterModels = vi.fn((adapter: "codex" | "gemini" | "claude") =>
     adapter === "codex"
       ? [{ slug: "gpt-5-codex", display_name: "GPT-5 Codex" }]
-      : [{ slug: "gemini-2.5-pro", display_name: "Gemini 2.5 Pro" }],
+      : adapter === "gemini"
+        ? [{ slug: "gemini-2.5-pro", display_name: "Gemini 2.5 Pro" }]
+        : [],
   );
 
   const updateAdapterModel = vi.fn();

--- a/tests/ts/unit/cli/repl.test.ts
+++ b/tests/ts/unit/cli/repl.test.ts
@@ -49,6 +49,10 @@ describe("repl builtin command routing", () => {
       kind: "adapter",
       adapter: "gemini",
     });
+    expect(getReplBuiltinCommand("/adapter claude")).toEqual({
+      kind: "adapter",
+      adapter: "claude",
+    });
     expect(getReplBuiltinCommand("/model")).toEqual({ kind: "model" });
     expect(getReplBuiltinCommand("/model gpt-5")).toEqual({
       kind: "model",
@@ -91,6 +95,10 @@ describe("repl builtin command routing", () => {
       command: "gemini",
       args: [],
     });
+    expect(getLoginCommandSpec("claude")).toEqual({
+      command: "claude",
+      args: ["auth", "login"],
+    });
   });
 
   it("applies /session, /adapter, /model, and /verbose builtin effects", () => {
@@ -120,6 +128,17 @@ describe("repl builtin command routing", () => {
     expect(adapterResult.shouldExit).toBe(false);
     expect(adapterResult.nextState.adapter).toBe("gemini");
     expect(adapterResult.output).toContain("REPL 어댑터가 gemini(으)로 설정되었습니다.");
+
+    const claudeAdapterResult = runReplBuiltinCommand(
+      { kind: "adapter", adapter: "claude" },
+      initialState,
+      "repl-session-123",
+    );
+    expect(claudeAdapterResult.shouldExit).toBe(false);
+    expect(claudeAdapterResult.nextState.adapter).toBe("claude");
+    expect(claudeAdapterResult.output).toContain(
+      "REPL 어댑터가 claude(으)로 설정되었습니다.",
+    );
 
     const modelResult = runReplBuiltinCommand(
       { kind: "model", model: "gemini-2.5-pro" },
@@ -158,6 +177,7 @@ describe("repl builtin command routing", () => {
     expect(menuResult.output).toContain("/help");
     expect(menuResult.output).toContain("/codex-models (/cms)");
     expect(menuResult.output).toContain("/gemini-models (/gms)");
+    expect(menuResult.output).toContain("/adapter claude");
     expect(menuResult.output).toContain("/adapter gemini");
     expect(menuResult.output).toContain("/verbose off");
     expect(menuResult.output).toContain("/quit");
@@ -176,7 +196,9 @@ describe("repl builtin command routing", () => {
       initialState,
       "repl-session-123",
     );
-    expect(adapterResult.output).toContain("/adapter codex 또는 /adapter gemini 를 입력해 어댑터를 변경하세요.");
+    expect(adapterResult.output).toContain(
+      "/adapter codex, /adapter gemini, 또는 /adapter claude 를 입력해 어댑터를 변경하세요.",
+    );
 
     const verboseResult = runReplBuiltinCommand(
       { kind: "verbose" },
@@ -215,6 +237,12 @@ describe("repl builtin command routing", () => {
         "codex::gpt-5::stub",
       ),
     ).toBe(true);
+    expect(
+      shouldEmitReplSourceBadge(
+        { ...initialState, adapter: "claude" as const },
+        "codex::gpt-5::stub",
+      ),
+    ).toBe(true);
   });
 
   it("builds the repl prompt label from the current source", () => {
@@ -234,6 +262,15 @@ describe("repl builtin command routing", () => {
         verbose: true,
       }),
     ).toBe("detoks[gemini]> ");
+
+    expect(
+      getReplPromptLabel({
+        adapter: "claude",
+        model: "claude-sonnet-4-6",
+        executionMode: "stub",
+        verbose: false,
+      }),
+    ).toBe("detoks[claude:claude-sonnet-4-6]> ");
   });
 
   it("tracks source badge emission on first response and source changes", () => {

--- a/tests/ts/unit/cli/terminal-style.test.ts
+++ b/tests/ts/unit/cli/terminal-style.test.ts
@@ -33,6 +33,12 @@ describe("terminal style", () => {
     expect(style.adapterBadge("gemini", { model: "gemini-2.5-pro", executionMode: "real" })).toBe(
       "\x1b[1m\x1b[35m◆ GEMINI[gemini-2.5-pro] · real\x1b[0m",
     );
+    expect(
+      style.adapterBadge("claude", {
+        model: "claude-sonnet-4-6",
+        executionMode: "real",
+      }),
+    ).toBe("\x1b[1m\x1b[33m◆ CLAUDE[claude-sonnet-4-6] · real\x1b[0m");
   });
 
   it("returns plain text when disabled", () => {
@@ -42,6 +48,12 @@ describe("terminal style", () => {
     expect(style.adapterBadge("codex", { model: "gpt-5", executionMode: "real" })).toBe(
       "◆ CODEX[gpt-5] · real",
     );
+    expect(
+      style.adapterBadge("claude", {
+        model: "claude-sonnet-4-6",
+        executionMode: "real",
+      }),
+    ).toBe("◆ CLAUDE[claude-sonnet-4-6] · real");
   });
 
   it("styles help titles, sections, and option names when enabled", () => {

--- a/tests/ts/unit/core/executor/execute.test.ts
+++ b/tests/ts/unit/core/executor/execute.test.ts
@@ -67,6 +67,23 @@ describe("executeWithAdapter", () => {
     expect(subprocessMocks.createRealRunner).not.toHaveBeenCalled();
   });
 
+  it("routes to the claude stub adapter", async () => {
+    const result = await executeWithAdapter({
+      adapter: "claude",
+      mode: "run",
+      executionMode: "stub",
+      prompt: "hello claude",
+      verbose: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.adapter).toBe("claude");
+    expect(result.rawOutput).toBe("[stub:claude] hello claude");
+    expect(result.exitCode).toBe(0);
+    expect(subprocessMocks.createStubRunner).toHaveBeenCalledTimes(1);
+    expect(subprocessMocks.createRealRunner).not.toHaveBeenCalled();
+  });
+
   it("uses the real execution path when requested", async () => {
     const result = await executeWithAdapter({
       adapter: "codex",

--- a/tests/ts/unit/integrations/adapters/adapter-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/adapter-path.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { CodexStubAdapter } from "../../../../../src/integrations/adapters/codex/adapter.js";
+import { ClaudeStubAdapter } from "../../../../../src/integrations/adapters/claude/adapter.js";
 import { GeminiStubAdapter } from "../../../../../src/integrations/adapters/gemini/adapter.js";
 import { executeAdapterViaSubprocess } from "../../../../../src/integrations/adapters/real.js";
 import { createStubSubprocessRunner } from "../../../../../src/integrations/subprocess/runner.js";
@@ -76,6 +77,32 @@ describe("adapter subprocess path", () => {
     });
   });
 
+  it("builds claude subprocess requests explicitly", () => {
+    const adapter = new ClaudeStubAdapter();
+    expect(
+      adapter.buildSubprocessRequest({
+        mode: "run",
+        prompt: "hello claude",
+        verbose: true,
+        model: "claude-sonnet-4-6",
+        cwd: "/tmp",
+      }),
+    ).toEqual({
+      command: "claude",
+      args: [
+        "-p",
+        "--output-format",
+        "text",
+        "--permission-mode",
+        "default",
+        "--model",
+        "claude-sonnet-4-6",
+      ],
+      cwd: "/tmp",
+      input: "hello claude",
+    });
+  });
+
   it("routes a codex request through the subprocess boundary", async () => {
     const adapter = new CodexStubAdapter();
     const result = await executeAdapterViaSubprocess(
@@ -95,6 +122,29 @@ describe("adapter subprocess path", () => {
     expect(result.success).toBe(true);
     expect(result.rawOutput).toBe(
       "[stub:subprocess] codex exec --model gpt-5 - --sandbox workspace-write --skip-git-repo-check --color never",
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("routes a claude request through the subprocess boundary", async () => {
+    const adapter = new ClaudeStubAdapter();
+    const result = await executeAdapterViaSubprocess(
+      adapter,
+      {
+        mode: "run",
+        prompt: "hello subprocess",
+        verbose: false,
+        model: "claude-sonnet-4-6",
+      },
+      {
+        executionMode: "real",
+        subprocessRunner: createStubSubprocessRunner(),
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.rawOutput).toBe(
+      "[stub:subprocess] claude -p --output-format text --permission-mode default --model claude-sonnet-4-6",
     );
     expect(result.exitCode).toBe(0);
   });

--- a/tests/ts/unit/integrations/adapters/real-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/real-path.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { CodexStubAdapter } from "../../../../../src/integrations/adapters/codex/adapter.js";
+import { ClaudeStubAdapter } from "../../../../../src/integrations/adapters/claude/adapter.js";
 import { GeminiStubAdapter } from "../../../../../src/integrations/adapters/gemini/adapter.js";
 import type { SubprocessRequest } from "../../../../../src/integrations/subprocess/types.js";
 import type { SubprocessRunner } from "../../../../../src/integrations/subprocess/types.js";
@@ -12,7 +13,7 @@ const fakeRunner: SubprocessRunner = {
     return {
       stdout: `[fake:${request.command}] ${request.input ?? ""}`,
       stderr: "",
-      exitCode: request.command === "codex" ? 0 : 3,
+      exitCode: request.command === "gemini" ? 3 : 0,
       timedOut: false,
     };
   },
@@ -89,6 +90,44 @@ describe("adapter execution modes", () => {
     expect(realResult.exitCode).toBe(3);
   });
 
+  it("records claude real execution requests with the claude command", async () => {
+    capturedRequests.length = 0;
+    const adapter = new ClaudeStubAdapter();
+
+    const realResult = await adapter.execute(
+      {
+        mode: "run",
+        prompt: "real prompt",
+        verbose: false,
+        model: "claude-sonnet-4-6",
+        cwd: "/workspace",
+      },
+      {
+        executionMode: "real",
+        subprocessRunner: fakeRunner,
+      },
+    );
+
+    expect(capturedRequests).toEqual([
+      {
+        command: "claude",
+        args: [
+          "-p",
+          "--output-format",
+          "text",
+          "--permission-mode",
+          "default",
+          "--model",
+          "claude-sonnet-4-6",
+        ],
+        cwd: "/workspace",
+        input: "real prompt",
+      },
+    ]);
+    expect(realResult.rawOutput).toBe("[fake:claude] real prompt");
+    expect(realResult.exitCode).toBe(0);
+  });
+
   it("keeps codex stub execution separate from real execution", async () => {
     const adapter = new CodexStubAdapter();
 
@@ -141,5 +180,32 @@ describe("adapter execution modes", () => {
     expect(stubResult.exitCode).toBe(0);
     expect(realResult.rawOutput).toBe("[fake:gemini] real prompt");
     expect(realResult.exitCode).toBe(3);
+  });
+
+  it("keeps claude stub execution separate from real execution", async () => {
+    const adapter = new ClaudeStubAdapter();
+
+    const stubResult = await adapter.execute({
+      mode: "run",
+      prompt: "stub prompt",
+      verbose: false,
+    });
+
+    const realResult = await adapter.execute(
+      {
+        mode: "run",
+        prompt: "real prompt",
+        verbose: false,
+      },
+      {
+        executionMode: "real",
+        subprocessRunner: fakeRunner,
+      },
+    );
+
+    expect(stubResult.rawOutput).toBe("[stub:claude] stub prompt");
+    expect(stubResult.exitCode).toBe(0);
+    expect(realResult.rawOutput).toBe("[fake:claude] real prompt");
+    expect(realResult.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Adds Claude Code support as a first-class adapter under the `claude` id.

Summary:
- registers `claude` in adapter types, parser, REPL, and executor registry
- adds Claude adapter runtime and adapter-info handlers
- updates unit/integration coverage for parser, REPL, executor, and adapter paths

Notes:
- actual CLI command remains `claude`
- local-only pipeline status doc was updated but is intentionally not part of this push