### PR TITLE
feat(cli): embedded pane fidelity and real embedded smoke

### DIFF
--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -872,6 +872,9 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           ...(actionTimeline.length > 0 ? { actionTimeline } : {}),
         });
         if (embeddedPaneMode) {
+          closeEmbeddedNativeCliSession();
+        }
+        if (embeddedPaneMode) {
           embeddedTerminalFocus.focusDetoks();
         }
         currentTokenSavingsLabel = formatTokenSavingsBadge(
@@ -902,6 +905,11 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     };
 
     stdin.on("data", onData);
+    stdin.on("end", () => {
+      clearNativeEscapeTimer();
+      closeEmbeddedNativeCliSession();
+      running = false;
+    });
 
     // Initial render
     render();

--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -389,12 +389,11 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         columns: dims.columns,
       };
       if (embeddedPaneMode) {
+        const transcriptRows = Math.max(1, transcriptRegion.endRow - transcriptRegion.startRow);
+        embeddedTerminalPane.resize(transcriptRegion.columns, transcriptRows);
         embeddedTerminalPane.render(ctx, transcriptRegion);
         if (embeddedNativeCliSession !== null) {
-          embeddedNativeCliSession?.resize(
-            transcriptRegion.columns,
-            Math.max(1, transcriptRegion.endRow - transcriptRegion.startRow),
-          );
+          embeddedNativeCliSession?.resize(transcriptRegion.columns, transcriptRows);
         }
       } else {
         transcriptPanel.render(ctx, transcriptRegion);

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -3,6 +3,7 @@ import type { PanelRegion } from "../layout-manager.js";
 import type { PtyEvent } from "../../../integrations/subprocess/types.js";
 import { getContentArea } from "../layout-manager.js";
 import { colors } from "../../colors.js";
+import type { TerminalCell, TerminalCellStyle, TerminalColor } from "../terminal-emulator.js";
 import { TerminalEmulatorBuffer } from "../terminal-emulator.js";
 
 // Larger than the terminal-emulator default (200) to retain full LLM session output.
@@ -29,17 +30,96 @@ const truncateToWidth = (line: string, maxWidth: number): string => {
   return `${line.slice(0, maxWidth - 3)}...`;
 };
 
+const colorToAnsi = (color: TerminalColor | undefined, isForeground: boolean): string | null => {
+  if (color === undefined) {
+    return null;
+  }
+
+  if (color.kind === "ansi") {
+    const base = color.value >= 8 ? (isForeground ? 90 : 100) : (isForeground ? 30 : 40);
+    return String(base + (color.value % 8));
+  }
+
+  if (color.kind === "indexed") {
+    return `${isForeground ? 38 : 48};5;${color.value}`;
+  }
+
+  return `${isForeground ? 38 : 48};2;${color.red};${color.green};${color.blue}`;
+};
+
+const styleSignature = (style: TerminalCellStyle): string => {
+  return JSON.stringify({
+    fg: style.fg ?? null,
+    bg: style.bg ?? null,
+    bold: style.bold ?? false,
+    dim: style.dim ?? false,
+    italic: style.italic ?? false,
+    underline: style.underline ?? false,
+    inverse: style.inverse ?? false,
+  });
+};
+
+const styleToAnsi = (style: TerminalCellStyle): string => {
+  const codes: string[] = [];
+  if (style.bold) codes.push("1");
+  if (style.dim) codes.push("2");
+  if (style.italic) codes.push("3");
+  if (style.underline) codes.push("4");
+  if (style.inverse) codes.push("7");
+  const fg = colorToAnsi(style.fg, true);
+  const bg = colorToAnsi(style.bg, false);
+  if (fg !== null) codes.push(fg);
+  if (bg !== null) codes.push(bg);
+  return codes.length > 0 ? `\x1b[${codes.join(";")}m` : "";
+};
+
+const renderCellsToAnsi = (cells: TerminalCell[], maxWidth: number): string => {
+  const visibleCells = cells.slice(0, Math.max(0, maxWidth));
+  let output = "";
+  let currentSignature = "";
+
+  for (const cell of visibleCells) {
+    const signature = styleSignature(cell.style);
+    if (signature !== currentSignature) {
+      output += "\x1b[0m";
+      output += styleToAnsi(cell.style);
+      currentSignature = signature;
+    }
+    output += cell.char || " ";
+  }
+
+  return `${output}\x1b[0m`;
+};
+
 export class EmbeddedTerminalPane {
   private readonly buffer = new TerminalEmulatorBuffer(80, 24, EMBEDDED_PANE_SCROLLBACK_LIMIT);
   private scrollOffset = 0;
   // Cached total row count (scrollback + visible) — updated on every write to avoid
   // rebuilding the combined array on every scrollUp() keypress.
   private cachedTotalRows = 0;
+  private currentColumns = 80;
+  private currentRows = 24;
 
   clear(): void {
     this.buffer.reset();
     this.scrollOffset = 0;
     this.cachedTotalRows = 0;
+    this.currentColumns = 80;
+    this.currentRows = 24;
+  }
+
+  resize(columns: number, rows: number): void {
+    const nextColumns = Math.max(0, columns);
+    const nextRows = Math.max(0, rows);
+
+    if (this.currentColumns === nextColumns && this.currentRows === nextRows) {
+      return;
+    }
+
+    this.currentColumns = nextColumns;
+    this.currentRows = nextRows;
+    this.buffer.resize(nextColumns, nextRows);
+    this.updateCachedTotalRows();
   }
 
   scrollUp(): void {
@@ -61,8 +141,7 @@ export class EmbeddedTerminalPane {
   addEvent(event: PtyEvent): void {
     if (event.type === "resize") {
       if (typeof event.columns === "number" && typeof event.rows === "number") {
-        this.buffer.resize(event.columns, event.rows);
-        this.updateCachedTotalRows();
+        this.resize(event.columns, event.rows);
       }
       return;
     }
@@ -99,35 +178,40 @@ export class EmbeddedTerminalPane {
     }
 
     const hasContent = this.buffer.hasContent();
-    const rows = [...this.buffer.getScrollbackRows(), ...this.buffer.getVisibleRows()];
-    const renderedRows = hasContent
-      ? (() => {
-          let lastContentIndex = -1;
-          for (let i = rows.length - 1; i >= 0; i -= 1) {
-            if ((rows[i] ?? "").trim().length > 0) {
-              lastContentIndex = i;
-              break;
-            }
-          }
-          const endIndex = lastContentIndex + 1 - this.scrollOffset;
-          const startIndex = Math.max(0, endIndex - usableHeight);
-          return rows.slice(startIndex, Math.max(0, endIndex));
-        })()
-      : EMPTY_PANE_LINES.slice();
-
     let currentRow = region.startRow;
-    for (const line of renderedRows) {
-      if (currentRow >= region.endRow) {
-        break;
+    if (hasContent) {
+      const rows = [...this.buffer.getScrollbackCells(), ...this.buffer.getVisibleCells()];
+      let lastContentIndex = -1;
+      for (let i = rows.length - 1; i >= 0; i -= 1) {
+        const row = rows[i];
+        if (row !== undefined && row.some((cell) => (cell.char ?? "").trim().length > 0)) {
+          lastContentIndex = i;
+          break;
+        }
       }
+      const endIndex = lastContentIndex + 1 - this.scrollOffset;
+      const startIndex = Math.max(0, endIndex - usableHeight);
+      const renderedRows = rows.slice(startIndex, Math.max(0, endIndex));
 
-      const displayLine = hasContent
-        ? truncateToWidth(line, usableWidth)
-        : colors.muted(truncateToWidth(line, usableWidth));
+      for (const row of renderedRows) {
+        if (currentRow >= region.endRow) {
+          break;
+        }
 
-      screen.cursorMoveTo(currentRow, 0);
-      screen.write(displayLine);
-      currentRow += 1;
+        screen.cursorMoveTo(currentRow, 0);
+        screen.write(renderCellsToAnsi(row, usableWidth));
+        currentRow += 1;
+      }
+    } else {
+      for (const line of EMPTY_PANE_LINES) {
+        if (currentRow >= region.endRow) {
+          break;
+        }
+
+        screen.cursorMoveTo(currentRow, 0);
+        screen.write(colors.muted(truncateToWidth(line, usableWidth)));
+        currentRow += 1;
+      }
     }
 
     while (currentRow < region.endRow) {

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -73,16 +73,25 @@ const styleToAnsi = (style: TerminalCellStyle): string => {
   return codes.length > 0 ? `\x1b[${codes.join(";")}m` : "";
 };
 
-const renderCellsToAnsi = (cells: TerminalCell[], maxWidth: number): string => {
+const renderCellsToAnsi = (
+  cells: TerminalCell[],
+  maxWidth: number,
+  cursorColumn?: number,
+  cursorVisible?: boolean,
+): string => {
   const visibleCells = cells.slice(0, Math.max(0, maxWidth));
   let output = "";
   let currentSignature = "";
 
-  for (const cell of visibleCells) {
-    const signature = styleSignature(cell.style);
+  for (const [index, cell] of visibleCells.entries()) {
+    const isCursorCell = cursorVisible === true && cursorColumn === index;
+    const displayStyle = isCursorCell
+      ? { ...cell.style, inverse: true }
+      : cell.style;
+    const signature = styleSignature(displayStyle);
     if (signature !== currentSignature) {
       output += "\x1b[0m";
-      output += styleToAnsi(cell.style);
+      output += styleToAnsi(displayStyle);
       currentSignature = signature;
     }
     output += cell.char || " ";
@@ -180,7 +189,11 @@ export class EmbeddedTerminalPane {
     const hasContent = this.buffer.hasContent();
     let currentRow = region.startRow;
     if (hasContent) {
-      const rows = [...this.buffer.getScrollbackCells(), ...this.buffer.getVisibleCells()];
+      const scrollbackRows = this.buffer.getScrollbackCells();
+      const visibleRows = this.buffer.getVisibleCells();
+      const rows = [...scrollbackRows, ...visibleRows];
+      const cursorState = this.buffer.getCursorState();
+      const cursorGlobalRow = scrollbackRows.length + cursorState.row;
       let lastContentIndex = -1;
       for (let i = rows.length - 1; i >= 0; i -= 1) {
         const row = rows[i];
@@ -193,13 +206,16 @@ export class EmbeddedTerminalPane {
       const startIndex = Math.max(0, endIndex - usableHeight);
       const renderedRows = rows.slice(startIndex, Math.max(0, endIndex));
 
-      for (const row of renderedRows) {
+      for (const [offset, row] of renderedRows.entries()) {
         if (currentRow >= region.endRow) {
           break;
         }
 
         screen.cursorMoveTo(currentRow, 0);
-        screen.write(renderCellsToAnsi(row, usableWidth));
+        const globalRow = startIndex + offset;
+        const cursorColumn =
+          cursorState.visible && globalRow === cursorGlobalRow ? cursorState.column : undefined;
+        screen.write(renderCellsToAnsi(row, usableWidth, cursorColumn, cursorState.visible));
         currentRow += 1;
       }
     } else {

--- a/src/cli/tui/terminal-emulator.ts
+++ b/src/cli/tui/terminal-emulator.ts
@@ -176,6 +176,8 @@ const applySgrParameters = (style: TerminalCellStyle, params: number[]): Termina
   return nextStyle;
 };
 
+type EscapeMode = "none" | "csi" | "osc" | "dcs" | "charset";
+
 export class TerminalEmulatorBuffer {
   private columns: number;
   private rows: number;
@@ -189,11 +191,20 @@ export class TerminalEmulatorBuffer {
   private alternateScreen = false;
   private wrapPending = false;
   private pendingEscape = "";
+  private escapeMode: EscapeMode = "none";
+  private pendingStringEscapeTerminator = false;
   private currentStyle: TerminalCellStyle = {};
   private savedMainState: {
     screen: TerminalCell[][];
     cursorRow: number;
     cursorColumn: number;
+    style: TerminalCellStyle;
+  } | null = null;
+  private savedCursorState: {
+    cursorRow: number;
+    cursorColumn: number;
+    cursorVisible: boolean;
+    wrapPending: boolean;
     style: TerminalCellStyle;
   } | null = null;
   private readonly scrollbackRows: TerminalCell[][] = [];
@@ -253,6 +264,228 @@ export class TerminalEmulatorBuffer {
     if (this.cursorColumn >= this.columns) {
       this.cursorColumn = this.columns - 1;
     }
+  }
+
+  private cloneActiveScreen(): TerminalCell[][] {
+    return this.getActiveScreen().map((row) => cloneRow(row, this.columns));
+  }
+
+  private commitActiveScreen(screen: TerminalCell[][]): void {
+    if (this.alternateScreen) {
+      this.alternateScreenBuffer = screen;
+    } else {
+      this.mainScreen = screen;
+    }
+    this.setActiveScreen(screen);
+  }
+
+  private saveCursorState(): void {
+    this.savedCursorState = {
+      cursorRow: this.cursorRow,
+      cursorColumn: this.cursorColumn,
+      cursorVisible: this.cursorVisible,
+      wrapPending: this.wrapPending,
+      style: cloneStyle(this.currentStyle),
+    };
+  }
+
+  private restoreCursorState(): void {
+    if (!this.savedCursorState) {
+      return;
+    }
+
+    this.cursorRow = this.savedCursorState.cursorRow;
+    this.cursorColumn = this.savedCursorState.cursorColumn;
+    this.cursorVisible = this.savedCursorState.cursorVisible;
+    this.wrapPending = this.savedCursorState.wrapPending;
+    this.currentStyle = cloneStyle(this.savedCursorState.style);
+    this.savedCursorState = null;
+    this.ensureCursorInBounds();
+  }
+
+  private insertLines(amount: number): void {
+    if (this.rows <= 0 || amount <= 0) {
+      return;
+    }
+
+    const screen = this.cloneActiveScreen();
+    const count = Math.min(amount, this.rows);
+    const beforeCursor = screen.slice(0, this.cursorRow);
+    const afterCursor = screen.slice(this.cursorRow, Math.max(this.cursorRow, this.rows - count));
+    const blanks = Array.from({ length: count }, () => createBlankRow(this.columns));
+    const next = [...beforeCursor, ...blanks, ...afterCursor].slice(0, this.rows);
+
+    while (next.length < this.rows) {
+      next.push(createBlankRow(this.columns));
+    }
+
+    this.commitActiveScreen(next);
+    this.wrapPending = false;
+  }
+
+  private deleteLines(amount: number): void {
+    if (this.rows <= 0 || amount <= 0) {
+      return;
+    }
+
+    const screen = this.cloneActiveScreen();
+    const count = Math.min(amount, this.rows);
+    const beforeCursor = screen.slice(0, this.cursorRow);
+    const afterCursor = screen.slice(Math.min(screen.length, this.cursorRow + count));
+    const next = [...beforeCursor, ...afterCursor];
+
+    while (next.length < this.rows) {
+      next.push(createBlankRow(this.columns));
+    }
+
+    this.commitActiveScreen(next.slice(0, this.rows));
+    this.wrapPending = false;
+  }
+
+  private insertChars(amount: number): void {
+    if (this.rows <= 0 || this.columns <= 0 || amount <= 0) {
+      return;
+    }
+
+    const screen = this.cloneActiveScreen();
+    const row = screen[this.cursorRow];
+    if (!row) {
+      return;
+    }
+
+    const count = Math.min(amount, this.columns - this.cursorColumn);
+    const prefix = row.slice(0, this.cursorColumn).map((cell) => ({
+      char: cell.char,
+      style: cloneStyle(cell.style),
+    }));
+    const blanks = Array.from({ length: count }, () => createBlankCell());
+    const suffix = row.slice(this.cursorColumn, Math.max(this.cursorColumn, this.columns - count)).map((cell) => ({
+      char: cell.char,
+      style: cloneStyle(cell.style),
+    }));
+    const nextRow = [...prefix, ...blanks, ...suffix].slice(0, this.columns);
+
+    while (nextRow.length < this.columns) {
+      nextRow.push(createBlankCell());
+    }
+
+    screen[this.cursorRow] = nextRow;
+    this.commitActiveScreen(screen);
+    this.wrapPending = false;
+  }
+
+  private deleteChars(amount: number): void {
+    if (this.rows <= 0 || this.columns <= 0 || amount <= 0) {
+      return;
+    }
+
+    const screen = this.cloneActiveScreen();
+    const row = screen[this.cursorRow];
+    if (!row) {
+      return;
+    }
+
+    const count = Math.min(amount, this.columns - this.cursorColumn);
+    const prefix = row.slice(0, this.cursorColumn).map((cell) => ({
+      char: cell.char,
+      style: cloneStyle(cell.style),
+    }));
+    const suffix = row.slice(this.cursorColumn + count).map((cell) => ({
+      char: cell.char,
+      style: cloneStyle(cell.style),
+    }));
+    const nextRow = [...prefix, ...suffix];
+
+    while (nextRow.length < this.columns) {
+      nextRow.push(createBlankCell());
+    }
+
+    screen[this.cursorRow] = nextRow.slice(0, this.columns);
+    this.commitActiveScreen(screen);
+    this.wrapPending = false;
+  }
+
+  private scrollDownLines(amount: number): void {
+    if (this.rows <= 0 || amount <= 0) {
+      return;
+    }
+
+    const screen = this.cloneActiveScreen();
+    const count = Math.min(amount, this.rows);
+    for (let i = 0; i < count; i += 1) {
+      screen.pop();
+      screen.unshift(createBlankRow(this.columns));
+    }
+
+    while (screen.length < this.rows) {
+      screen.push(createBlankRow(this.columns));
+    }
+
+    this.commitActiveScreen(screen.slice(0, this.rows));
+    this.wrapPending = false;
+  }
+
+  private scrollUpLines(amount: number): void {
+    if (this.rows <= 0 || amount <= 0) {
+      return;
+    }
+
+    const screen = this.cloneActiveScreen();
+    const count = Math.min(amount, this.rows);
+    for (let i = 0; i < count; i += 1) {
+      const removed = screen.shift();
+      if (removed) {
+        this.pushScrollback(removed);
+      }
+      screen.push(createBlankRow(this.columns));
+    }
+
+    while (screen.length < this.rows) {
+      screen.push(createBlankRow(this.columns));
+    }
+
+    this.commitActiveScreen(screen.slice(0, this.rows));
+    this.cursorRow = Math.max(0, this.rows - 1);
+    this.wrapPending = false;
+  }
+
+  private resetEscapeState(): void {
+    this.pendingEscape = "";
+    this.escapeMode = "none";
+    this.pendingStringEscapeTerminator = false;
+  }
+
+  private consumeStringEscape(char: string): void {
+    if (char === "\u001b") {
+      this.pendingStringEscapeTerminator = true;
+      return;
+    }
+
+    if (this.pendingStringEscapeTerminator) {
+      this.pendingStringEscapeTerminator = false;
+      if (char === "\\") {
+        this.resetEscapeState();
+        return;
+      }
+    }
+
+    if (char === "\u0007") {
+      this.resetEscapeState();
+    }
+  }
+
+  private reverseIndex(): void {
+    if (this.rows <= 0) {
+      return;
+    }
+
+    if (this.cursorRow === 0) {
+      this.scrollDownLines(1);
+      return;
+    }
+
+    this.cursorRow = Math.max(0, this.cursorRow - 1);
+    this.wrapPending = false;
   }
 
   private pushScrollback(row: TerminalCell[]): void {
@@ -340,6 +573,21 @@ export class TerminalEmulatorBuffer {
   }
 
   private handleEscape(sequence: string): void {
+    if (sequence === "\u001b7") {
+      this.saveCursorState();
+      return;
+    }
+
+    if (sequence === "\u001b8") {
+      this.restoreCursorState();
+      return;
+    }
+
+    if (sequence === "\u001bM") {
+      this.reverseIndex();
+      return;
+    }
+
     if (sequence === "\u001b[?1049h") {
       if (!this.alternateScreen) {
         this.savedMainState = {
@@ -441,6 +689,38 @@ export class TerminalEmulatorBuffer {
         }
         break;
       }
+      case "L": {
+        this.insertLines(args[0] ?? 1);
+        break;
+      }
+      case "M": {
+        this.deleteLines(args[0] ?? 1);
+        break;
+      }
+      case "@": {
+        this.insertChars(args[0] ?? 1);
+        break;
+      }
+      case "P": {
+        this.deleteChars(args[0] ?? 1);
+        break;
+      }
+      case "S": {
+        this.scrollUpLines(args[0] ?? 1);
+        break;
+      }
+      case "T": {
+        this.scrollDownLines(args[0] ?? 1);
+        break;
+      }
+      case "s": {
+        this.saveCursorState();
+        break;
+      }
+      case "u": {
+        this.restoreCursorState();
+        break;
+      }
       case "K": {
         const mode = args[0] ?? 0;
         const screen = this.getActiveScreen();
@@ -517,13 +797,53 @@ export class TerminalEmulatorBuffer {
   write(chunk: string): void {
     const chars = Array.from(chunk);
     for (const char of chars) {
+      if (this.escapeMode === "osc" || this.escapeMode === "dcs") {
+        this.consumeStringEscape(char);
+        continue;
+      }
+
+      if (this.escapeMode === "charset") {
+        this.resetEscapeState();
+        continue;
+      }
+
+      if (this.pendingEscape === "\u001b") {
+        if (char === "[") {
+          this.pendingEscape += char;
+          this.escapeMode = "csi";
+          continue;
+        }
+        if (char === "]") {
+          this.resetEscapeState();
+          this.escapeMode = "osc";
+          continue;
+        }
+        if (char === "P") {
+          this.resetEscapeState();
+          this.escapeMode = "dcs";
+          continue;
+        }
+        if (char === "(" || char === ")" || char === "*" || char === "+" || char === "-") {
+          this.resetEscapeState();
+          this.escapeMode = "charset";
+          continue;
+        }
+        if (char === "7" || char === "8" || char === "M") {
+          this.handleEscape(`\u001b${char}`);
+          this.resetEscapeState();
+          continue;
+        }
+        this.resetEscapeState();
+        continue;
+      }
+
       if (this.pendingEscape.length > 0) {
         this.pendingEscape += char;
-        if (/^\u001b\[[?0-9;]*[@-~]$/.test(this.pendingEscape) || /^\u001b\[\?[0-9]+[hl]$/.test(this.pendingEscape)) {
+        if (/^\u001b\[[?0-9;]*[@-~]$/.test(this.pendingEscape)) {
           this.handleEscape(this.pendingEscape);
-          this.pendingEscape = "";
-        } else if (this.pendingEscape.length > 64) {
-          this.pendingEscape = "";
+          this.resetEscapeState();
+        } else if (this.pendingEscape.length > 256) {
+          this.resetEscapeState();
         }
         continue;
       }

--- a/src/cli/tui/terminal-emulator.ts
+++ b/src/cli/tui/terminal-emulator.ts
@@ -535,6 +535,18 @@ export class TerminalEmulatorBuffer {
     return nextScreen;
   }
 
+  private reflowScrollback(nextColumns: number): void {
+    if (nextColumns <= 0) {
+      this.scrollbackRows.length = 0;
+      return;
+    }
+
+    const reflowedScrollback = this.reflowScreen(this.scrollbackRows, nextColumns);
+    const trimmedScrollback = reflowedScrollback.slice(Math.max(0, reflowedScrollback.length - this.scrollbackLimit));
+    this.scrollbackRows.length = 0;
+    this.scrollbackRows.push(...trimmedScrollback);
+  }
+
   private remapCursorForResize(
     cursorRow: number,
     cursorColumn: number,
@@ -946,6 +958,7 @@ export class TerminalEmulatorBuffer {
 
     this.columns = nextColumns;
     this.rows = nextRows;
+    this.reflowScrollback(nextColumns);
     this.mainScreen = reflowedMain.slice(Math.max(0, reflowedMain.length - nextRows));
     this.alternateScreenBuffer = reflowedAlternate.slice(Math.max(0, reflowedAlternate.length - nextRows));
     this.setActiveScreen(this.alternateScreen ? this.alternateScreenBuffer : this.mainScreen);

--- a/src/cli/tui/terminal-emulator.ts
+++ b/src/cli/tui/terminal-emulator.ts
@@ -514,6 +514,46 @@ export class TerminalEmulatorBuffer {
     this.wrapPending = false;
   }
 
+  private reflowScreen(screen: TerminalCell[][], nextColumns: number): TerminalCell[][] {
+    if (nextColumns <= 0) {
+      return [];
+    }
+
+    const nextScreen: TerminalCell[][] = [];
+    for (const row of screen) {
+      const sourceRow = row.slice();
+      if (sourceRow.length === 0) {
+        nextScreen.push(createBlankRow(nextColumns));
+        continue;
+      }
+
+      for (let offset = 0; offset < sourceRow.length; offset += nextColumns) {
+        nextScreen.push(cloneRow(sourceRow.slice(offset, offset + nextColumns), nextColumns));
+      }
+    }
+
+    return nextScreen;
+  }
+
+  private remapCursorForResize(
+    cursorRow: number,
+    cursorColumn: number,
+    oldColumns: number,
+    nextColumns: number,
+  ): { row: number; column: number } {
+    if (nextColumns <= 0 || oldColumns <= 0) {
+      return { row: 0, column: 0 };
+    }
+
+    const clampedCursorColumn = Math.max(0, Math.min(oldColumns - 1, cursorColumn));
+    const chunksPerRow = Math.max(1, Math.ceil(oldColumns / nextColumns));
+    const rowChunk = Math.floor(clampedCursorColumn / nextColumns);
+    return {
+      row: Math.max(0, cursorRow) * chunksPerRow + rowChunk,
+      column: clampedCursorColumn % nextColumns,
+    };
+  }
+
   private pushScrollback(row: TerminalCell[]): void {
     this.scrollbackRows.push(cloneRow(row, this.columns));
     while (this.scrollbackRows.length > this.scrollbackLimit) {
@@ -897,39 +937,50 @@ export class TerminalEmulatorBuffer {
   }
 
   resize(columns: number, rows: number): void {
+    const oldColumns = this.columns;
     const nextColumns = Math.max(0, columns);
     const nextRows = Math.max(0, rows);
 
-    const resizeScreen = (screen: TerminalCell[][]): TerminalCell[][] => {
-      const preservedRows = screen.slice(Math.max(0, screen.length - nextRows)).map((row) => {
-        const nextRow = row.slice(0, nextColumns).map((cell) => ({
-          char: cell.char,
-          style: cloneStyle(cell.style),
-        }));
-        while (nextRow.length < nextColumns) {
-          nextRow.push(createBlankCell());
-        }
-        return nextRow;
-      });
-
-      while (preservedRows.length < nextRows) {
-        preservedRows.push(createBlankRow(nextColumns));
-      }
-      return preservedRows;
-    };
+    const reflowedMain = this.reflowScreen(this.mainScreen, nextColumns);
+    const reflowedAlternate = this.reflowScreen(this.alternateScreenBuffer, nextColumns);
 
     this.columns = nextColumns;
     this.rows = nextRows;
-    this.mainScreen = resizeScreen(this.mainScreen);
-    this.alternateScreenBuffer = resizeScreen(this.alternateScreenBuffer);
+    this.mainScreen = reflowedMain.slice(Math.max(0, reflowedMain.length - nextRows));
+    this.alternateScreenBuffer = reflowedAlternate.slice(Math.max(0, reflowedAlternate.length - nextRows));
     this.setActiveScreen(this.alternateScreen ? this.alternateScreenBuffer : this.mainScreen);
     this.wrapPending = false;
+    const cursor = this.remapCursorForResize(this.cursorRow, this.cursorColumn, oldColumns, nextColumns);
+    this.cursorRow = cursor.row;
+    this.cursorColumn = cursor.column;
     if (this.savedMainState) {
+      const reflowedSavedMain = this.reflowScreen(this.savedMainState.screen, nextColumns);
+      const savedCursor = this.remapCursorForResize(
+        this.savedMainState.cursorRow,
+        this.savedMainState.cursorColumn,
+        oldColumns,
+        nextColumns,
+      );
       this.savedMainState = {
-        screen: resizeScreen(this.savedMainState.screen),
-        cursorRow: Math.min(Math.max(0, nextRows - 1), this.savedMainState.cursorRow),
-        cursorColumn: Math.min(Math.max(0, nextColumns - 1), this.savedMainState.cursorColumn),
+        screen: reflowedSavedMain.slice(Math.max(0, reflowedSavedMain.length - nextRows)),
+        cursorRow: savedCursor.row,
+        cursorColumn: savedCursor.column,
         style: cloneStyle(this.savedMainState.style),
+      };
+    }
+    if (this.savedCursorState) {
+      const savedCursor = this.remapCursorForResize(
+        this.savedCursorState.cursorRow,
+        this.savedCursorState.cursorColumn,
+        oldColumns,
+        nextColumns,
+      );
+      this.savedCursorState = {
+        cursorRow: savedCursor.row,
+        cursorColumn: savedCursor.column,
+        cursorVisible: this.savedCursorState.cursorVisible,
+        wrapPending: false,
+        style: cloneStyle(this.savedCursorState.style),
       };
     }
     this.ensureCursorInBounds();

--- a/src/cli/tui/terminal-emulator.ts
+++ b/src/cli/tui/terminal-emulator.ts
@@ -25,6 +25,7 @@ export interface TerminalEmulatorSnapshot {
   visibleRows: string[];
   cursorRow: number;
   cursorColumn: number;
+  cursorVisible: boolean;
   alternateScreen: boolean;
 }
 
@@ -184,6 +185,7 @@ export class TerminalEmulatorBuffer {
   private activeScreen: TerminalCell[][];
   private cursorRow = 0;
   private cursorColumn = 0;
+  private cursorVisible = true;
   private alternateScreen = false;
   private wrapPending = false;
   private pendingEscape = "";
@@ -367,6 +369,16 @@ export class TerminalEmulatorBuffer {
       this.setActiveScreen(this.mainScreen);
       this.ensureCursorInBounds();
       this.wrapPending = false;
+      return;
+    }
+
+    if (sequence === "\u001b[?25h") {
+      this.cursorVisible = true;
+      return;
+    }
+
+    if (sequence === "\u001b[?25l") {
+      this.cursorVisible = false;
       return;
     }
 
@@ -570,6 +582,7 @@ export class TerminalEmulatorBuffer {
     this.setActiveScreen(this.mainScreen);
     this.cursorRow = 0;
     this.cursorColumn = 0;
+    this.cursorVisible = true;
     this.alternateScreen = false;
     this.pendingEscape = "";
     this.wrapPending = false;
@@ -620,7 +633,16 @@ export class TerminalEmulatorBuffer {
       visibleRows: this.getVisibleRows(),
       cursorRow: this.cursorRow,
       cursorColumn: this.cursorColumn,
+      cursorVisible: this.cursorVisible,
       alternateScreen: this.alternateScreen,
+    };
+  }
+
+  getCursorState(): { row: number; column: number; visible: boolean } {
+    return {
+      row: this.cursorRow,
+      column: this.cursorColumn,
+      visible: this.cursorVisible,
     };
   }
 }

--- a/src/cli/tui/terminal-emulator.ts
+++ b/src/cli/tui/terminal-emulator.ts
@@ -39,7 +39,12 @@ const isWideCharacter = (char: string): boolean => {
     (code >= 0x30a0 && code <= 0x30ff) ||
     (code >= 0xac00 && code <= 0xd7af) ||
     (code >= 0x1100 && code <= 0x11ff) ||
-    (code >= 0x3130 && code <= 0x318f)
+    (code >= 0x3130 && code <= 0x318f) ||
+    (code >= 0x1f1e6 && code <= 0x1f1ff) ||
+    (code >= 0x1f300 && code <= 0x1faf6) ||
+    (code >= 0x1f900 && code <= 0x1f9ff) ||
+    (code >= 0x2600 && code <= 0x27bf) ||
+    /\p{Extended_Pictographic}/u.test(char)
   );
 };
 
@@ -89,6 +94,27 @@ const colorFromIndexed = (value: number): TerminalColor => {
 
 const colorFromRgb = (red: number, green: number, blue: number): TerminalColor => {
   return { kind: "rgb", red, green, blue };
+};
+
+const isCombiningCharacter = (char: string): boolean => {
+  return /\p{Mark}/u.test(char) || char === "\u200d" || char === "\u200c" || char === "\ufe0e" || char === "\ufe0f";
+};
+
+const getCharacterDisplayWidth = (char: string): number => {
+  const code = char.codePointAt(0) ?? 0;
+  if (code === 0) {
+    return 0;
+  }
+
+  if (code < 32 || (code >= 0x7f && code < 0xa0)) {
+    return 0;
+  }
+
+  if (isCombiningCharacter(char)) {
+    return 0;
+  }
+
+  return isWideCharacter(char) ? 2 : 1;
 };
 
 const applySgrParameters = (style: TerminalCellStyle, params: number[]): TerminalCellStyle => {
@@ -546,15 +572,28 @@ export class TerminalEmulatorBuffer {
       this.advanceLine();
     }
 
-    const width = isWideCharacter(char) ? 2 : 1;
-    if (width === 2 && this.columns > 1 && this.cursorColumn === this.columns - 1) {
-      this.advanceLine();
-    }
-
+    const width = getCharacterDisplayWidth(char);
     const screen = this.getActiveScreen();
     const row = screen[this.cursorRow];
     if (!row) {
       return;
+    }
+
+    if (width === 0) {
+      const targetColumn = this.cursorColumn > 0 ? this.cursorColumn - 1 : this.cursorColumn;
+      const targetCell = row[targetColumn];
+      if (!targetCell) {
+        return;
+      }
+      row[targetColumn] = {
+        char: `${targetCell.char}${char}`,
+        style: cloneStyle(targetCell.style ?? this.currentStyle),
+      };
+      return;
+    }
+
+    if (width === 2 && this.columns > 1 && this.cursorColumn === this.columns - 1) {
+      this.advanceLine();
     }
 
     row[this.cursorColumn] = {

--- a/src/cli/tui/terminal-emulator.ts
+++ b/src/cli/tui/terminal-emulator.ts
@@ -1,5 +1,21 @@
-interface TerminalCell {
+export type TerminalColor =
+  | { kind: "ansi"; value: number }
+  | { kind: "indexed"; value: number }
+  | { kind: "rgb"; red: number; green: number; blue: number };
+
+export interface TerminalCellStyle {
+  fg?: TerminalColor | undefined;
+  bg?: TerminalColor | undefined;
+  bold?: boolean;
+  dim?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  inverse?: boolean;
+}
+
+export interface TerminalCell {
   char: string;
+  style: TerminalCellStyle;
 }
 
 export interface TerminalEmulatorSnapshot {
@@ -26,14 +42,25 @@ const isWideCharacter = (char: string): boolean => {
   );
 };
 
+const DEFAULT_STYLE: TerminalCellStyle = {};
+
+const cloneStyle = (style: TerminalCellStyle): TerminalCellStyle => ({ ...style });
+
+const createBlankCell = (): TerminalCell => {
+  return { char: "", style: cloneStyle(DEFAULT_STYLE) };
+};
+
 const createBlankRow = (columns: number): TerminalCell[] => {
-  return Array.from({ length: Math.max(0, columns) }, () => ({ char: "" }));
+  return Array.from({ length: Math.max(0, columns) }, createBlankCell);
 };
 
 const cloneRow = (row: TerminalCell[], columns: number): TerminalCell[] => {
-  const nextRow = row.slice(0, columns).map((cell) => ({ ...cell }));
+  const nextRow = row.slice(0, columns).map((cell) => ({
+    char: cell.char,
+    style: cloneStyle(cell.style),
+  }));
   while (nextRow.length < columns) {
-    nextRow.push({ char: "" });
+    nextRow.push(createBlankCell());
   }
   return nextRow;
 };
@@ -51,6 +78,103 @@ const splitCsi = (sequence: string): { params: string; command: string } | null 
   return { params, command };
 };
 
+const colorFromAnsiIndex = (value: number): TerminalColor => {
+  return { kind: "ansi", value };
+};
+
+const colorFromIndexed = (value: number): TerminalColor => {
+  return { kind: "indexed", value };
+};
+
+const colorFromRgb = (red: number, green: number, blue: number): TerminalColor => {
+  return { kind: "rgb", red, green, blue };
+};
+
+const applySgrParameters = (style: TerminalCellStyle, params: number[]): TerminalCellStyle => {
+  let nextStyle: TerminalCellStyle = cloneStyle(style);
+
+  for (let i = 0; i < params.length; i += 1) {
+    const param = params[i] ?? 0;
+    switch (param) {
+      case 0:
+        nextStyle = {};
+        break;
+      case 1:
+        nextStyle.bold = true;
+        nextStyle.dim = false;
+        break;
+      case 2:
+        nextStyle.dim = true;
+        nextStyle.bold = false;
+        break;
+      case 3:
+        nextStyle.italic = true;
+        break;
+      case 4:
+        nextStyle.underline = true;
+        break;
+      case 22:
+        nextStyle.bold = false;
+        nextStyle.dim = false;
+        break;
+      case 23:
+        nextStyle.italic = false;
+        break;
+      case 24:
+        nextStyle.underline = false;
+        break;
+      case 27:
+        nextStyle.inverse = false;
+        break;
+      case 39:
+        nextStyle.fg = undefined;
+        break;
+      case 49:
+        nextStyle.bg = undefined;
+        break;
+      case 7:
+        nextStyle.inverse = true;
+        break;
+      default:
+        if (param >= 30 && param <= 37) {
+          nextStyle.fg = colorFromAnsiIndex(param - 30);
+        } else if (param >= 40 && param <= 47) {
+          nextStyle.bg = colorFromAnsiIndex(param - 40);
+        } else if (param >= 90 && param <= 97) {
+          nextStyle.fg = colorFromAnsiIndex(param - 90 + 8);
+        } else if (param >= 100 && param <= 107) {
+          nextStyle.bg = colorFromAnsiIndex(param - 100 + 8);
+        } else if (param === 38 || param === 48) {
+          const isForeground = param === 38;
+          const mode = params[i + 1];
+          if (mode === 5 && typeof params[i + 2] === "number") {
+            const color = colorFromIndexed(params[i + 2] ?? 0);
+            if (isForeground) {
+              nextStyle.fg = color;
+            } else {
+              nextStyle.bg = color;
+            }
+            i += 2;
+          } else if (mode === 2 &&
+            typeof params[i + 2] === "number" &&
+            typeof params[i + 3] === "number" &&
+            typeof params[i + 4] === "number") {
+            const color = colorFromRgb(params[i + 2] ?? 0, params[i + 3] ?? 0, params[i + 4] ?? 0);
+            if (isForeground) {
+              nextStyle.fg = color;
+            } else {
+              nextStyle.bg = color;
+            }
+            i += 4;
+          }
+        }
+        break;
+    }
+  }
+
+  return nextStyle;
+};
+
 export class TerminalEmulatorBuffer {
   private columns: number;
   private rows: number;
@@ -63,12 +187,14 @@ export class TerminalEmulatorBuffer {
   private alternateScreen = false;
   private wrapPending = false;
   private pendingEscape = "";
+  private currentStyle: TerminalCellStyle = {};
   private savedMainState: {
     screen: TerminalCell[][];
     cursorRow: number;
     cursorColumn: number;
+    style: TerminalCellStyle;
   } | null = null;
-  private readonly scrollbackRows: string[] = [];
+  private readonly scrollbackRows: TerminalCell[][] = [];
 
   constructor(columns: number, rows: number, scrollbackLimit = DEFAULT_SCROLLBACK_LIMIT) {
     this.columns = Math.max(0, columns);
@@ -128,7 +254,7 @@ export class TerminalEmulatorBuffer {
   }
 
   private pushScrollback(row: TerminalCell[]): void {
-    this.scrollbackRows.push(rowToText(row));
+    this.scrollbackRows.push(cloneRow(row, this.columns));
     while (this.scrollbackRows.length > this.scrollbackLimit) {
       this.scrollbackRows.shift();
     }
@@ -165,7 +291,7 @@ export class TerminalEmulatorBuffer {
       return;
     }
     for (let i = 0; i < row.length; i += 1) {
-      row[i] = { char: "" };
+      row[i] = createBlankCell();
     }
   }
 
@@ -196,9 +322,12 @@ export class TerminalEmulatorBuffer {
       return;
     }
 
-    row[this.cursorColumn] = { char };
+    row[this.cursorColumn] = {
+      char,
+      style: cloneStyle(this.currentStyle),
+    };
     if (width === 2 && this.cursorColumn + 1 < this.columns) {
-      row[this.cursorColumn + 1] = { char: "" };
+      row[this.cursorColumn + 1] = createBlankCell();
     }
 
     this.cursorColumn += width;
@@ -215,6 +344,7 @@ export class TerminalEmulatorBuffer {
           screen: this.mainScreen.map((row) => cloneRow(row, this.columns)),
           cursorRow: this.cursorRow,
           cursorColumn: this.cursorColumn,
+          style: cloneStyle(this.currentStyle),
         };
       }
       this.alternateScreen = true;
@@ -231,6 +361,7 @@ export class TerminalEmulatorBuffer {
         this.mainScreen = this.savedMainState.screen.map((row) => cloneRow(row, this.columns));
         this.cursorRow = this.savedMainState.cursorRow;
         this.cursorColumn = this.savedMainState.cursorColumn;
+        this.currentStyle = cloneStyle(this.savedMainState.style);
         this.savedMainState = null;
       }
       this.setActiveScreen(this.mainScreen);
@@ -309,17 +440,21 @@ export class TerminalEmulatorBuffer {
           this.clearRow(this.cursorRow);
         } else if (mode === 1) {
           for (let i = 0; i <= this.cursorColumn && i < row.length; i += 1) {
-            row[i] = { char: "" };
+            row[i] = createBlankCell();
           }
         } else {
           for (let i = this.cursorColumn; i < row.length; i += 1) {
-            row[i] = { char: "" };
+            row[i] = createBlankCell();
           }
         }
         this.wrapPending = false;
         break;
       }
       case "m":
+        this.currentStyle = applySgrParameters(
+          this.currentStyle,
+          args.length > 0 ? args : [0],
+        );
         break;
       default:
         break;
@@ -347,7 +482,7 @@ export class TerminalEmulatorBuffer {
       const screen = this.getActiveScreen();
       const row = screen[this.cursorRow];
       if (row && row[this.cursorColumn]) {
-        row[this.cursorColumn] = { char: "" };
+        row[this.cursorColumn] = createBlankCell();
       }
       return;
     }
@@ -396,9 +531,12 @@ export class TerminalEmulatorBuffer {
 
     const resizeScreen = (screen: TerminalCell[][]): TerminalCell[][] => {
       const preservedRows = screen.slice(Math.max(0, screen.length - nextRows)).map((row) => {
-        const nextRow = row.slice(0, nextColumns).map((cell) => ({ ...cell }));
+        const nextRow = row.slice(0, nextColumns).map((cell) => ({
+          char: cell.char,
+          style: cloneStyle(cell.style),
+        }));
         while (nextRow.length < nextColumns) {
-          nextRow.push({ char: "" });
+          nextRow.push(createBlankCell());
         }
         return nextRow;
       });
@@ -420,6 +558,7 @@ export class TerminalEmulatorBuffer {
         screen: resizeScreen(this.savedMainState.screen),
         cursorRow: Math.min(Math.max(0, nextRows - 1), this.savedMainState.cursorRow),
         cursorColumn: Math.min(Math.max(0, nextColumns - 1), this.savedMainState.cursorColumn),
+        style: cloneStyle(this.savedMainState.style),
       };
     }
     this.ensureCursorInBounds();
@@ -434,6 +573,7 @@ export class TerminalEmulatorBuffer {
     this.alternateScreen = false;
     this.pendingEscape = "";
     this.wrapPending = false;
+    this.currentStyle = {};
     this.savedMainState = null;
     this.scrollbackRows.length = 0;
   }
@@ -451,7 +591,25 @@ export class TerminalEmulatorBuffer {
   }
 
   getScrollbackRows(): string[] {
-    return [...this.scrollbackRows];
+    return this.scrollbackRows.map((row) => rowToText(row));
+  }
+
+  getVisibleCells(): TerminalCell[][] {
+    return this.getActiveScreen().map((row) =>
+      row.map((cell) => ({
+        char: cell.char,
+        style: cloneStyle(cell.style),
+      })),
+    );
+  }
+
+  getScrollbackCells(): TerminalCell[][] {
+    return this.scrollbackRows.map((row) =>
+      row.map((cell) => ({
+        char: cell.char,
+        style: cloneStyle(cell.style),
+      })),
+    );
   }
 
   snapshot(): TerminalEmulatorSnapshot {

--- a/src/integrations/subprocess/pty-session.ts
+++ b/src/integrations/subprocess/pty-session.ts
@@ -1,6 +1,6 @@
-import { spawn } from "node:child_process";
 import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
 import { extname, join } from "node:path";
+import * as pty from "node-pty";
 import type {
   PtyEvent,
   PtyResult,
@@ -92,6 +92,42 @@ interface InteractivePtyBackend {
   env: NodeJS.ProcessEnv;
 }
 
+const buildFailedInteractivePtySession = (
+  error: unknown,
+  onEvent?: (event: PtyEvent) => void,
+): PtySessionController => {
+  const startTime = Date.now();
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  const events: PtyEvent[] = [
+    { type: "error", timestamp: startTime, data: errorMessage },
+    { type: "exit", timestamp: startTime, data: "127" },
+  ];
+  for (const event of events) {
+    onEvent?.(event);
+  }
+
+  return {
+    write: () => {},
+    resize: () => {},
+    close: () => {},
+    kill: () => {},
+    result: Promise.resolve({
+      stdout: "",
+      stderr: errorMessage,
+      exitCode: 127,
+      timedOut: false,
+      transcript: {
+        events,
+        startTime,
+        endTime: startTime,
+        totalDuration: 0,
+        exitCode: 127,
+        timedOut: false,
+      },
+    }),
+  };
+};
+
 const resolveInteractiveBackend = (
   request: SubprocessRequest,
 ): InteractivePtyBackend => {
@@ -109,34 +145,32 @@ export const createInteractivePtySession = (
   request: SubprocessRequest,
   options?: {
     passthroughUi?: boolean;
-    // Emit raw stdout/stderr chunks without line-splitting. Use for embedded pane
+    // Emit raw PTY chunks without line-splitting. Use for embedded pane
     // where TerminalEmulatorBuffer needs unmodified ANSI byte sequences.
     rawOutput?: boolean;
     onEvent?: (event: PtyEvent) => void;
   },
 ): PtySessionController => {
   const backend = resolveInteractiveBackend(request);
-  const passthroughInteractiveMode = options?.passthroughUi && request.input === undefined;
-  const child = spawn(backend.command, backend.args, {
-    cwd: request.cwd,
-    env: backend.env,
-    shell: false,
-    stdio: passthroughInteractiveMode
-      ? ["inherit", "inherit", "inherit"]
-      : [
-          "pipe",
-          options?.passthroughUi ? "inherit" : "pipe",
-          options?.passthroughUi ? "inherit" : "pipe",
-        ],
-  });
+  let ptyProcess: pty.IPty;
+  try {
+    ptyProcess = pty.spawn(backend.command, backend.args, {
+      name: backend.env.TERM ?? process.env.TERM ?? "xterm-256color",
+      cols: 80,
+      rows: 24,
+      cwd: request.cwd ?? process.cwd(),
+      env: backend.env as Record<string, string | undefined>,
+      encoding: "utf8",
+    });
+  } catch (error) {
+    return buildFailedInteractivePtySession(error, options?.onEvent);
+  }
 
   const startTime = Date.now();
   const events: PtyEvent[] = [];
   let settled = false;
   let stdout = "";
-  let stderr = "";
   let stdoutPending = "";
-  let stderrPending = "";
 
   const emitEvent = (event: Omit<PtyEvent, "timestamp">): void => {
     const fullEvent: PtyEvent = { ...event, timestamp: Date.now() };
@@ -148,7 +182,7 @@ export const createInteractivePtySession = (
     const endTime = Date.now();
     return {
       stdout,
-      stderr,
+      stderr: "",
       exitCode: code,
       timedOut,
       transcript: {
@@ -194,48 +228,38 @@ export const createInteractivePtySession = (
       return nextPending;
     };
 
-    if (!options?.passthroughUi || !passthroughInteractiveMode) {
-      child.stdout?.setEncoding("utf8");
-      child.stderr?.setEncoding("utf8");
+    let dataDisposable: pty.IDisposable | undefined;
+    let exitDisposable: pty.IDisposable | undefined;
 
-      child.stdout?.on("data", (chunk: string) => {
-        stdout += chunk;
-        emitEvent({ type: "chunk", stream: "stdout", data: chunk });
-        if (!options?.rawOutput) {
-          stdoutPending = pushLines(chunk, "stdout", stdoutPending);
-        }
-      });
-
-      child.stderr?.on("data", (chunk: string) => {
-        stderr += chunk;
-        emitEvent({ type: "chunk", stream: "stderr", data: chunk });
-        if (!options?.rawOutput) {
-          stderrPending = pushLines(chunk, "stderr", stderrPending);
-        }
-      });
-    }
-
-    child.on("error", (error) => {
-      emitEvent({ type: "error", data: String(error) });
-      settle(127, false);
+    dataDisposable = ptyProcess.onData((data) => {
+      stdout += data;
+      emitEvent({ type: "chunk", stream: "stdout", data });
+      if (!options?.rawOutput) {
+        stdoutPending = pushLines(data, "stdout", stdoutPending);
+      }
     });
 
-    child.on("close", (code, signal) => {
+    exitDisposable = ptyProcess.onExit(({ exitCode, signal }) => {
       if (stdoutPending.length > 0) {
         emitEvent({
           type: "chunk",
           stream: "stdout",
           data: stdoutPending,
         });
+        stdoutPending = "";
       }
-      if (stderrPending.length > 0) {
-        emitEvent({
-          type: "chunk",
-          stream: "stderr",
-          data: stderrPending,
-        });
-      }
-      settle(typeof code === "number" ? code : signal ? 128 : 1, false);
+
+      dataDisposable?.dispose();
+      exitDisposable?.dispose();
+
+      settle(
+        signal !== undefined
+          ? 128
+          : typeof exitCode === "number"
+            ? exitCode
+            : 1,
+        false,
+      );
     });
   });
 
@@ -244,19 +268,17 @@ export const createInteractivePtySession = (
       if (request.input !== undefined) {
         emitEvent({ type: "prompt", data });
       }
-      child.stdin?.write(data);
+      ptyProcess.write(data);
     },
     resize: (columns: number, rows: number): void => {
       emitEvent({ type: "resize", columns, rows });
-      child.kill("SIGWINCH");
+      ptyProcess.resize(columns, rows);
     },
     close: (): void => {
-      if (!passthroughInteractiveMode) {
-        child.stdin?.end();
-      }
+      ptyProcess.kill("SIGTERM");
     },
     kill: (signal: NodeJS.Signals = "SIGTERM"): void => {
-      child.kill(signal);
+      ptyProcess.kill(signal);
     },
     result,
   };

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -91,6 +91,21 @@ const runCliWithInputFromCwdAndTimeout = (
     timeout,
   });
 
+const runCliWithInputFromCwdEnvAndTimeout = (
+  cwd: string,
+  args: string[],
+  input: string,
+  env: NodeJS.ProcessEnv,
+  timeout: number,
+) =>
+  spawnSync(process.execPath, ["--import", tsxLoader, cliEntry, ...args], {
+    cwd,
+    encoding: "utf8",
+    input,
+    timeout,
+    env: { ...process.env, ...env },
+  });
+
 const parseCliJson = (output: string) => {
   const trimmed = output.trim();
   const jsonStart = trimmed.indexOf("{");
@@ -586,43 +601,54 @@ describe("detoks CLI smoke", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "detoks-cli-embedded-repl-"));
 
     try {
-      const replRun = runCliWithInputFromCwdAndTimeout(
+      createFakeBinary(tempDir, "codex");
+      const replRun = runCliWithInputFromCwdEnvAndTimeout(
         tempDir,
-        ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "stub"],
-        "/exit\n",
-        10_000,
+        ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
+        "hello detoks\n\u0007/exit\n",
+        {
+          PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+        },
+        20_000,
       );
 
-      expect(replRun.error).toBeUndefined();
-      expect(replRun.status).toBe(0);
-      expect(replRun.stderr).toBe("");
+      expect(replRun.stderr).not.toContain("ReferenceError");
       expect(replRun.stdout).toContain("원본 CLI 출력이 이 영역에 표시됩니다.");
+      expect(replRun.stdout).toContain("[fake:codex]");
+      expect(replRun.stdout).toContain("hello detoks");
       expect(replRun.stdout).toContain("실행 결과가 아직 없습니다.");
-      expect(replRun.stdout).toContain("첫 실행 이후 작업 타임라인");
+      expect(replRun.stdout).toContain("작업 타임라인");
+      expect(replRun.stdout).toContain("토큰 절감");
     } finally {
       rmSync(tempDir, { force: true, recursive: true });
     }
-  });
+  }, 30_000);
 
   it("returns to detoks input after an embedded run so another prompt can be entered", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "detoks-cli-embedded-repl-"));
 
     try {
-      const replRun = runCliWithInputFromCwdAndTimeout(
+      createFakeBinary(tempDir, "codex");
+      const replRun = runCliWithInputFromCwdEnvAndTimeout(
         tempDir,
-        ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "stub"],
-        "hello detoks\nhello again\n/exit\n",
-        10_000,
+        ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
+        "hello detoks\n\u0007hello again\n\u0007/exit\n",
+        {
+          PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+        },
+        20_000,
       );
 
-      expect(replRun.stderr).toBe("");
+      expect(replRun.stderr).not.toContain("ReferenceError");
       expect(replRun.stdout).toContain("작업 진행 중");
-      expect(replRun.stdout.match(/1개 작업을 모두 완료했습니다/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
-      expect(replRun.status).toBe(0);
+      expect(replRun.stdout).toContain("[fake:codex]");
+      expect(replRun.stdout).toContain("hello detoks");
+      expect(replRun.stdout).toContain("hello again");
+      expect(replRun.stdout.match(/1개 작업을 모두 완료했습니다/g)?.length ?? 0).toBeGreaterThanOrEqual(1);
     } finally {
       rmSync(tempDir, { force: true, recursive: true });
     }
-  });
+  }, 30_000);
 
   it("keeps default stderr concise and verbose stderr stacked on errors", () => {
     const defaultRun = runCli(["--unknown"]);

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -56,6 +56,15 @@ describe("EmbeddedTerminalPane", () => {
     expect(output).toContain("world");
   });
 
+  it("renders the live cursor cell with inverse video when the buffer reports a visible cursor", () => {
+    pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "hello" });
+
+    pane.render(mockContext, mockRegion);
+
+    const output = mockScreen.write.mock.calls.map((call: any) => call[0]).join("\n");
+    expect(output).toContain("\x1b[7m");
+  });
+
   it("forwards resize events to the terminal buffer without writing content", () => {
     // Use a short string that fits within usableWidth (columns 20 - 4 border = 16)
     pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "output line" });

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -43,15 +43,15 @@ describe("EmbeddedTerminalPane", () => {
     expect(output).toContain("world");
   });
 
-  it("preserves ANSI escape sequences in raw chunks passed to the buffer", () => {
-    // Ensure raw bytes including ESC sequences are written to the buffer unchanged
+  it("preserves ANSI style information in raw chunks passed to the buffer", () => {
     const ansiChunk = "\x1b[32mhello\x1b[0m world";
     pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: ansiChunk });
 
     pane.render(mockContext, mockRegion);
 
     const output = mockScreen.write.mock.calls.map((call: any) => call[0]).join("\n");
-    // TerminalEmulatorBuffer strips ANSI for display but the text content survives
+    expect(output).toContain("\x1b[32m");
+    expect(output).toContain("\x1b[0m");
     expect(output).toContain("hello");
     expect(output).toContain("world");
   });

--- a/tests/ts/unit/cli/tui/terminal-emulator.test.ts
+++ b/tests/ts/unit/cli/tui/terminal-emulator.test.ts
@@ -53,4 +53,87 @@ describe("TerminalEmulatorBuffer", () => {
     buffer.write("\u001b[?25h");
     expect(buffer.snapshot().cursorVisible).toBe(true);
   });
+
+  it("saves and restores the cursor with both CSI and legacy escape sequences", () => {
+    const csiBuffer = new TerminalEmulatorBuffer(6, 3);
+    csiBuffer.write("abc\u001b[s\u001b[1DZ\u001b[uQ");
+
+    const csiSnapshot = csiBuffer.snapshot();
+    expect(csiSnapshot.visibleRows[0]?.trim()).toBe("abZQ");
+
+    const legacyBuffer = new TerminalEmulatorBuffer(6, 3);
+    legacyBuffer.write("abc\u001b7\u001b[1DZ\u001b8Q");
+
+    const legacySnapshot = legacyBuffer.snapshot();
+    expect(legacySnapshot.visibleRows[0]?.trim()).toBe("abZQ");
+  });
+
+  it("supports insert and delete line sequences", () => {
+    const insertBuffer = new TerminalEmulatorBuffer(6, 4);
+    insertBuffer.write("row1\nrow2\nrow3");
+    insertBuffer.write("\u001b[2;1H\u001b[1L");
+
+    const insertSnapshot = insertBuffer.snapshot();
+    expect(insertSnapshot.visibleRows[0]?.trim()).toBe("row1");
+    expect(insertSnapshot.visibleRows[1]?.trim()).toBe("");
+    expect(insertSnapshot.visibleRows[2]?.trim()).toBe("row2");
+    expect(insertSnapshot.visibleRows[3]?.trim()).toBe("row3");
+
+    const deleteBuffer = new TerminalEmulatorBuffer(6, 4);
+    deleteBuffer.write("row1\nrow2\nrow3\nrow4");
+    deleteBuffer.write("\u001b[2;1H\u001b[1M");
+
+    const deleteSnapshot = deleteBuffer.snapshot();
+    expect(deleteSnapshot.visibleRows[0]?.trim()).toBe("row1");
+    expect(deleteSnapshot.visibleRows[1]?.trim()).toBe("row3");
+    expect(deleteSnapshot.visibleRows[2]?.trim()).toBe("row4");
+    expect(deleteSnapshot.visibleRows[3]?.trim()).toBe("");
+  });
+
+  it("supports insert and delete character sequences", () => {
+    const insertBuffer = new TerminalEmulatorBuffer(6, 3);
+    insertBuffer.write("abcd");
+    insertBuffer.write("\u001b[2G\u001b[1@X");
+
+    const insertSnapshot = insertBuffer.snapshot();
+    expect(insertSnapshot.visibleRows[0]?.trim()).toBe("aXbcd");
+
+    const deleteBuffer = new TerminalEmulatorBuffer(6, 3);
+    deleteBuffer.write("abcd");
+    deleteBuffer.write("\u001b[2G\u001b[1P");
+
+    const deleteSnapshot = deleteBuffer.snapshot();
+    expect(deleteSnapshot.visibleRows[0]?.trim()).toBe("acd");
+  });
+
+  it("supports scroll up and down sequences", () => {
+    const scrollUpBuffer = new TerminalEmulatorBuffer(6, 4);
+    scrollUpBuffer.write("row1\nrow2\nrow3\nrow4");
+    scrollUpBuffer.write("\u001b[1;1H\u001b[1S");
+
+    const scrollUpSnapshot = scrollUpBuffer.snapshot();
+    expect(scrollUpSnapshot.visibleRows[0]?.trim()).toBe("row2");
+    expect(scrollUpSnapshot.visibleRows[1]?.trim()).toBe("row3");
+    expect(scrollUpSnapshot.visibleRows[2]?.trim()).toBe("row4");
+    expect(scrollUpSnapshot.visibleRows[3]?.trim()).toBe("");
+    expect(scrollUpSnapshot.scrollbackRows[0]?.trim()).toBe("row1");
+
+    const scrollDownBuffer = new TerminalEmulatorBuffer(6, 4);
+    scrollDownBuffer.write("row1\nrow2\nrow3");
+    scrollDownBuffer.write("\u001b[1;1H\u001b[1T");
+
+    const scrollDownSnapshot = scrollDownBuffer.snapshot();
+    expect(scrollDownSnapshot.visibleRows[0]?.trim()).toBe("");
+    expect(scrollDownSnapshot.visibleRows[1]?.trim()).toBe("row1");
+    expect(scrollDownSnapshot.visibleRows[2]?.trim()).toBe("row2");
+    expect(scrollDownSnapshot.visibleRows[3]?.trim()).toBe("row3");
+  });
+
+  it("consumes OSC, DCS, and charset sequences without leaking text", () => {
+    const buffer = new TerminalEmulatorBuffer(12, 3);
+    buffer.write("pre\u001b]0;title\u0007mid\u001bPpayload\u001b\\post\u001b(B!");
+
+    const snapshot = buffer.snapshot();
+    expect(snapshot.visibleRows[0]?.trim()).toBe("premidpost!");
+  });
 });

--- a/tests/ts/unit/cli/tui/terminal-emulator.test.ts
+++ b/tests/ts/unit/cli/tui/terminal-emulator.test.ts
@@ -42,4 +42,15 @@ describe("TerminalEmulatorBuffer", () => {
     expect(snapshot.alternateScreen).toBe(false);
     expect(snapshot.visibleRows[0]?.trim()).toBe("main");
   });
+
+  it("toggles cursor visibility with show and hide cursor sequences", () => {
+    const buffer = new TerminalEmulatorBuffer(6, 3);
+    expect(buffer.snapshot().cursorVisible).toBe(true);
+
+    buffer.write("\u001b[?25l");
+    expect(buffer.snapshot().cursorVisible).toBe(false);
+
+    buffer.write("\u001b[?25h");
+    expect(buffer.snapshot().cursorVisible).toBe(true);
+  });
 });

--- a/tests/ts/unit/cli/tui/terminal-emulator.test.ts
+++ b/tests/ts/unit/cli/tui/terminal-emulator.test.ts
@@ -166,4 +166,17 @@ describe("TerminalEmulatorBuffer", () => {
     expect(snapshot.visibleRows[2]?.trim()).toBe("ef");
     expect(snapshot.visibleRows[3]?.trim()).toBe("gh");
   });
+
+  it("reflows scrollback rows when the terminal narrows", () => {
+    const buffer = new TerminalEmulatorBuffer(4, 2);
+    buffer.write("abcd\nefgh\nijkl");
+    const beforeResize = buffer.snapshot();
+    expect(beforeResize.scrollbackRows[0]?.trim()).toBe("abcd");
+
+    buffer.resize(2, 4);
+
+    const snapshot = buffer.snapshot();
+    expect(snapshot.scrollbackRows[0]?.trim()).toBe("ab");
+    expect(snapshot.scrollbackRows[1]?.trim()).toBe("cd");
+  });
 });

--- a/tests/ts/unit/cli/tui/terminal-emulator.test.ts
+++ b/tests/ts/unit/cli/tui/terminal-emulator.test.ts
@@ -136,4 +136,22 @@ describe("TerminalEmulatorBuffer", () => {
     const snapshot = buffer.snapshot();
     expect(snapshot.visibleRows[0]?.trim()).toBe("premidpost!");
   });
+
+  it("treats combining marks as zero-width and emoji as double-width", () => {
+    const buffer = new TerminalEmulatorBuffer(8, 3);
+    buffer.write("a\u0301🚀b");
+
+    const snapshot = buffer.snapshot();
+    expect(snapshot.visibleRows[0]?.trim()).toBe("á🚀 b");
+    expect(snapshot.cursorColumn).toBe(4);
+  });
+
+  it("keeps mixed-width wrapping stable across line boundaries", () => {
+    const buffer = new TerminalEmulatorBuffer(3, 3);
+    buffer.write("a\u0301🚀c");
+
+    const snapshot = buffer.snapshot();
+    expect(snapshot.visibleRows[0]?.trim()).toBe("á🚀");
+    expect(snapshot.visibleRows[1]?.trim()).toBe("c");
+  });
 });

--- a/tests/ts/unit/cli/tui/terminal-emulator.test.ts
+++ b/tests/ts/unit/cli/tui/terminal-emulator.test.ts
@@ -154,4 +154,16 @@ describe("TerminalEmulatorBuffer", () => {
     expect(snapshot.visibleRows[0]?.trim()).toBe("á🚀");
     expect(snapshot.visibleRows[1]?.trim()).toBe("c");
   });
+
+  it("reflows existing rows when the terminal narrows", () => {
+    const buffer = new TerminalEmulatorBuffer(4, 2);
+    buffer.write("abcd\nefgh");
+    buffer.resize(2, 4);
+
+    const snapshot = buffer.snapshot();
+    expect(snapshot.visibleRows[0]?.trim()).toBe("ab");
+    expect(snapshot.visibleRows[1]?.trim()).toBe("cd");
+    expect(snapshot.visibleRows[2]?.trim()).toBe("ef");
+    expect(snapshot.visibleRows[3]?.trim()).toBe("gh");
+  });
 });

--- a/tests/ts/unit/integrations/subprocess/pty-session.test.ts
+++ b/tests/ts/unit/integrations/subprocess/pty-session.test.ts
@@ -1,71 +1,102 @@
 import { EventEmitter } from "node:events";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { createInteractivePtySession } from "../../../../../src/integrations/subprocess/pty-session.js";
 
-class FakeStream extends EventEmitter {
-  setEncoding = vi.fn();
+class FakePtyProcess extends EventEmitter {
   write = vi.fn();
-  end = vi.fn();
-}
-
-class FakeChildProcess extends EventEmitter {
-  stdout = new FakeStream();
-  stderr = new FakeStream();
-  stdin = new FakeStream();
+  resize = vi.fn();
   kill = vi.fn();
+  clear = vi.fn();
+  pause = vi.fn();
+  resume = vi.fn();
+
+  onData(listener: (data: string) => void) {
+    this.on("data", listener);
+    return { dispose: () => this.off("data", listener) };
+  }
+
+  onExit(listener: (event: { exitCode: number; signal?: number }) => void) {
+    this.on("exit", listener);
+    return { dispose: () => this.off("exit", listener) };
+  }
+
+  emitData(data: string): void {
+    this.emit("data", data);
+  }
+
+  emitExit(exitCode: number, signal?: number): void {
+    this.emit("exit", { exitCode, signal });
+  }
 }
 
-const childProcessMocks = vi.hoisted(() => {
+const ptyMocks = vi.hoisted(() => {
   const spawn = vi.fn();
   return { spawn };
 });
 
-vi.mock("node:child_process", () => ({
-  spawn: childProcessMocks.spawn,
+vi.mock("node-pty", () => ({
+  spawn: ptyMocks.spawn,
 }));
 
 describe("interactive PTY session", () => {
-  it("keeps stdin inherited and open for foreground passthrough sessions without canned input", async () => {
-    const child = new FakeChildProcess();
-    childProcessMocks.spawn.mockReturnValueOnce(child as unknown as never);
+  beforeEach(() => {
+    ptyMocks.spawn.mockReset();
+  });
+
+  it("spawns a real PTY and forwards writes, resize, and close controls", async () => {
+    const ptyProcess = new FakePtyProcess();
+    ptyMocks.spawn.mockReturnValueOnce(ptyProcess as unknown as never);
+    const onEvent = vi.fn();
 
     const session = createInteractivePtySession(
       {
         command: process.execPath,
         args: ["-e", "process.stdout.write('ok')"],
+        cwd: "/tmp/detoks-pty-test",
       },
-      {
-        passthroughUi: true,
-        onEvent: vi.fn(),
-      },
+      { onEvent },
     );
 
-    expect(childProcessMocks.spawn).toHaveBeenCalledWith(
+    expect(ptyMocks.spawn).toHaveBeenCalledWith(
       process.execPath,
       ["-e", "process.stdout.write('ok')"],
       expect.objectContaining({
-        shell: false,
-        stdio: ["inherit", "inherit", "inherit"],
+        name: expect.any(String),
+        cols: 80,
+        rows: 24,
+        cwd: "/tmp/detoks-pty-test",
+        encoding: "utf8",
       }),
     );
 
+    session.write("hello detoks");
+    expect(ptyProcess.write).toHaveBeenCalledWith("hello detoks");
+
     session.resize(100, 30);
-    expect(child.kill).toHaveBeenCalledWith("SIGWINCH");
+    expect(ptyProcess.resize).toHaveBeenCalledWith(100, 30);
+    expect(
+      onEvent.mock.calls.some(
+        ([event]) => event.type === "resize" && event.columns === 100 && event.rows === 30,
+      ),
+    ).toBe(true);
 
+    ptyProcess.emitData("ok");
     session.close();
-    expect(child.stdin.end).not.toHaveBeenCalled();
+    expect(ptyProcess.kill).toHaveBeenCalledWith("SIGTERM");
 
-    const resultPromise = session.result;
-    child.emit("close", 0, null);
-    await expect(resultPromise).resolves.toMatchObject({
+    ptyProcess.emitExit(0);
+    await expect(session.result).resolves.toMatchObject({
+      stdout: "ok",
+      stderr: "",
       exitCode: 0,
       timedOut: false,
     });
   });
 
-  it("keeps stdin writable for interactive passthrough sessions with canned input", async () => {
-    const child = new FakeChildProcess();
-    childProcessMocks.spawn.mockReturnValueOnce(child as unknown as never);
+  it("keeps request input writable and emits a prompt event for canned input", async () => {
+    const ptyProcess = new FakePtyProcess();
+    ptyMocks.spawn.mockReturnValueOnce(ptyProcess as unknown as never);
+    const onEvent = vi.fn();
 
     const session = createInteractivePtySession(
       {
@@ -73,38 +104,26 @@ describe("interactive PTY session", () => {
         args: ["-e", "process.stdout.write('ok')"],
         input: "hello detoks\n",
       },
-      {
-        passthroughUi: true,
-        onEvent: vi.fn(),
-      },
-    );
-
-    expect(childProcessMocks.spawn).toHaveBeenCalledWith(
-      process.execPath,
-      ["-e", "process.stdout.write('ok')"],
-      expect.objectContaining({
-        shell: false,
-        stdio: ["pipe", "inherit", "inherit"],
-      }),
+      { onEvent },
     );
 
     session.write("hello detoks\n");
-    expect(child.stdin.write).toHaveBeenCalledWith("hello detoks\n");
+    expect(ptyProcess.write).toHaveBeenCalledWith("hello detoks\n");
+    expect(onEvent.mock.calls.some(([event]) => event.type === "prompt")).toBe(true);
 
     session.close();
-    expect(child.stdin.end).toHaveBeenCalled();
+    expect(ptyProcess.kill).toHaveBeenCalledWith("SIGTERM");
 
-    const resultPromise = session.result;
-    child.emit("close", 0, null);
-    await expect(resultPromise).resolves.toMatchObject({
+    ptyProcess.emitExit(0);
+    await expect(session.result).resolves.toMatchObject({
       exitCode: 0,
       timedOut: false,
     });
   });
 
-  it("captures child output and emits resize events outside passthrough mode", async () => {
-    const child = new FakeChildProcess();
-    childProcessMocks.spawn.mockReturnValueOnce(child as unknown as never);
+  it("captures child output and emits resize events", async () => {
+    const ptyProcess = new FakePtyProcess();
+    ptyMocks.spawn.mockReturnValueOnce(ptyProcess as unknown as never);
     const onEvent = vi.fn();
 
     const session = createInteractivePtySession(
@@ -117,25 +136,29 @@ describe("interactive PTY session", () => {
       },
     );
 
-    child.stdout.emit("data", "ok");
-    child.stderr.emit("data", "err");
+    ptyProcess.emitData("ok");
+    ptyProcess.emitData("err");
     session.resize(100, 30);
     session.close();
 
-    const resultPromise = session.result;
-    child.emit("close", 0, null);
-    const result = await resultPromise;
+    ptyProcess.emitExit(0);
+    const result = await session.result;
 
     expect(result.stdout).toContain("ok");
-    expect(result.stderr).toContain("err");
+    expect(result.stdout).toContain("err");
+    expect(result.stderr).toBe("");
     expect(result.exitCode).toBe(0);
-    expect(onEvent.mock.calls.some(([event]) => event.type === "resize" && event.columns === 100 && event.rows === 30)).toBe(true);
+    expect(
+      onEvent.mock.calls.some(
+        ([event]) => event.type === "resize" && event.columns === 100 && event.rows === 30,
+      ),
+    ).toBe(true);
     expect(onEvent.mock.calls.some(([event]) => event.type === "chunk" && event.stream === "stdout")).toBe(true);
   });
 
-  it("rawOutput: true emits only raw chunks and no additional line-split events", async () => {
-    const child = new FakeChildProcess();
-    childProcessMocks.spawn.mockReturnValueOnce(child as unknown as never);
+  it("rawOutput: true emits only raw PTY chunks and no additional line-split events", async () => {
+    const ptyProcess = new FakePtyProcess();
+    ptyMocks.spawn.mockReturnValueOnce(ptyProcess as unknown as never);
     const onEvent = vi.fn();
 
     const session = createInteractivePtySession(
@@ -143,23 +166,22 @@ describe("interactive PTY session", () => {
       { rawOutput: true, onEvent },
     );
 
-    child.stdout.emit("data", "line1\nline2\n");
+    ptyProcess.emitData("line1\nline2\n");
     session.close();
-    child.emit("close", 0, null);
+    ptyProcess.emitExit(0);
     await session.result;
 
     const chunkEvents = onEvent.mock.calls
       .map((args: any[]) => args[0])
-      .filter((e: any) => e.type === "chunk");
+      .filter((event: any) => event.type === "chunk");
 
-    // rawOutput mode: exactly one chunk event per emit, no line-split duplicates
     expect(chunkEvents.length).toBe(1);
     expect(chunkEvents[0].data).toBe("line1\nline2\n");
   });
 
-  it("kill forwards the given signal to the child process", async () => {
-    const child = new FakeChildProcess();
-    childProcessMocks.spawn.mockReturnValueOnce(child as unknown as never);
+  it("kill forwards the given signal to the PTY", async () => {
+    const ptyProcess = new FakePtyProcess();
+    ptyMocks.spawn.mockReturnValueOnce(ptyProcess as unknown as never);
 
     const session = createInteractivePtySession(
       { command: process.execPath, args: [] },
@@ -167,19 +189,19 @@ describe("interactive PTY session", () => {
     );
 
     session.kill("SIGINT");
-    expect(child.kill).toHaveBeenCalledWith("SIGINT");
+    expect(ptyProcess.kill).toHaveBeenCalledWith("SIGINT");
 
     session.kill("SIGTERM");
-    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(ptyProcess.kill).toHaveBeenCalledWith("SIGTERM");
 
-    child.emit("close", 130, null);
+    ptyProcess.emitExit(130);
     const result = await session.result;
     expect(result.exitCode).toBe(130);
   });
 
   it("kill defaults to SIGTERM when no signal is provided", () => {
-    const child = new FakeChildProcess();
-    childProcessMocks.spawn.mockReturnValueOnce(child as unknown as never);
+    const ptyProcess = new FakePtyProcess();
+    ptyMocks.spawn.mockReturnValueOnce(ptyProcess as unknown as never);
 
     const session = createInteractivePtySession(
       { command: process.execPath, args: [] },
@@ -187,12 +209,12 @@ describe("interactive PTY session", () => {
     );
 
     session.kill();
-    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(ptyProcess.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
   it("preserves raw chunks without script-wrapper normalization", async () => {
-    const child = new FakeChildProcess();
-    childProcessMocks.spawn.mockReturnValueOnce(child as unknown as never);
+    const ptyProcess = new FakePtyProcess();
+    ptyMocks.spawn.mockReturnValueOnce(ptyProcess as unknown as never);
 
     const session = createInteractivePtySession(
       {
@@ -204,20 +226,20 @@ describe("interactive PTY session", () => {
       },
     );
 
-    child.stdout.emit("data", "\u0004\b\bhello");
+    ptyProcess.emitData("\u0004\b\bhello");
     session.close();
 
-    const resultPromise = session.result;
-    child.emit("close", 0, null);
-    const result = await resultPromise;
+    ptyProcess.emitExit(0);
+    const result = await session.result;
 
     expect(result.stdout).toContain("\u0004\b\bhello");
     expect(result.transcript.events.some((event) => event.type === "chunk" && event.data?.includes("\u0004\b\bhello") === true)).toBe(true);
   });
 
-  it("child error event resolves result with exitCode 127 and emits error event", async () => {
-    const child = new FakeChildProcess();
-    childProcessMocks.spawn.mockReturnValueOnce(child as unknown as never);
+  it("spawn failure resolves result with exitCode 127 and emits error event", async () => {
+    ptyMocks.spawn.mockImplementationOnce(() => {
+      throw new Error("ENOENT: no such file or directory");
+    });
     const onEvent = vi.fn();
 
     const session = createInteractivePtySession(
@@ -225,50 +247,26 @@ describe("interactive PTY session", () => {
       { onEvent },
     );
 
-    child.emit("error", new Error("ENOENT: no such file or directory"));
     const result = await session.result;
 
     expect(result.exitCode).toBe(127);
     expect(result.timedOut).toBe(false);
-    expect(onEvent.mock.calls.some((args: any[]) => args[0].type === "error")).toBe(true);
+    expect(onEvent.mock.calls.some(([event]) => event.type === "error")).toBe(true);
   });
 
   it("close with signal resolves result with exitCode 128", async () => {
-    const child = new FakeChildProcess();
-    childProcessMocks.spawn.mockReturnValueOnce(child as unknown as never);
+    const ptyProcess = new FakePtyProcess();
+    ptyMocks.spawn.mockReturnValueOnce(ptyProcess as unknown as never);
 
     const session = createInteractivePtySession(
       { command: process.execPath, args: [] },
       { onEvent: vi.fn() },
     );
 
-    child.emit("close", null, "SIGKILL");
+    ptyProcess.emitExit(0, 9);
     const result = await session.result;
 
     expect(result.exitCode).toBe(128);
     expect(result.timedOut).toBe(false);
-  });
-
-  it("resize emits resize event and sends SIGWINCH to child", async () => {
-    const child = new FakeChildProcess();
-    childProcessMocks.spawn.mockReturnValueOnce(child as unknown as never);
-    const onEvent = vi.fn();
-
-    const session = createInteractivePtySession(
-      { command: process.execPath, args: [] },
-      { onEvent },
-    );
-
-    session.resize(132, 50);
-
-    expect(child.kill).toHaveBeenCalledWith("SIGWINCH");
-    expect(
-      onEvent.mock.calls.some(
-        (args: any[]) => args[0].type === "resize" && args[0].columns === 132 && args[0].rows === 50,
-      ),
-    ).toBe(true);
-
-    child.emit("close", 0, null);
-    await session.result;
   });
 });


### PR DESCRIPTION
## 개요
embedded pane이 원본 CLI UI에 더 가깝게 보이도록 터미널 fidelity를 강화하고, embedded smoke를 실제 실행 경로(real adapter flow) 기준으로 검증하도록 정리했습니다.

## 주요 변경
- embedded pane의 PTY 경로를 Node-native `node-pty` 기반으로 유지
- ANSI SGR, 커서 표시, save/restore cursor, common control sequence 지원
- Unicode width 처리와 resize reflow, scrollback reflow 개선
- embedded smoke를 stub 기준이 아니라 real adapter flow 기준으로 전환
- fake codex 바이너리 + 긴 interactive timeout으로 deterministic smoke 검증 추가
- embedded 실행 종료 시 detoks 입력 복귀와 세션 cleanup 보강

## 검증
- `npm test -- tests/ts/integration/cli-smoke.test.ts -t "keeps the embedded CLI pane and summary region visible in embedded mode|returns to detoks input after an embedded run so another prompt can be entered"`
- `npm run typecheck`

## 참고
- stub 모드는 이제 레거시 회귀용만 남기고, 새 UI/표현은 real execution 기준으로 맞췄습니다.