### PR TITLE
Fix PATH issue by using npx --no-install for tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">=24.15.0 <26"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "npx --no-install tsc -p tsconfig.json",
     "prepare": "npm run build",
     "prepack": "npm run build",
     "cli": "tsx src/cli/index.ts",


### PR DESCRIPTION
## 요약

- `npm install -g github:tok-it/detoks#dev` 실행 시 `tsc`를 찾지 못해 설치가 실패하는 문제 수정
- `prepare` 스크립트가 임시 디렉토리에서 실행될 때 `node_modules/.bin`의 `tsc`를 참조하지 못하는 Windows 환경 이슈
- `tsc` → `npx --no-install tsc`로 변경하여 `node_modules/.bin/tsc`를 명시적으로 참조

## 관련 이슈

- 없음 (사용자 설치 중 직접 발견)

## 변경 유형

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [ ] 테스트 추가/수정

## 영향 범위

- 변경된 파일:
  - `package.json` — `build` 스크립트 `tsc` → `npx --no-install tsc` 변경

## 문제 원인

```
npm install -g github:tok-it/detoks#dev
  → npm이 임시 디렉토리에 repo 클론
  → npm install --force --include=dev 실행 (의존성 설치)
  → npm run prepare → npm run build → tsc 실행
  → 'tsc'은(는) 인식할 수 없는 명령 (ENOENT)
```

Windows에서 npm 스크립트 실행 시 `node_modules/.bin`이 PATH에 추가되어야 하지만,
git 의존성 준비 과정의 임시 디렉토리 컨텍스트에서는 이 동작이 보장되지 않음.

## 수정 내용

```diff
- "build": "tsc -p tsconfig.json",
+ "build": "npx --no-install tsc -p tsconfig.json",
```

`--no-install` 플래그: 외부에서 tsc를 다운받지 않고 `node_modules/.bin`에서만 탐색.
Mac/Linux 기존 환경에서 동작 변화 없음.

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [ ] 필요한 경우 테스트를 추가하거나 수정했습니다
- [ ] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 리뷰어 참고사항

- Mac 사용자 기존 워크플로우(`npm run build`, `npm install`) 영향 없음
- `npx --no-install`은 tsc가 devDependencies에 없을 경우 다운로드 없이 즉시 실패하므로 의도치 않은 버전 설치 방지
