### PR TITLE
Enhance pipeline progress events with metrics and task graph details

### DIFF
--- a/src/core/context/ContextCompressor.ts
+++ b/src/core/context/ContextCompressor.ts
@@ -75,6 +75,10 @@ export class ContextCompressor {
     return compressed;
   }
 
+  static estimateTokens(state: SessionState, modelName: string): number {
+    return this.estimateTokenUsage(state, modelName);
+  }
+
   private static estimateTokenUsage(state: SessionState, modelName: string): number {
     try {
       const content = JSON.stringify(state);

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -6,6 +6,7 @@ import { TaskGraphProcessor } from "../task-graph/TaskGraphProcessor.js";
 import { TaskSentenceSplitter } from "../task-graph/TaskSentenceSplitter.js";
 import { compilePrompt, createRole2PromptInput } from "../prompt/compiler.js";
 import { ContextBuilder } from "../context/ContextBuilder.js";
+import { ContextCompressor } from "../context/ContextCompressor.js";
 import { SessionStateManager } from "../state/SessionStateManager.js";
 import { executeWithAdapter } from "../executor/execute.js";
 import { logger } from "../utils/logger.js";
@@ -641,24 +642,42 @@ export const orchestratePipeline = async (
       state = { ...state, current_task_id: task.id };
 
       // ExecutionContext 생성 (Role 2.2 — ContextCompressor → ContextSelector → ContextBuilder)
-      await emitProgressWithLogging( {
+      await emitProgressWithLogging({
         stage: "Context Optimizer",
         status: "start",
         taskId: task.id,
         message: `Context Optimizer(${task.id}) 시작`,
       });
       PipelineTracer.startStage(`ContextOptimizer:${task.id}`);
-      const context = ContextBuilder.build(state, task, resolveModelName(request.adapter, request.env));
+      const modelName = resolveModelName(request.adapter, request.env);
+      const tokensBeforeCompression = ContextCompressor.estimateTokens(state, modelName);
+      const context = ContextBuilder.build(state, task, modelName);
+      const compressedTaskIds = Object.entries(state.task_results)
+        .filter(([, r]) => (r as Record<string, unknown>)._compressed === true)
+        .map(([id]) => id);
+      const keptTaskIds = state.completed_task_ids.filter(
+        (id) => !compressedTaskIds.includes(id),
+      );
+      const contextTokens = ContextCompressor.estimateTokens(
+        { ...state, task_results: context.selected_context as typeof state.task_results },
+        modelName,
+      );
       await PipelineTracer.trace({
         sessionId, stage: "ContextOptimizer", role: "role2.2", phase: "output",
         dataType: "ExecutionContext", data: context,
         durationMs: PipelineTracer.endStage(`ContextOptimizer:${task.id}`),
       });
-      await emitProgressWithLogging( {
+      await emitProgressWithLogging({
         stage: "Context Optimizer",
         status: "end",
         taskId: task.id,
         message: `Context Optimizer(${task.id}) 완료`,
+        data: {
+          tokensBeforeCompression,
+          contextTokens,
+          compressedTaskIds,
+          keptTaskIds,
+        },
       });
 
       // Task 실행 (Role 3)

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -526,10 +526,22 @@ export const orchestratePipeline = async (
       })),
     },
   });
-  await emitProgressWithLogging( {
+  await emitProgressWithLogging({
     stage: "Task Graph Builder",
     status: "end",
-    message: "Task Graph Builder 완료",
+    message: `태스크 ${graph.tasks.length}개 생성 완료`,
+    data: {
+      tasks: graph.tasks.map((t) => ({
+        id: t.id,
+        type: t.type,
+        title: t.title,
+        depends_on: t.depends_on,
+      })),
+      stages: stages.map(({ stage, tasks: stageTasks }) => ({
+        stage,
+        taskIds: stageTasks.map((t) => t.id),
+      })),
+    },
   });
 
   // ── Step 5: 세션 상태 초기화 / 로드 (Role 2.2) ───────────────────────────

--- a/src/core/pipeline/types.ts
+++ b/src/core/pipeline/types.ts
@@ -20,6 +20,7 @@ export interface PipelineProgressEvent {
   status: PipelineProgressStatus;
   message: string;
   taskId?: string;
+  data?: Record<string, unknown>;
 }
 
 export type PipelineProgressHandler = (


### PR DESCRIPTION
## 요약

- `PipelineProgressEvent`에 `data?` 필드를 추가해 각 파이프라인 단계가 구조화된 데이터를 UI로 전달할 수 있게 했습니다
- Task Graph Builder 완료 시 생성된 태스크 목록과 병렬 실행 stage 순서를 이벤트에 포함했습니다
- Context Optimizer 완료 시 압축 전후 토큰 수, 전체 유지된 task 목록, 요약으로 압축된 task 목록을 이벤트에 포함했습니다
- `ContextCompressor.estimateTokens()`를 public static으로 노출해 orchestrator에서 직접 토큰 측정이 가능하게 했습니다

## 관련 이슈

- Closes #213 

## 변경 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [ ] 테스트 추가/수정

## 영향 범위

- 변경된 파일:
  - `src/core/pipeline/types.ts` — `PipelineProgressEvent`에 `data?` 필드 추가
  - `src/core/context/ContextCompressor.ts` — `estimateTokens` public static 추가
  - `src/core/pipeline/orchestrator.ts` — Task Graph Builder / Context Optimizer end 이벤트에 data 포함

## 수정 내용

### 1. PipelineProgressEvent 확장

```typescript
// 변경 전
export interface PipelineProgressEvent {
  stage: string;
  status: PipelineProgressStatus;
  message: string;
  taskId?: string;
}

// 변경 후
export interface PipelineProgressEvent {
  stage: string;
  status: PipelineProgressStatus;
  message: string;
  taskId?: string;
  data?: Record<string, unknown>;
}
```

기존 소비 코드는 `data`를 무시하면 되므로 브레이킹 체인지 없음.

### 2. Task Graph Builder end 이벤트

```typescript
await emitProgressWithLogging({
  stage: "Task Graph Builder",
  status: "end",
  message: `태스크 ${graph.tasks.length}개 생성 완료`,
  data: {
    tasks: graph.tasks.map((t) => ({
      id: t.id, type: t.type, title: t.title, depends_on: t.depends_on,
    })),
    stages: stages.map(({ stage, tasks: stageTasks }) => ({
      stage, taskIds: stageTasks.map((t) => t.id),
    })),
  },
});
```

UI 수신 예시:

```json
{
  "tasks": [
    { "id": "task_001", "type": "explore", "title": "API 코드 위치 탐색", "depends_on": [] },
    { "id": "task_002", "type": "analyze", "title": "에러 처리 흐름 분석", "depends_on": ["task_001"] },
    { "id": "task_003", "type": "modify", "title": "공통 유틸 구조화", "depends_on": ["task_002"] }
  ],
  "stages": [
    { "stage": 1, "taskIds": ["task_001"] },
    { "stage": 2, "taskIds": ["task_002"] },
    { "stage": 3, "taskIds": ["task_003"] }
  ]
}
```

### 3. Context Optimizer end 이벤트

```typescript
const tokensBeforeCompression = ContextCompressor.estimateTokens(state, modelName);
const context = ContextBuilder.build(state, task, modelName);
const compressedTaskIds = Object.entries(state.task_results)
  .filter(([, r]) => (r as Record<string, unknown>)._compressed === true)
  .map(([id]) => id);
const keptTaskIds = state.completed_task_ids.filter(
  (id) => !compressedTaskIds.includes(id),
);

await emitProgressWithLogging({
  stage: "Context Optimizer",
  status: "end",
  taskId: task.id,
  message: `Context Optimizer(${task.id}) 완료`,
  data: { tokensBeforeCompression, contextTokens, compressedTaskIds, keptTaskIds },
});
```

| 필드 | 의미 |
|---|---|
| `tokensBeforeCompression` | 압축 전 세션 state 전체 토큰 수 |
| `contextTokens` | 이 task에 실제 전달되는 컨텍스트 토큰 수 |
| `keptTaskIds` | 전체 결과를 유지하는 이전 task |
| `compressedTaskIds` | 요약본으로 줄인 이전 task |

## 테스트 방법

```bash
npx tsc --noEmit
```

`onProgress` 콜백에서 `event.data`를 로깅해 Task Graph Builder / Context Optimizer 이벤트 확인:

```typescript
onProgress: (event) => {
  if (event.stage === "Task Graph Builder" && event.status === "end") {
    console.log("tasks:", event.data?.tasks);
    console.log("stages:", event.data?.stages);
  }
  if (event.stage === "Context Optimizer" && event.status === "end") {
    console.log("tokens:", event.data?.tokensBeforeCompression, "→", event.data?.contextTokens);
    console.log("compressed:", event.data?.compressedTaskIds);
  }
}
```

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [ ] 필요한 경우 테스트를 추가하거나 수정했습니다
- [ ] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 리뷰어 참고사항

- `data` 필드는 optional이므로 `onProgress` 소비 코드에서 기존처럼 `event.stage`/`event.message`만 읽어도 정상 동작합니다.
- 세션 파일에 중간 상태를 저장하는 방식을 검토했으나 채택하지 않았습니다. Task Graph는 세션 초기화 이전에 생성되어 물리적으로 저장 대상이 없고, Context Optimizer 결과를 세션에 쓰면 미완성 상태가 파일에 남아 resume 로직과 충돌합니다.
- `ContextCompressor.estimateTokens()`는 private `estimateTokenUsage`를 래핑한 것으로, 기존 내부 동작은 변경 없습니다.
