### PR TITLE
fix: resolve tsc PATH issue when installing from GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">=24.15.0 <26"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "npx --no-install tsc -p tsconfig.json",
     "prepare": "npm run build",
     "prepack": "npm run build",
     "cli": "tsx src/cli/index.ts",


### PR DESCRIPTION
## Summary

- `npm install -g github:tok-it/detoks#dev` 실행 시 `prepare` 스크립트가 `tsc`를 찾지 못해 설치 실패하는 문제 수정
- `tsc` → `npx --no-install tsc` 로 변경하여 임시 디렉토리에서도 `node_modules/.bin/tsc`를 명시적으로 참조
- 기존 Mac/Linux 개발 환경에서 `npm run build` 동작은 동일하게 유지됨

## Test plan

- [ ] `npm install -g github:tok-it/detoks#dev` 설치 후 `detoks` 명령어 실행 확인
- [ ] 기존 `npm run build` 정상 동작 확인