### PR TITLE
Align compression flow spec and improve taskgraph handoff tests

### DIFF
--- a/docs/02-token-efficiency/INDEX.md
+++ b/docs/02-token-efficiency/INDEX.md
@@ -34,7 +34,7 @@
 | 개념 | 설명 | 파일 |
 |------|------|------|
 | **토큰 메트릭** | 입력/출력 원본 vs 최적화 비교 | TOKEN_EFFICIENCY_ARCHITECTURE.md |
-| **입력 최적화** | 정규화 + 번역 + 압축 | TOKEN_EFFICIENCY_ARCHITECTURE.md |
+| **입력 최적화** | 정규화 + 번역 | TOKEN_EFFICIENCY_ARCHITECTURE.md |
 | **컨텍스트 압축** | 토큰 임계값 기반 자동 축소 | TOKEN_EFFICIENCY_ARCHITECTURE.md |
 | **동적 임계값** | LLM별 실제 윈도우 기반 계산 | LLM_CONTEXT_WINDOW_COMPRESSION.md |
 | **인코더 통합** | o200k_base, cl100k_base, gpt2 등 | LLM_CONTEXT_WINDOW_COMPRESSION.md |

--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -175,8 +175,7 @@ type CliOutput = {
 
 ## 2. Prompt Compiler API
 
-The Prompt Compiler compresses Korean user input into concise English prompts while preserving intent. It is implemented as TypeScript core logic under `src/core/prompt` and `src/core/translate`.
-The Prompt Compiler compresses Korean user input into concise English prompts while preserving intent. It is implemented as TypeScript core logic under `src/core/prompt` and `src/core/translate`.
+The Prompt Compiler translates and normalizes Korean user input into English while preserving intent. It is implemented as TypeScript core logic under `src/core/prompt` and `src/core/translate`.
 
 ### Request
 
@@ -232,37 +231,39 @@ type PromptCompileResponse = {
 
 - input text may be Korean, English, or mixed
 - output must remain semantically aligned with the original request
-- output must be shorter and cleaner than the source input when possible
+- output should be normalized and cleaned, but Role 1 must not weaken action signals through compression
 - `max_translation_attempts` defaults to `5` and counts the primary request plus fallback requests
 - `validation_errors`, `repair_actions`, `inference_time_sec`, `debug` are Role 1 metadata fields and are not part of the Role 2.1 handoff contract
 - Role 2.1 handoff uses `Role2PromptInput { compiled_prompt: string }`
 - task decomposition, `id`, and `depends_on` generation are not part of this API
 
-<!-- 한국어 설명: Prompt Compiler는 한국어 중심 입력을 더 짧고 명확한 영어 프롬프트로 바꾸되, 원래 의도와 제약 조건을 유지해야 합니다. -->
+<!-- 한국어 설명: Prompt Compiler는 한국어 중심 입력을 action signal이 보존된 번역/정규화 영어 프롬프트로 바꾸되, Role 1 단계에서 압축으로 의도와 제약 조건을 약화시키지 않습니다. -->
 
-### Prompt Compression Strategy
+### Context Compression Strategy
 
-v1 prompt compression uses `Kompress` (`chopratejas/kompress-base`) on translated English natural-language spans while preserving protected code-like units through masking. It does not use LLM-based prompt engineering or the old rule-based path as the primary compressor.
+v1 compression uses `Kompress` (`chopratejas/kompress-base`) only after Role 2.1 has built the TaskGraph. Role 2.2 applies compression to the selected execution context summary for the active task, while preserving protected code-like units through masking. It does not use LLM-based prompt engineering or the old rule-based path as the primary compressor.
 
 Flow:
 
 1. mask protected segments
 2. translate Korean input to English
 3. validate and repair translated output
-4. preserve code, paths, commands, JSON keys, API names, model names, and Markdown units through masking
-5. run Kompress on the remaining natural-language body only
-6. validate placeholder order and action-signal preservation
-7. if compression is unsafe, use `normalized_input` as `compressed_prompt`
+4. pass `CompiledPrompt.normalized_input` as `Role2PromptInput.compiled_prompt`
+5. build TaskGraph from the normalized input
+6. select only the context required by the active task
+7. run Kompress on the selected context summary only
+8. validate placeholder order and action-signal preservation
+9. if compression is unsafe, use the uncompressed context summary
 
 Compression rules:
 
 - code blocks, inline code, shell commands, paths, URLs, JSON keys, API names, and model names must not be compressed
 - Markdown headings, bullets, and numbered lists should be preserved as much as possible
 - filenames, paths, commands, options, numeric constraints, error messages, forbidden conditions, completion criteria, and test requirements must be preserved
-- if compression loses placeholders, action signals, or becomes too aggressive, the pipeline must use `normalized_input` directly without retrying Kompress
+- if compression loses placeholders, action signals, or becomes too aggressive, the pipeline must use the uncompressed selected context directly without retrying Kompress
 - `llm` and `small_model` providers are extension points only and must not be used by v1 compression
 
-<!-- 한국어 설명: v1 압축은 번역 검증/보정이 끝난 영어 텍스트를 대상으로 하며, 자연어 body에만 Kompress를 적용합니다. Kompress 결과가 안전하지 않으면 재생성하지 않고 `normalized_input`을 그대로 사용합니다. -->
+<!-- 한국어 설명: v1 압축은 TaskGraph 생성 이후 Role 2.2가 선택한 실행 context summary에만 Kompress를 적용합니다. Kompress 결과가 안전하지 않으면 재생성하지 않고 선택된 원본 context summary를 그대로 사용합니다. -->
 
 ### Role 1 Batch Result Artifact
 

--- a/docs/CLI_WRAPPER_PIPELINE.md
+++ b/docs/CLI_WRAPPER_PIPELINE.md
@@ -42,7 +42,7 @@ The wrapper CLI may call all stages, but each stage still has its own owner.
 
 - Prompt Compiler
 - Korean-to-English translation
-- Compressed English prompt handoff
+- Normalized English prompt handoff
 
 ### Role 2.1: Task Graph Engineer
 
@@ -253,7 +253,7 @@ The wrapper CLI may call all stages, but each stage still has its own owner.
 - `src/core/translate/*`
   - Role 1 translation pipeline
 - `src/core/prompt/*`
-  - Role 1 prompt compression
+  - Role 1 prompt normalization and reusable compression helpers
 - `src/core/guardrails/*`
   - Role 1 validation and repair support
 - `src/core/llm-client/*`
@@ -261,7 +261,7 @@ The wrapper CLI may call all stages, but each stage still has its own owner.
 - `src/core/translate/*`
   - Role 1 translation pipeline
 - `src/core/prompt/*`
-  - Role 1 prompt compression
+  - Role 1 prompt normalization and reusable compression helpers
 - `src/core/guardrails/*`
   - Role 1 validation and repair support
 - `src/core/llm-client/*`
@@ -279,7 +279,7 @@ The wrapper CLI may call all stages, but each stage still has its own owner.
 - `src/integrations/subprocess/*`
   - Role 3
 - `src/core/prompt/*`
-  - Role 1 prompt compression runtime
+  - reusable Kompress runtime used by context optimization
 
 <!-- 한국어 설명: 각 폴더의 책임을 유지해야 팀원 작업 영역이 겹치지 않고, CLI 계층이 다른 역할의 구현을 흡수하는 문제를 막을 수 있습니다. -->
 <!-- 한국어 설명: 각 폴더의 책임을 유지해야 팀원 작업 영역이 겹치지 않고, CLI 계층이 다른 역할의 구현을 흡수하는 문제를 막을 수 있습니다. -->

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -17,10 +17,9 @@ detoks operates as a **stage-based pipeline** from input to output.
 - Translate Korean input to English
 - Validate and repair translated output
 - Preserve code, paths, commands, JSON keys, API names, model names, and Markdown units
-- Compress translated English text with the Kompress model
-- Validate the compressed output through guardrails
-- If compression validation fails, pass `normalized_input` as `compressed_prompt`
-<!-- 한국어 설명: Prompt Compiler는 번역 결과를 먼저 검증/보정한 뒤 영어 텍스트의 자연어 body에만 Kompress(`chopratejas/kompress-base`)를 적용합니다. code/path/command/JSON key 같은 보호 단위는 placeholder로 마스킹한 뒤 복원하며, Kompress 결과가 안전하지 않으면 재생성하지 않고 `normalized_input`을 그대로 handoff 합니다. -->
+- Produce `normalized_input` for Role 2.1 task graph generation
+- Keep `compressed_prompt` as a compatibility field equal to `normalized_input`
+<!-- 한국어 설명: Prompt Compiler는 번역 결과를 먼저 검증/보정하고, Role 2.1에는 action signal이 살아 있는 `normalized_input`을 그대로 전달합니다. Kompress는 Role 2.2의 context optimizer가 현재 task에 필요한 context summary를 만들 때만 적용합니다. -->
 
 ---
 
@@ -29,7 +28,7 @@ detoks operates as a **stage-based pipeline** from input to output.
 - Validate protected terms, placeholders, numeric constraints, filenames, commands, and completion criteria
 - Treat Korean text copied unchanged into translated output as a translation failure
 - Retry failed translation spans up to 5 total requests including fallback requests
-- Repair invalid translation output before compression
+- Repair invalid translation output before TaskGraph generation
 <!-- 한국어 설명: Translation Guardrails는 번역 단계에서 필수 정보 보존 여부를 검증하고, 한글이 그대로 출력된 번역 실패를 감지하며, 실패 span은 fallback 포함 최대 5회까지 재요청합니다. 이 단계는 번역 보정 전용이며 Kompress 재시도와는 분리됩니다. -->
 
 ---
@@ -56,6 +55,7 @@ detoks operates as a **stage-based pipeline** from input to output.
 
 - Remove duplication
 - Preserve essential information
+- Compress only the selected execution context summary for the active task
 <!-- 한국어 설명: Context Optimizer는 중복 정보를 제거하면서 핵심 문맥은 유지합니다. -->
 
 ---
@@ -85,7 +85,7 @@ detoks operates as a **stage-based pipeline** from input to output.
 
 ## Flow
 
-Input → Translate → Validate/Repair → Analyze → Task Graph → Context (→ Compress per task) → Execute → Store → Next
+Input → Translate/Normalize → Task Graph from `normalized_input` → Select Context → Compress selected context summary → Execute → Store → Next
 
 <!-- 한국어 설명: 전체 흐름은 입력 번역, 번역 검증/보정, 요청 분류(action signal 기반), 작업 그래프 생성, 문맥 구성, 실행, 저장, 다음 턴 준비 순서로 이어집니다. 압축(Kompress)은 task 실행 context 단계에서 필요한 만큼 수행됩니다. Kompress 결과가 안전하지 않으면 재생성 없이 `normalized_input`을 사용합니다. -->
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -54,7 +54,7 @@ detoks/
 - `src/core/state`: session state management
 - `src/core/executor`: execution flow coordination
 - `src/core/translate`: Korean-to-English translation pipeline
-- `src/core/prompt`: prompt compression
+- `src/core/prompt`: prompt normalization and reusable Kompress helpers
 - `src/core/guardrails`: translated output validation and repair
 - `src/core/llm-client`: communication with the local llama.cpp server
 - `src/integrations/adapters/*`: target CLI integrations such as Codex and Gemini

--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -5,8 +5,8 @@
 
 - Prompt compiler
 - Korean-to-English translation
-- Compressed English prompt handoff
-<!-- 한국어 설명: AI Prompt Engineer는 프롬프트를 정제하고 한국어 입력을 영어로 변환한 뒤 압축된 영문 프롬프트 전문을 Role 2.1에 전달합니다. Task 분해, task type 지정, id 생성, depends_on 생성은 Role 2.1이 담당합니다. -->
+- Normalized English prompt handoff
+<!-- 한국어 설명: AI Prompt Engineer는 프롬프트를 정제하고 한국어 입력을 영어로 변환한 뒤 정규화된 영문 프롬프트 전문을 Role 2.1에 전달합니다. Task 분해, task type 지정, id 생성, depends_on 생성은 Role 2.1이 담당합니다. -->
 
 ---
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -49,7 +49,7 @@ type CompiledPrompt = {
 ```
 
 **책임:** Role 1 (AI Prompt Engineer)  
-**설명:** 자연어를 정규화하고 Kompress 기반으로 압축한 결과. 공식 Role 2.1 handoff는 `compressed_prompt`만 사용하고, 나머지 필드는 Role 1 내부 검증/디버그 metadata다.
+**설명:** 자연어를 번역/정규화한 결과. `compressed_prompt`는 v1 호환 필드이며 Role 1 단계에서는 `normalized_input`과 같은 값을 가진다. Kompress 압축은 Role 2.2가 task 실행에 필요한 context를 만들 때 선택된 context summary에만 적용한다.
 
 ---
 
@@ -62,7 +62,7 @@ type Role2PromptInput = {
 ```
 
 **책임:** Role 1 (AI Prompt Engineer)  
-**설명:** Role 1이 Role 2.1로 넘기는 handoff schema. 값은 `CompiledPrompt.compressed_prompt`와 동일한 압축 영문 프롬프트 전문이다. task 분해 / id / depends_on 생성은 Role 2.1 담당.
+**설명:** Role 1이 Role 2.1로 넘기는 handoff schema. 값은 `CompiledPrompt.normalized_input`과 동일한 번역/정규화 텍스트다. task type 분류는 action signal이 살아 있는 압축 전 텍스트를 기준으로 하며, task 분해 / id / depends_on 생성은 Role 2.1 담당.
 
 ---
 

--- a/docs/SCHEMA_FLOW.md
+++ b/docs/SCHEMA_FLOW.md
@@ -150,7 +150,7 @@ type TaskGraph = {
 
 **입력:** `Role2PromptInput`
 
-**의미:** 압축된 영문 프롬프트 전문을 바탕으로 실행 가능한 그래프로 변환
+**의미:** 번역/정규화된 `Role2PromptInput.compiled_prompt`를 바탕으로 실행 가능한 그래프로 변환
 
 ---
 

--- a/docs/SHARED_DATA_FLOW.md
+++ b/docs/SHARED_DATA_FLOW.md
@@ -60,7 +60,7 @@ Raw user input entering the system.
 ### 2. CompiledPrompt
 
 
-Translated and normalized prompt output from the Prompt Compiler. Contains both `normalized_input` (pre-compression) and `compressed_prompt` (post-compression).
+Translated and normalized prompt output from the Prompt Compiler. `compressed_prompt` is retained as a v1 compatibility field and is equal to `normalized_input`; compression is applied later to selected execution context.
 
 ### 3. Role2PromptInput
 

--- a/docs/related-token/TOKEN_EFFICIENCY_ARCHITECTURE.md
+++ b/docs/related-token/TOKEN_EFFICIENCY_ARCHITECTURE.md
@@ -174,25 +174,18 @@ export async function compilePrompt(
     ? null 
     : await translate_to_english(normalizedInput, { config, policies, ... });
 
-  // 4. 프롬프트 압축
+  // 4. Role 2.1 handoff용 normalized_input 확정
   const translatedOutput = translationResult?.text ?? normalizedInput;
-  const compressionResult = await compress_prompt(translatedOutput, {
-    config,
-    policies,
-    ...
-  });
-
   // 5. 결과 반환
   return {
     raw_input: request.raw_input,
     normalized_input: translatedOutput,
-    compressed_prompt: compressionResult.compressed_prompt, // ← 최적화된 프롬프트
+    compressed_prompt: translatedOutput, // v1 compatibility; context compression happens later
     language,
     compression_provider: SUPPORTED_COMPRESSION_PROVIDER,
     inference_time_sec: translationResult?.inference_time_sec ?? 0,
     validation_errors: translationResult?.validation_errors ?? [],
-    repair_actions: [...(translationResult?.repair_actions ?? []), 
-                      ...compressionResult.repair_actions],
+    repair_actions: translationResult?.repair_actions ?? [],
   };
 }
 ```
@@ -202,11 +195,11 @@ export async function compilePrompt(
 1. **정규화**: 입력 텍스트 정제 (공백, 특수문자 등)
 2. **언어 감지**: 입력 언어 자동 감지
 3. **번역**: 비영어 → 영어 (사전학습 모델 효율성 극대화)
-4. **압축**: 의미를 유지하며 토큰 수 최소화
+4. **context 압축**: TaskGraph 이후 선택된 실행 context summary만 압축
 
 ### 효과
 
-**입력 토큰 50-70% 절감**
+**TaskGraph 분류 안정성 확보 및 실행 context 단계 토큰 절감**
 
 ---
 
@@ -345,7 +338,7 @@ function buildPipelineStages(ok: boolean): PipelineStageStatus[] {
 
 | 단계 | 역할 | 토큰 최적화 | 소유자 |
 |------|------|-----------|--------|
-| **Prompt Compiler** | 입력 정규화 + 번역 + 압축 | 입력 50-70% 절감 | Role 1 |
+| **Prompt Compiler** | 입력 정규화 + 번역 | action signal 보존 | Role 1 |
 | **Task Graph Builder** | 작업 의존성 분석 | 병렬화 기반 불필요한 작업 제외 | Role 2.1 |
 | **Context Optimizer** | 컨텍스트 압축 + 선택 | 컨텍스트 30-50% 절감 | Role 2.2 |
 | **Executor** | LLM 실행 | (최적화된 입력/컨텍스트 사용) | Role 3 |
@@ -356,7 +349,7 @@ function buildPipelineStages(ok: boolean): PipelineStageStatus[] {
 ```
 원본 입력 (1000 토큰)
   ↓ [Prompt Compiler]
-압축 입력 (300 토큰) + 메타데이터
+정규화 입력 + 메타데이터
   ↓ [Task Graph Builder]
 작업 그래프 + 의존성
   ↓ [Context Optimizer]
@@ -401,7 +394,7 @@ export async function runBatchPromptPipeline(
         index,
         raw_input,
         normalized_input: compiled.normalized_input,
-        compiled_prompt: compiled.compressed_prompt,
+        compiled_prompt: compiled.normalized_input,
         role2_handoff: handoff.compiled_prompt,
         language: compiled.language,
         inference_time_sec: compiled.inference_time_sec ?? 0,
@@ -499,12 +492,12 @@ for (const { stage, tasks } of stages) {
 │  [Prompt Compiler]                   │
 │  • 정규화                             │
 │  • 언어 감지 → 번역 (비영어)         │
-│  • 프롬프트 압축                     │
-│  → 원본 대비 50-70% 절감              │
+│  • normalized_input 확정             │
+│  → TaskGraph 분류 신호 보존           │
 └──────────┬──────────────────────────┘
            │
       ┌────▼────┐
-      │ 압축 입력 │ (300토큰)
+      │ 정규화 입력 │
       └────┬────┘
            │
            ▼
@@ -562,7 +555,7 @@ for (const { stage, tasks } of stages) {
 | 개념 | 파일 | 메커니즘 | 효과 |
 |------|------|---------|------|
 | **토큰 메트릭** | tokenMetrics.ts | 입력/출력 원본 vs 최적화 비교 | 절감 정량화 |
-| **입력 최적화** | compiler.ts | 정규화 + 번역 + 압축 | 50-70% 절감 |
+| **입력 최적화** | compiler.ts | 정규화 + 번역 | 분류 신호 보존 |
 | **컨텍스트 압축** | ContextCompressor.ts | 토큰 임계값 기반 자동 축소 | 장기 세션 지원 |
 | **컨텍스트 선택** | ContextBuilder.ts | 의존성 그래프 기반 선택 | 30-50% 절감 |
 | **세션 상태 관리** | SessionStateManager.ts | 자동 정규화 + 압축 + 검증 | 중복 실행 방지 |

--- a/src/core/pipeline/batch.ts
+++ b/src/core/pipeline/batch.ts
@@ -68,7 +68,7 @@ export async function runBatchPromptPipeline(
         index,
         raw_input,
         normalized_input: compiled.normalized_input,
-        compiled_prompt: compiled.compressed_prompt,
+        compiled_prompt: compiled.normalized_input,
         role2_handoff: handoff.compiled_prompt,
         language: compiled.language,
         inference_time_sec: compiled.inference_time_sec ?? 0,

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -5,6 +5,8 @@ import { ParallelClassifier } from "../task-graph/ParallelClassifier.js";
 import { TaskGraphProcessor } from "../task-graph/TaskGraphProcessor.js";
 import { TaskSentenceSplitter } from "../task-graph/TaskSentenceSplitter.js";
 import { compilePrompt, createRole2PromptInput } from "../prompt/compiler.js";
+import { loadRole1Policies, loadRole1RuntimeConfig } from "../prompt/config.js";
+import { compress_prompt } from "../prompt/compression.js";
 import { ContextBuilder } from "../context/ContextBuilder.js";
 import { ContextCompressor } from "../context/ContextCompressor.js";
 import { SessionStateManager } from "../state/SessionStateManager.js";
@@ -215,6 +217,47 @@ function applySessionTokenMetrics(
     },
     tokenMetrics,
   };
+}
+
+async function compressExecutionContextSummary(
+  summary: string | undefined,
+  request: PipelineExecutionRequest,
+): Promise<{ summary: string | undefined; repairActions: string[] }> {
+  if (!summary?.trim() || !summary.includes("Previous Task Results:")) {
+    return { summary, repairActions: [] };
+  }
+
+  try {
+    const runtimeConfig = loadRole1RuntimeConfig({
+      ...(request.userRequest.cwd ? { cwd: request.userRequest.cwd } : {}),
+      ...(request.env ? { env: request.env } : {}),
+    });
+    const policies = loadRole1Policies({
+      ...(request.userRequest.cwd ? { cwd: request.userRequest.cwd } : {}),
+    });
+    const compressionResult = await compress_prompt(summary, {
+      config: runtimeConfig,
+      policies,
+      ...(runtimeConfig.localLlmModelName
+        ? { localLlmModelName: runtimeConfig.localLlmModelName }
+        : {}),
+      ...(request.userRequest.cwd ? { cwd: request.userRequest.cwd } : {}),
+      ...(request.env ? { env: request.env } : {}),
+      ...(request.compressionImplementation
+        ? { compressionImplementation: request.compressionImplementation }
+        : {}),
+    });
+
+    return {
+      summary: compressionResult.compressed_prompt,
+      repairActions: compressionResult.repair_actions,
+    };
+  } catch (error) {
+    return {
+      summary,
+      repairActions: [`context_compression_failed:${toErrorMessage(error)}`],
+    };
+  }
 }
 
 function mergePtyTranscripts(
@@ -662,6 +705,14 @@ export const orchestratePipeline = async (
       const modelName = resolveModelName(request.adapter, request.env);
       const tokensBeforeCompression = ContextCompressor.estimateTokens(state, modelName);
       const context = ContextBuilder.build(state, task, modelName);
+      const contextCompression = await compressExecutionContextSummary(
+        context.context_summary,
+        request,
+      );
+      const executionContext = {
+        ...context,
+        context_summary: contextCompression.summary,
+      };
       const compressedTaskIds = Object.entries(state.task_results)
         .filter(([, r]) => (r as Record<string, unknown>)._compressed === true)
         .map(([id]) => id);
@@ -674,7 +725,7 @@ export const orchestratePipeline = async (
       );
       await PipelineTracer.trace({
         sessionId, stage: "ContextOptimizer", role: "role2.2", phase: "output",
-        dataType: "ExecutionContext", data: context,
+        dataType: "ExecutionContext", data: executionContext,
         durationMs: PipelineTracer.endStage(`ContextOptimizer:${task.id}`),
       });
       await emitProgressWithLogging({
@@ -685,13 +736,14 @@ export const orchestratePipeline = async (
         data: {
           tokensBeforeCompression,
           contextTokens,
+          contextCompressionRepairActions: contextCompression.repairActions,
           compressedTaskIds,
           keptTaskIds,
         },
       });
 
       // Task 실행 (Role 3)
-      const prompt = `[${task.type.toUpperCase()}] ${task.title}\n\nContext: ${context.context_summary}`;
+      const prompt = `[${task.type.toUpperCase()}] ${task.title}\n\nContext: ${executionContext.context_summary}`;
       logger.info(`작업 [${task.id}] 실행 중 type=${task.type}`);
       await emitProgressWithLogging( {
         stage: "Executor",

--- a/src/core/prompt/compiler.ts
+++ b/src/core/prompt/compiler.ts
@@ -7,7 +7,7 @@ import {
   type Role2PromptInput,
 } from "../../schemas/pipeline.js";
 import { loadRole1Policies, loadRole1RuntimeConfig } from "./config.js";
-import { compress_prompt, type CompressTextImplementation } from "./compression.js";
+import type { CompressTextImplementation } from "./compression.js";
 import { translate_to_english } from "../translate/translate.js";
 
 const SUPPORTED_COMPRESSION_PROVIDER = "kompress";
@@ -79,27 +79,12 @@ export async function compilePrompt(
             : {}),
         });
   const translatedOutput = translationResult?.text ?? normalizedInput;
-  const compressionResult = await compress_prompt(translatedOutput, {
-    config: runtimeConfig,
-    policies,
-    ...(runtimeConfig.localLlmModelName
-      ? { localLlmModelName: runtimeConfig.localLlmModelName }
-      : {}),
-    ...(options.cwd ? { cwd: options.cwd } : {}),
-    ...(options.env ? { env: options.env } : {}),
-    ...(options.compressionImplementation
-      ? { compressionImplementation: options.compressionImplementation }
-      : {}),
-  });
-  const repairActions = [
-    ...(translationResult?.repair_actions ?? []),
-    ...compressionResult.repair_actions,
-  ];
+  const repairActions = translationResult?.repair_actions ?? [];
 
   return PromptCompileResponseSchema.parse({
     raw_input: request.raw_input,
     normalized_input: translatedOutput,
-    compressed_prompt: compressionResult.compressed_prompt,
+    compressed_prompt: translatedOutput,
     language,
     compression_provider: SUPPORTED_COMPRESSION_PROVIDER,
     ...(translationResult

--- a/src/core/task-graph/TaskGraphProcessor.ts
+++ b/src/core/task-graph/TaskGraphProcessor.ts
@@ -9,7 +9,7 @@ import type { Task, TaskGraph, RequestCategory } from "../../schemas/pipeline.js
  * Role 2.1 내부 sentence split 결과를 받아 실행 가능한 TaskGraph로 변환합니다.
  *
  * ─── 역할 분담 ──────────────────────────────────────────────────
- * Role 1 담당 : 한국어 → 영어 변환, compressed_prompt 생성
+ * Role 1 담당 : 한국어 → 영어 변환, normalized_input 생성
  * Role 2.1 내부 보조 : compiled_prompt 문자열을 sentence 단위로 분리
  * Role 2.1 담당 (이 클래스):
  *   1. single(문장 1개) / multi(문장 여러 개) 요청 구분

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -747,8 +747,8 @@ describe("detoks CLI smoke", () => {
       });
       expect(verboseJson.run_metadata.input_count).toBe(2);
       expect(verboseJson.results).toHaveLength(2);
-      expect(verboseJson.results[0].compiled_prompt).toBe("Create a new file");
-      expect(verboseJson.results[1].compiled_prompt).toBe("Run npm test");
+      expect(verboseJson.results[0].compiled_prompt).toBe("Please create a new file");
+      expect(verboseJson.results[1].compiled_prompt).toBe("Please run npm test");
     } finally {
       rmSync(tempDir, { force: true, recursive: true });
     }

--- a/tests/ts/unit/core/pipeline/batch.test.ts
+++ b/tests/ts/unit/core/pipeline/batch.test.ts
@@ -70,7 +70,7 @@ describe("runBatchPromptPipeline", () => {
 
     expect(result.run_metadata.pipeline_mode).toBe("safe");
     expect(result.results).toHaveLength(1);
-    expect(result.results[0]?.compiled_prompt).toBe("Create a new file");
+    expect(result.results[0]?.compiled_prompt).toBe("Please create a new file");
     expect(result.results[0]?.role2_handoff).toBe("Please create a new file");
     expect(result.results[0]?.status).toBe("completed");
     expect(result.results[0]?.inference_time_sec).toBe(0);

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -203,7 +203,12 @@ describe("orchestratePipeline", () => {
     }
   });
 
-  it("surfaces Role 1 metadata from prompt compilation on success", async () => {
+  it("surfaces Role 1 metadata from prompt normalization on success", async () => {
+    const compressionImplementation = vi.fn(async (text: string) => ({
+      compressed: text.replace(/^Can you please /i, ""),
+      compression_ratio: 0.56,
+      tokens_saved: 4,
+    }));
     const result = await orchestratePipeline({
       mode: "run",
       adapter: "codex",
@@ -213,21 +218,58 @@ describe("orchestratePipeline", () => {
         raw_input:
           "Can you please update src/api/user.ts and run npm test -- --runInBand 2 times?",
       },
-      compressionImplementation: vi.fn(async (text: string) => ({
-        compressed: text.replace(/^Can you please /i, ""),
-        compression_ratio: 0.56,
-        tokens_saved: 4,
-      })),
+      compressionImplementation,
     });
 
     expect(result.ok).toBe(true);
     expect(result.compiledPrompt).toBe(
-      "Update src/api/user.ts and run npm test -- --runInBand 2 times?",
+      "Can you please update src/api/user.ts and run npm test -- --runInBand 2 times?",
     );
     expect(result.promptLanguage).toBe("en");
     expect(result.promptInferenceTimeSec).toBe(0);
     expect(result.promptValidationErrors).toEqual([]);
-    expect(result.promptRepairActions).toContain("compressed_with_kompress");
+    expect(result.promptRepairActions).toEqual([]);
+    expect(compressionImplementation).not.toHaveBeenCalled();
+  });
+
+  it("compresses only the selected execution context before adapter execution", async () => {
+    executeWithAdapterMock
+      .mockResolvedValueOnce({
+        ok: true,
+        adapter: "codex",
+        rawOutput: "[mock] Find auth module in src/auth.ts with detailed notes about imports exports middleware routing and tests",
+        exitCode: 0,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        adapter: "codex",
+        rawOutput: "[mock] validated",
+        exitCode: 0,
+      });
+    const compressionImplementation = vi.fn(async (text: string) => ({
+      compressed: `${text} compressed Find context src/auth.ts`,
+      compression_ratio: 0.7,
+      tokens_saved: 2,
+    }));
+
+    const result = await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "stub",
+      verbose: false,
+      userRequest: {
+        raw_input: "Find the auth module. Test the auth module.",
+      },
+      compressionImplementation,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(compressionImplementation).toHaveBeenCalled();
+    expect(executeWithAdapterMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("compressed Find context"),
+      }),
+    );
   });
 
   it("bridges Korean input through the local LLM request contract when runtime overrides are provided", async () => {

--- a/tests/ts/unit/core/prompt/compiler.test.ts
+++ b/tests/ts/unit/core/prompt/compiler.test.ts
@@ -32,23 +32,25 @@ describe("compilePrompt", () => {
     expect(compiled.language).toBe("en");
   });
 
-  it("영문 입력은 보수적으로 압축하되 핵심 토큰을 보존한다", async () => {
+  it("영문 입력은 Role 1에서 압축하지 않고 normalized input을 보존한다", async () => {
+    const compressionImplementation = vi.fn(async (text: string) => ({
+      compressed: text.replace(/^Can you please /i, ""),
+      compression_ratio: 0.56,
+      tokens_saved: 4,
+    }));
     const compiled = await compilePrompt({
       raw_input:
         "Can you please update src/api/user.ts and run npm test -- --runInBand 2 times?",
     }, {
-      compressionImplementation: vi.fn(async (text: string) => ({
-        compressed: text.replace(/^Can you please /i, ""),
-        compression_ratio: 0.56,
-        tokens_saved: 4,
-      })),
+      compressionImplementation,
     });
 
     expect(compiled.language).toBe("en");
     expect(compiled.compressed_prompt).toBe(
-      "Update src/api/user.ts and run npm test -- --runInBand 2 times?",
+      "Can you please update src/api/user.ts and run npm test -- --runInBand 2 times?",
     );
-    expect(compiled.repair_actions ?? []).toContain("compressed_with_kompress");
+    expect(compiled.repair_actions ?? []).not.toContain("compressed_with_kompress");
+    expect(compressionImplementation).not.toHaveBeenCalled();
   });
 
   it("Role 2.1 handoff uses normalized input before compression", async () => {
@@ -64,7 +66,7 @@ describe("compilePrompt", () => {
     const handoff = createRole2PromptInput(compiled);
 
     expect(compiled.normalized_input).toBe("Please create a new file and test it");
-    expect(compiled.compressed_prompt).toBe("Create a new file and test it");
+    expect(compiled.compressed_prompt).toBe("Please create a new file and test it");
     expect(handoff.compiled_prompt).toBe("Please create a new file and test it");
   });
 


### PR DESCRIPTION
## 요약

- Role 1 `compilePrompt()`에서 Kompress 실행을 제거하고, 번역/정규화 결과인 `normalized_input`을 TaskGraph 생성 입력으로 보존
- `compressed_prompt`는 v1 호환 필드로 유지하되 Role 1 단계에서는 `normalized_input`과 동일하게 반환
- 실행 직전 Context Optimizer 단계에서 선택된 `ExecutionContext.context_summary`만 Kompress 압축
- batch 결과의 `compiled_prompt`와 Role 2.1 handoff 의미를 `normalized_input` 기준으로 정리
- 문서 전역에서 Role 1 prompt compression / compressed handoff 설명을 context compression 계약으로 수정
- `origin/dev` 병합 충돌 해소: dev의 한국어 응답 지시와 압축된 execution context를 함께 사용

## 관련 이슈

- Closes #230 

## 변경 유형

- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩터링
- [x] 문서 수정
- [x] 테스트 추가/수정

## 영향 범위

- 영향받는 모듈:
  - `src/core/prompt/compiler.ts`
  - `src/core/pipeline/orchestrator.ts`
  - `src/core/pipeline/batch.ts`
  - `src/core/task-graph/TaskGraphProcessor.ts`
  - `tests/ts/unit/core/prompt/compiler.test.ts`
  - `tests/ts/unit/core/pipeline/orchestrator.test.ts`
  - `tests/ts/unit/core/pipeline/batch.test.ts`
  - `tests/ts/integration/cli-smoke.test.ts`
  - `docs/*`
- 영향받지 않는 모듈:
  - `src/core/task-graph/TaskSentenceSplitter.ts`
  - `src/core/task-graph/DAGValidator.ts`
  - `src/core/task-graph/DependencyResolver.ts`
  - adapter subprocess 실행 경계

## 변경 후 파이프라인

```text
raw_input
  -> 번역/정규화
  -> normalized_input
  -> TaskSentenceSplitter
  -> TaskGraphProcessor
  -> DAGValidator / DependencyResolver / ParallelClassifier
  -> task별 selected context 구성
  -> selected context summary 압축
  -> executor/session context 전달
```

## 핵심 변경

### Role 1

- `compilePrompt()`는 더 이상 prompt 전체를 Kompress로 압축하지 않습니다.
- `compiledPrompt.compressed_prompt`는 호환 필드로 유지하며 `translatedOutput`을 그대로 사용합니다.
- `repair_actions`에는 translation repair action만 남습니다.

### Role 2.1

- `Role2PromptInput.compiled_prompt`는 계속 `CompiledPrompt.normalized_input`입니다.
- task 분해/분류는 action signal이 살아 있는 정규화 텍스트를 기준으로 합니다.

### Role 2.2

- `compressExecutionContextSummary()`를 추가했습니다.
- 현재 task 실행에 필요한 `context.context_summary`만 압축합니다.
- 이전 task 결과가 없는 context는 압축하지 않습니다.
- 압축 실패 시 원본 context summary를 유지하고 repair action에 실패 원인을 기록합니다.

### Executor Prompt

dev의 한국어 응답 지시 변경과 병합하면서 다음 형태로 정리했습니다.

```ts
const prompt =
  `${responseLanguageInstruction}[${task.type.toUpperCase()}] ${task.title}\n\n` +
  `Context: ${executionContext.context_summary}`;
```

## 테스트 방법

1. 빌드

```bash
npm run build
```

2. 관련 unit tests

```bash
npm test -- tests/ts/unit/core/prompt/compiler.test.ts tests/ts/unit/core/pipeline/orchestrator.test.ts tests/ts/unit/core/pipeline/batch.test.ts tests/ts/unit/core/prompt/compression.test.ts
```

3. 변경 영향권 CLI smoke

```bash
npx vitest run tests/ts/integration/cli-smoke.test.ts -t "keeps default stdout concise"
```

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] 필요한 테스트를 추가/수정했습니다
- [x] 필요한 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] `origin/dev` 병합 충돌을 해소했습니다
- [x] 리뷰하기 좋은 크기로 커밋을 분리했습니다

## 스크린샷 / 로그

```text
> npm run build
> npx --no-install tsc -p tsconfig.json

(0 errors)
```

```text
> npm test -- tests/ts/unit/core/prompt/compiler.test.ts tests/ts/unit/core/pipeline/orchestrator.test.ts tests/ts/unit/core/pipeline/batch.test.ts tests/ts/unit/core/prompt/compression.test.ts

Test Files  4 passed (4)
Tests       26 passed | 1 skipped (27)
```

```text
> npx vitest run tests/ts/integration/cli-smoke.test.ts -t "keeps default stdout concise"

Test Files  1 passed (1)
Tests       2 passed | 27 skipped (29)
```

## 리뷰어 참고사항

- 전체 `cli-smoke.test.ts`는 Windows Node ESM loader의 `ERR_UNSUPPORTED_ESM_URL_SCHEME` / `c:` path 문제로 완료되지 않습니다.
- 동일 REPL/embedded smoke 실패는 `origin/dev`에서도 재현됩니다.
- 이번 PR의 변경 영향권인 batch/default stdout smoke는 통과했습니다.
- task title은 압축하지 않고, task별 selected context summary만 압축합니다. 실행 지시문의 action signal 보존을 우선한 결정입니다.
