### PR TITLE
Update SessionState schema to align with pipeline.ts

### DIFF
--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -82,10 +82,22 @@ type TaskGraph = {
 
 ```ts
 type SessionState = {
-  shared_context: Record<string, unknown>;
-  task_results: Record<string, unknown>;
+  version?: string;
+  shared_context: {
+    session_id: string;
+    failed_task_ids?: string[];
+    [key: string]: unknown;
+  };
+  task_results: Record<string, TaskResult>;
+  current_task_id?: string | null;
+  completed_task_ids: string[];
+  last_summary?: string;
+  next_action?: string;
+  updated_at?: string;
 };
 ```
+
+> canonical schema: `src/schemas/pipeline.ts` `SessionStateSchema`
 
 <!-- 한국어 설명: RequestCategory, Task, TaskGraph, SessionState는 docs/SCHEMAS.md에 정의된 핵심 구조이며, 이후 API 계약의 기본 타입으로 사용됩니다. RequestCategory의 의미 기준은 docs/TYPE_DEFINITION.md를 따릅니다. -->
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -248,27 +248,30 @@ type Checkpoint = {
 };
 
 type SessionState = {
-	session_id: string;
-	version: string;
-	goal: string;
-	current_task: string | null;
-	completed_tasks: string[];
-	key_decisions: string[];
-	active_files: string[];
-	tasks: Task[];
-	summaries: {
-		rolling: string;
-		latest_checkpoint: string | null;
+	version?: string;
+	shared_context: {
+		session_id: string;
+		raw_input?: string;
+		failed_task_ids?: string[];   // saveSession 호출마다 task_results 기준으로 자동 동기화
+		input_history?: string[];
+		project_id?: string;
+		project_path?: string;
+		project_name?: string;
+		repl_mode?: boolean;
+		created_at?: string;
+		last_modified_at?: string;
+		[key: string]: unknown;       // passthrough — 역할별 추가 컨텍스트 허용
 	};
-	artifacts: {
-		task_results: Record<string, unknown>;
-		errors: string[];
-	};
-	metadata: Record<string, unknown>;
+	task_results: Record<string, TaskResult>;  // Zod discriminated union으로 type/success 보존 강제
+	current_task_id?: string | null;
+	completed_task_ids: string[];
 	last_summary?: string;
 	next_action?: string;
-	updated_at: string;
+	updated_at?: string;             // ISO 8601
 };
+
+// NOTE: SharedContext (src/types/context.ts) 는 ContextBuilder가 사용하는 런타임 컨텍스트로,
+// SessionState.shared_context 와 다른 별개의 개념입니다.
 ```
 
 **책임:** Role 2.2 (State & Context Engineer)  

--- a/docs/SCHEMA_FLOW.md
+++ b/docs/SCHEMA_FLOW.md
@@ -179,16 +179,23 @@ type ExecutionContext = {
 
 ```ts
 type SessionState = {
-  shared_context: Record<string, unknown>;
-  task_results: Record<string, unknown>;
-  current_task_id?: string;
+  version?: string;
+  shared_context: {
+    session_id: string;
+    failed_task_ids?: string[];   // saveSession마다 task_results 기준 자동 동기화
+    [key: string]: unknown;
+  };
+  task_results: Record<string, TaskResult>;  // discriminated union — type/success 손실 없음
+  current_task_id?: string | null;
   completed_task_ids: string[];
   last_summary?: string;
   next_action?: string;
+  updated_at?: string;
 };
 ```
 
-**의미:** 전체 세션을 들고 다니지 않고 필요한 것만 압축
+**의미:** 전체 세션을 들고 다니지 않고 필요한 것만 압축  
+**canonical schema:** `src/schemas/pipeline.ts` `SessionStateSchema`
 
 ---
 


### PR DESCRIPTION
## 요약

- `docs/SCHEMAS.md`, `docs/API_SPEC.md`, `docs/SCHEMA_FLOW.md` 세 곳의 `SessionState` 정의를 실제 런타임 기준인 `src/schemas/pipeline.ts`에 맞게 통일했습니다
- 개선 2에서 도입된 `failed_task_ids` 자동 동기화와 Zod discriminated union 설계 의도를 문서에 반영했습니다
- `SessionState.shared_context`와 `SharedContext` (`src/types/context.ts`)가 다른 개념임을 명시했습니다

## 관련 이슈

- Closes #212

## 변경 유형

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [x] 문서 수정
- [ ] 테스트 추가/수정

## 영향 범위

- 변경된 파일:
  - `docs/SCHEMAS.md` — `SessionState` 섹션 전면 교체 (구형 flat → Two-Tier 구조)
  - `docs/API_SPEC.md` — `SessionState` 정의 상세화 및 canonical schema 참조 추가
  - `docs/SCHEMA_FLOW.md` — `SessionState` 정의에 누락 필드 보완 및 설계 의도 주석 추가

## 수정 내용

### SCHEMAS.md — 구형 flat 구조 → 현재 Two-Tier 구조

**변경 전 (legacy):**
```typescript
type SessionState = {
  session_id: string;
  goal: string;
  current_task: string | null;
  completed_tasks: string[];
  key_decisions: string[];
  active_files: string[];
  tasks: Task[];
  summaries: { rolling: string; latest_checkpoint: string | null };
  artifacts: { task_results: Record<string, unknown>; errors: string[] };
  metadata: Record<string, unknown>;
};
```

**변경 후 (현재 코드 기준):**
```typescript
type SessionState = {
  version?: string;
  shared_context: {
    session_id: string;
    failed_task_ids?: string[];   // saveSession마다 자동 동기화
    [key: string]: unknown;
  };
  task_results: Record<string, TaskResult>;  // discriminated union — type/success 보존
  current_task_id?: string | null;
  completed_task_ids: string[];
  last_summary?: string;
  next_action?: string;
  updated_at?: string;
};
```

### 주요 추가 설명

| 필드 | 추가된 설계 의도 |
|---|---|
| `failed_task_ids` | `saveSession` 호출마다 `task_results`의 `success: false` 항목 기준으로 자동 동기화 |
| `task_results` | Zod discriminated union으로 `type`/`success` 손실 없이 보존 강제 |
| canonical 참조 | 각 문서에 `src/schemas/pipeline.ts SessionStateSchema` 참조 명시 |

## 테스트 방법

문서 변경이므로 코드 실행 테스트 불필요. `src/schemas/pipeline.ts`의 `SessionStateSchema`와 대조 확인.

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [ ] 필요한 경우 테스트를 추가하거나 수정했습니다
- [x] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 리뷰어 참고사항

- `key_decisions`는 `src/types/context.ts`의 `SharedContext`에 존재하지만, 이는 ContextBuilder가 런타임에 쓰는 컨텍스트이며 `SessionState.shared_context`와 다른 개념입니다. 문서에서 이 구분을 명시했습니다.
- `goal`, `active_files`, `tasks` 등 구형 필드는 코드 어디에도 없으므로 문서에서 완전히 제거했습니다.
