### PR TITLE
Add Windows support for TSX CLI and native runtimes

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -97,5 +97,5 @@ detoks repl --adapter codex --execution-mode stub
 
 ## Windows usage
 
-Windows native execution is not supported; use WSL Ubuntu instead.
+Windows native execution is supported when Node.js, Python 3.13, uv, and a Windows `llama-server.exe` build are installed. Set `LOCAL_LLM_SERVER_BINARY` to the executable path when it is not on `PATH`.
 See [LLAMA_CPP_SERVER_SPEC.md](./docs/LLAMA_CPP_SERVER_SPEC.md) for installation and execution details.

--- a/bin/detoks.js
+++ b/bin/detoks.js
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { createRequire } from "node:module";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const require = createRequire(import.meta.url);
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -17,7 +17,12 @@ const launch = (() => {
       const tsxLoader = require.resolve("tsx");
       return {
         command: process.execPath,
-        args: ["--import", tsxLoader, sourceEntry, ...cliArgs],
+        args: [
+          "--import",
+          pathToFileURL(tsxLoader).href,
+          sourceEntry,
+          ...cliArgs,
+        ],
       };
     } catch {
       // Fall back to the built JS entrypoint when tsx is unavailable.

--- a/docs/LLAMA_CPP_SERVER_SPEC.md
+++ b/docs/LLAMA_CPP_SERVER_SPEC.md
@@ -78,6 +78,17 @@ This document defines the current `python/llama-server` runtime contract used by
 
 ---
 
+### Windows Native Runtime
+
+Windows native execution does not require WSL when Node.js `>=24.15.0 <26`, Python `3.13.x`, `uv`, and a Windows `llama-server.exe` build are installed. If `llama-server.exe` is not on `PATH`, set `LOCAL_LLM_SERVER_BINARY` to the absolute executable path.
+
+PowerShell example:
+
+```powershell
+$env:LOCAL_LLM_SERVER_BINARY = "C:\tools\llama.cpp\llama-server.exe"
+detoks repl --adapter codex --execution-mode stub
+```
+
 ## Execution Modes
 
 ### 1. Proxy Mode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "detoks",
+  "name": "@sorlros/detoks",
   "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "detoks",
+      "name": "@sorlros/detoks",
       "version": "0.1.1",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -13,7 +13,7 @@
         "zod": "4.3.6"
       },
       "bin": {
-        "detoks": "dist/src/cli/index.js"
+        "detoks": "bin/detoks.js"
       },
       "devDependencies": {
         "@types/node": "24.3.1",

--- a/src/cli/model-setup/index.ts
+++ b/src/cli/model-setup/index.ts
@@ -91,16 +91,24 @@ export const runModelSetupIfNeeded = async (cwd: string = process.cwd()): Promis
   process.stdout.write(
     colors.muted("# 빠른 시작\n"),
   );
-  process.stdout.write(
-    colors.muted(
-      "export $(cat .env | xargs)\n",
-    ),
-  );
-  process.stdout.write(
-    colors.muted(
-      'llama-server -m "$LOCAL_LLM_MODEL_PATH" -ngl 32 -c 4096\n\n',
-    ),
-  );
+  if (process.platform === "win32") {
+    process.stdout.write(
+      colors.muted(
+        'llama-server.exe -m "$env:LOCAL_LLM_MODEL_PATH" --gpu-layers all --ctx-size 4096\n\n',
+      ),
+    );
+  } else {
+    process.stdout.write(
+      colors.muted(
+        "export $(cat .env | xargs)\n",
+      ),
+    );
+    process.stdout.write(
+      colors.muted(
+        'llama-server -m "$LOCAL_LLM_MODEL_PATH" -ngl 32 -c 4096\n\n',
+      ),
+    );
+  }
   process.stdout.write(
     colors.info(
       "자세한 가이드: src/cli/model-setup/LLAMA_SERVER_GUIDE.md\n\n",

--- a/src/core/llm-client/local-runtime.ts
+++ b/src/core/llm-client/local-runtime.ts
@@ -153,7 +153,8 @@ async function assertExpectedServerModel(
 
 async function listLlamaServerProcesses(): Promise<Array<{ pid: number; command: string }>> {
   return await new Promise((resolve) => {
-    const child = spawn("pgrep", ["-af", "llama-server"], {
+    const processListCommand = getProcessListCommand();
+    const child = spawn(processListCommand.command, processListCommand.args, {
       stdio: ["ignore", "pipe", "pipe"],
     });
     let stdout = "";
@@ -197,7 +198,8 @@ async function listLlamaServerProcesses(): Promise<Array<{ pid: number; command:
           (
             processInfo,
           ): processInfo is { pid: number; command: string } => processInfo !== null,
-        );
+        )
+        .filter(({ command }) => isLlamaServerCommand(command));
 
       resolve(processes);
     });
@@ -215,7 +217,7 @@ function isProcessAlive(pid: number): boolean {
 
 function commandMatchesPort(command: string, port: number): boolean {
   return (
-    command.includes("llama-server") &&
+    isLlamaServerCommand(command) &&
     (command.includes(`--port ${port}`) || command.includes(`--port=${port}`))
   );
 }
@@ -233,13 +235,64 @@ export function getBinaryProbeCommand(platform: NodeJS.Platform = process.platfo
   return platform === "win32" ? "where" : "which";
 }
 
-function isLlamaServerBinaryAvailable(binary: string): boolean {
-  if (binary.includes("/") || binary.includes("\\")) {
-    return isExecutablePath(binary);
+export function getProcessListCommand(
+  platform: NodeJS.Platform = process.platform,
+): { command: string; args: string[] } {
+  if (platform !== "win32") {
+    return {
+      command: "pgrep",
+      args: ["-af", "llama-server"],
+    };
   }
 
-  const probe = spawnSync(getBinaryProbeCommand(), [binary], { stdio: "ignore" });
-  return !probe.error && probe.status === 0;
+  return {
+    command: "powershell.exe",
+    args: [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      [
+        "Get-CimInstance Win32_Process",
+        "| Where-Object { $_.CommandLine -like '*llama-server*' }",
+        "| ForEach-Object { \"$($_.ProcessId) $($_.CommandLine)\" }",
+      ].join(" "),
+    ],
+  };
+}
+
+function isLlamaServerCommand(command: string): boolean {
+  const normalized = command.toLowerCase();
+  return (
+    normalized.includes("llama-server") &&
+    !normalized.includes("get-ciminstance win32_process")
+  );
+}
+
+function candidateBinaryNames(binary: string): string[] {
+  if (process.platform !== "win32" || binary.toLowerCase().endsWith(".exe")) {
+    return [binary];
+  }
+
+  return [binary, `${binary}.exe`];
+}
+
+function isLlamaServerBinaryAvailable(binary: string): boolean {
+  if (binary.includes("/") || binary.includes("\\")) {
+    return candidateBinaryNames(binary).some(isExecutablePath);
+  }
+
+  return candidateBinaryNames(binary).some((candidate) => {
+    const probe = spawnSync(getBinaryProbeCommand(), [candidate], { stdio: "ignore" });
+    return !probe.error && probe.status === 0;
+  });
+}
+
+function resolveLlamaServerLaunchBinary(binary: string): string {
+  if (!binary.includes("/") && !binary.includes("\\")) {
+    return binary;
+  }
+
+  return candidateBinaryNames(binary).find(isExecutablePath) ?? binary;
 }
 
 async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
@@ -271,7 +324,7 @@ async function stopExistingServerProcess(port: number): Promise<void> {
 
   for (const pid of pids) {
     try {
-      process.kill(pid, "SIGTERM");
+      terminateProcess(pid, false);
     } catch {
       // 이미 종료됐거나 권한이 없으면 무시하고 다음 단계로 진행한다.
     }
@@ -289,7 +342,7 @@ async function stopExistingServerProcess(port: number): Promise<void> {
 
   for (const pid of pidsArray.filter((_, index) => !terminated[index])) {
     try {
-      process.kill(pid, "SIGKILL");
+      terminateProcess(pid, true);
     } catch {
       // 강제 종료가 불가능하면 아래 readiness 확인에서 걸러진다.
     }
@@ -303,6 +356,23 @@ async function stopExistingServerProcess(port: number): Promise<void> {
   }
 
   activeServerPid = null;
+}
+
+function terminateProcess(pid: number, force: boolean): void {
+  try {
+    if (process.platform === "win32") {
+      const args = ["/PID", String(pid), "/T"];
+      if (force) {
+        args.push("/F");
+      }
+      spawnSync("taskkill.exe", args, { stdio: "ignore" });
+      return;
+    }
+
+    process.kill(pid, force ? "SIGKILL" : "SIGTERM");
+  } catch {
+    // The process may have already exited between discovery and termination.
+  }
 }
 
 async function downloadModel(modelUrl: string, modelPath: string): Promise<void> {
@@ -458,7 +528,9 @@ async function startServerProcess(
   config: Role1RuntimeConfig,
   apiBase: string,
 ): Promise<void> {
-  const binary = config.localLlmServerBinary ?? "llama-server";
+  const binary = resolveLlamaServerLaunchBinary(
+    config.localLlmServerBinary ?? "llama-server",
+  );
   const args = buildLlamaServerArgs(config);
   logger.warn(`Starting llama.cpp server: ${binary} ${args.join(" ")}`);
   const child = spawn(binary, args, {

--- a/src/core/prompt/kompress-client.ts
+++ b/src/core/prompt/kompress-client.ts
@@ -91,7 +91,7 @@ function buildLauncherCandidates(
   if (explicitPythonBin && explicitPythonBin !== DEFAULT_PYTHON_BIN) {
     return [
       {
-        command: "uv",
+        command: process.platform === "win32" ? "uv.exe" : "uv",
         args: ["run", "--python", explicitPythonBin, "python"],
         key: `uv:${explicitPythonBin}`,
       },
@@ -104,27 +104,50 @@ function buildLauncherCandidates(
   }
 
   const candidates: LauncherCandidate[] = [];
-  const localVenvPython = resolve(cwd, ".venv/bin/python");
-  if (existsSync(localVenvPython)) {
-    candidates.push({
-      command: localVenvPython,
-      args: [],
-      key: localVenvPython,
-    });
+  const localVenvPythons = process.platform === "win32"
+    ? [
+        resolve(cwd, ".venv/Scripts/python.exe"),
+        resolve(cwd, ".venv/Scripts/python"),
+      ]
+    : [resolve(cwd, ".venv/bin/python")];
+  for (const localVenvPython of localVenvPythons) {
+    if (existsSync(localVenvPython)) {
+      candidates.push({
+        command: localVenvPython,
+        args: [],
+        key: localVenvPython,
+      });
+    }
   }
 
   candidates.push(
     {
-      command: "uv",
+      command: process.platform === "win32" ? "uv.exe" : "uv",
       args: ["run", "--python", basePythonBin, "python"],
       key: `uv:${basePythonBin}`,
     },
-    {
+  );
+
+  if (process.platform === "win32") {
+    candidates.push(
+      {
+        command: "py",
+        args: ["-3.13"],
+        key: "py:-3.13",
+      },
+      {
+        command: "python",
+        args: [],
+        key: "python",
+      },
+    );
+  } else {
+    candidates.push({
       command: DEFAULT_PYTHON_BIN,
       args: [],
       key: DEFAULT_PYTHON_BIN,
-    },
-  );
+    });
+  }
 
   return candidates;
 }

--- a/tests/ts/unit/core/llm-client/local-runtime.test.ts
+++ b/tests/ts/unit/core/llm-client/local-runtime.test.ts
@@ -1,10 +1,11 @@
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	buildLlamaServerArgs,
 	getBinaryProbeCommand,
+	getProcessListCommand,
 	ensureLocalLlmRuntime,
 } from "../../../../../src/core/llm-client/local-runtime.js";
 
@@ -18,6 +19,11 @@ describe("buildLlamaServerArgs", () => {
 		expect(getBinaryProbeCommand("win32")).toBe("where");
 		expect(getBinaryProbeCommand("linux")).toBe("which");
 		expect(getBinaryProbeCommand("darwin")).toBe("which");
+		expect(getProcessListCommand("win32").command).toBe("powershell.exe");
+		expect(getProcessListCommand("linux")).toEqual({
+			command: "pgrep",
+			args: ["-af", "llama-server"],
+		});
 	});
 
 	it("GGUF 경로가 있으면 해당 파일을 모델로 로드한다", () => {
@@ -224,17 +230,20 @@ describe("buildLlamaServerArgs", () => {
 		const scriptDir = mkdtempSync(join(tmpdir(), "detoks-gguf-"));
 		const originalPath = process.env.PATH ?? "";
 		const modelPath = join(scriptDir, "broken.gguf");
+		const serverBinary = process.platform === "win32" ? "llama-server.cmd" : "llama-server";
 		writeFileSync(
-			join(scriptDir, "llama-server"),
-			[
-				"#!/bin/sh",
-				"exit 0",
-			].join("\n"),
+			join(scriptDir, serverBinary),
+			process.platform === "win32"
+				? "@exit /b 0\r\n"
+				: [
+					"#!/bin/sh",
+					"exit 0",
+				].join("\n"),
 			"utf8",
 		);
 		writeFileSync(modelPath, "", "utf8");
-		chmodSync(join(scriptDir, "llama-server"), 0o755);
-		process.env.PATH = `${scriptDir}:${originalPath}`;
+		chmodSync(join(scriptDir, serverBinary), 0o755);
+		process.env.PATH = `${scriptDir}${delimiter}${originalPath}`;
 		const fetchMock = vi
 			.fn<typeof fetch>()
 			.mockResolvedValue({ ok: false } as Response);
@@ -268,7 +277,7 @@ describe("buildLlamaServerArgs", () => {
 		}
 	});
 
-	it("모델이 바뀌면 기존 서버를 종료하고 새 모델로 다시 띄운다", async () => {
+	it.runIf(process.platform !== "win32")("모델이 바뀌면 기존 서버를 종료하고 새 모델로 다시 띄운다", async () => {
 		const scriptDir = mkdtempSync(join(tmpdir(), "detoks-llama-"));
 		const originalPath = process.env.PATH ?? "";
 		writeFileSync(


### PR DESCRIPTION
# PR: Windows native 런타임 지원

## 요약

Windows에서 WSL Ubuntu를 켜지 않고 detoks를 직접 실행할 수 있도록 CLI 진입점, 로컬 llama.cpp 런타임, Kompress Python 런처를 보강했습니다.

이 PR은 macOS/Linux의 기존 실행 경로를 유지하면서, Windows일 때만 별도 탐색 및 프로세스 관리 경로를 사용합니다.

## 관련 이슈

- Closes #201 

## 변경 유형

- [x] 버그 수정
- [x] 기능 추가
- [ ] 리팩터링
- [x] 문서 변경
- [x] 테스트 보강

## 변경 범위

- `bin/detoks.js`
  - Windows ESM loader가 `C:\...` 절대 경로를 URL scheme으로 오해하지 않도록 `tsx` loader 경로를 `file://` URL로 변환했습니다.

- `src/core/llm-client/local-runtime.ts`
  - Windows에서 `where`, `powershell.exe Get-CimInstance`, `taskkill.exe`, `llama-server.exe` 후보를 사용하도록 분기했습니다.
  - macOS/Linux는 기존 `which`, `pgrep`, signal 기반 종료 흐름을 유지했습니다.

- `src/core/prompt/kompress-client.ts`
  - Windows `.venv\Scripts\python.exe`, `uv.exe`, `py -3.13`, `python` 실행 후보를 추가했습니다.

- `src/cli/model-setup/index.ts`
  - Windows PowerShell용 `llama-server.exe` 빠른 시작 안내를 출력하도록 변경했습니다.

- `README.en.md`, `docs/LLAMA_CPP_SERVER_SPEC.md`
  - Windows native 실행 조건과 `LOCAL_LLM_SERVER_BINARY` 설정 예시를 문서화했습니다.

- `tests/ts/unit/core/llm-client/local-runtime.test.ts`
  - 플랫폼별 바이너리 탐색 명령, 프로세스 조회 명령, Windows PATH separator 관련 테스트를 보강했습니다.

## 구현 메모

1. CLI 진입점
   - `--import`에 넘기는 `tsx` loader 경로만 `pathToFileURL(...).href`로 변환했습니다.
   - 실행 대상 TypeScript entry는 `tsx`가 Windows에서 처리할 수 있도록 파일 시스템 경로 문자열로 유지했습니다.

2. llama.cpp 프로세스 관리
   - Windows 프로세스 조회는 `powershell.exe -NoProfile -NonInteractive -Command Get-CimInstance Win32_Process ...`를 사용합니다.
   - Windows 프로세스 종료는 `taskkill.exe /PID <pid> /T`를 사용하고, 강제 종료에는 `/F`를 추가합니다.
   - `LOCAL_LLM_SERVER_BINARY`가 절대 경로이고 `.exe`가 생략된 경우 `<path>.exe` 후보도 확인합니다.

3. Kompress Python 런처
   - Windows local venv 경로를 먼저 확인합니다.
   - `uv.exe run --python ... python`을 우선 사용하고, fallback으로 `py -3.13`, `python`을 둡니다.

## 검증

- [x] `node bin\detoks.js --help`
- [x] `node bin\detoks.js --execution-mode stub "hello detoks"`
- [x] `"exit`n" | node bin\detoks.js repl --execution-mode stub`
- [x] `npm run build`
- [x] 관련 unit test: `24 passed | 1 skipped`
- [x] `node dist\src\cli\index.js --help`
- [x] `npm pack --dry-run`
- [x] Windows native `llama-server.exe --help`
- [x] tiny GGUF 모델로 Windows native llama.cpp 자동 시작
- [x] 시작된 서버에 대해 `/health`, `/v1/models` 확인
- [x] 시작된 서버에 대해 `/v1/chat/completions` 확인
- [x] detoks 파이프라인이 Windows native llama.cpp endpoint를 통해 실행되는지 확인

## 수동 런타임 검증 상세

- llama.cpp Windows CPU 빌드 다운로드
  - `llama-b8833-bin-win-cpu-x64.zip`
  - 압축 해제 위치: `C:\tmp\detoks-llama-b8833\llama-server.exe`

- 첫 번째 smoke 모델
  - `Mozilla/llama-test-model`
  - 서버 시작과 모델 로딩은 확인했습니다.
  - 다만 generation endpoint는 모델 metadata 관련 오류를 반환했습니다.

- 두 번째 smoke 모델
  - `tensorblock/tiny-mistral-test-GGUF`
  - `tiny-mistral-test-Q2_K.gguf`
  - 서버 시작, 모델 로딩, OpenAI-compatible chat completion, detoks 파이프라인 연결을 모두 확인했습니다.

tiny 모델 출력 품질은 의미가 없지만, Windows native 런타임 경로가 end-to-end로 연결되는지는 검증했습니다.

## 주의 사항

- 검증 환경의 Node는 `v24.13.1`이었고, `package.json`의 요구 조건은 `>=24.15.0 <26`입니다. 검증은 통과했지만 공식 사용 환경은 engine range를 따라야 합니다.
- 전체 `npm run test`에는 이번 변경과 무관한 Windows/home-config 테스트 격리 실패가 남아 있습니다. 이번 변경 범위의 targeted test는 통과했습니다.
- Windows native 로컬 LLM 실행은 Node.js, Python 3.13, `uv`, Windows용 `llama-server.exe` 설치가 전제입니다.

## 커밋 구성

- `fix: support windows tsx cli entrypoint`
- `feat: support windows native local runtimes`
- `docs: document windows native runtime setup`
- `chore: sync package lock metadata`
