### PR TITLE
fix(cli): render embedded CLI wide chars contiguously

### DIFF
--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -4,7 +4,7 @@ import type { PtyEvent } from "../../../integrations/subprocess/types.js";
 import { getContentArea } from "../layout-manager.js";
 import { colors } from "../../colors.js";
 import type { TerminalCell, TerminalCellStyle, TerminalColor } from "../terminal-emulator.js";
-import { TerminalEmulatorBuffer } from "../terminal-emulator.js";
+import { TerminalEmulatorBuffer, getCharacterDisplayWidth } from "../terminal-emulator.js";
 
 // Larger than the terminal-emulator default (200) to retain full LLM session output.
 const EMBEDDED_PANE_SCROLLBACK_LIMIT = 500;
@@ -81,9 +81,14 @@ const renderCellsToAnsi = (
 ): string => {
   const visibleCells = cells.slice(0, Math.max(0, maxWidth));
   let output = "";
+  let renderedColumns = 0;
   let currentSignature = "";
 
   for (const [index, cell] of visibleCells.entries()) {
+    if (cell.wideContinuation) {
+      continue;
+    }
+
     const isCursorCell = cursorVisible === true && cursorColumn === index;
     const displayStyle = isCursorCell
       ? { ...cell.style, inverse: true }
@@ -94,7 +99,13 @@ const renderCellsToAnsi = (
       output += styleToAnsi(displayStyle);
       currentSignature = signature;
     }
-    output += cell.char || " ";
+    const renderedChar = cell.char || " ";
+    output += renderedChar;
+    renderedColumns += cell.char.length > 0 ? getCharacterDisplayWidth(renderedChar) : 1;
+  }
+
+  if (renderedColumns < maxWidth) {
+    output += " ".repeat(maxWidth - renderedColumns);
   }
 
   return `${output}\x1b[0m`;

--- a/src/cli/tui/terminal-emulator.ts
+++ b/src/cli/tui/terminal-emulator.ts
@@ -16,6 +16,7 @@ export interface TerminalCellStyle {
 export interface TerminalCell {
   char: string;
   style: TerminalCellStyle;
+  wideContinuation?: boolean;
 }
 
 export interface TerminalEmulatorSnapshot {
@@ -56,23 +57,52 @@ const createBlankCell = (): TerminalCell => {
   return { char: "", style: cloneStyle(DEFAULT_STYLE) };
 };
 
+const cloneCell = (cell: TerminalCell): TerminalCell => {
+  return {
+    char: cell.char,
+    style: cloneStyle(cell.style),
+    ...(cell.wideContinuation ? { wideContinuation: true } : {}),
+  };
+};
+
 const createBlankRow = (columns: number): TerminalCell[] => {
   return Array.from({ length: Math.max(0, columns) }, createBlankCell);
 };
 
 const cloneRow = (row: TerminalCell[], columns: number): TerminalCell[] => {
-  const nextRow = row.slice(0, columns).map((cell) => ({
-    char: cell.char,
-    style: cloneStyle(cell.style),
-  }));
+  const nextRow = row.slice(0, columns).map((cell) => cloneCell(cell));
   while (nextRow.length < columns) {
     nextRow.push(createBlankCell());
   }
   return nextRow;
 };
 
+export const getCharacterDisplayWidth = (char: string): number => {
+  const code = char.codePointAt(0) ?? 0;
+  if (code === 0) {
+    return 0;
+  }
+
+  if (code < 32 || (code >= 0x7f && code < 0xa0)) {
+    return 0;
+  }
+
+  if (isCombiningCharacter(char)) {
+    return 0;
+  }
+
+  return isWideCharacter(char) ? 2 : 1;
+};
+
 const rowToText = (row: TerminalCell[]): string => {
-  return row.map((cell) => cell.char || " ").join("");
+  let output = "";
+  for (const cell of row) {
+    if (cell.wideContinuation) {
+      continue;
+    }
+    output += cell.char || " ";
+  }
+  return output;
 };
 
 const splitCsi = (sequence: string): { params: string; command: string } | null => {
@@ -98,23 +128,6 @@ const colorFromRgb = (red: number, green: number, blue: number): TerminalColor =
 
 const isCombiningCharacter = (char: string): boolean => {
   return /\p{Mark}/u.test(char) || char === "\u200d" || char === "\u200c" || char === "\ufe0e" || char === "\ufe0f";
-};
-
-const getCharacterDisplayWidth = (char: string): number => {
-  const code = char.codePointAt(0) ?? 0;
-  if (code === 0) {
-    return 0;
-  }
-
-  if (code < 32 || (code >= 0x7f && code < 0xa0)) {
-    return 0;
-  }
-
-  if (isCombiningCharacter(char)) {
-    return 0;
-  }
-
-  return isWideCharacter(char) ? 2 : 1;
 };
 
 const applySgrParameters = (style: TerminalCellStyle, params: number[]): TerminalCellStyle => {
@@ -381,13 +394,11 @@ export class TerminalEmulatorBuffer {
 
     const count = Math.min(amount, this.columns - this.cursorColumn);
     const prefix = row.slice(0, this.cursorColumn).map((cell) => ({
-      char: cell.char,
-      style: cloneStyle(cell.style),
+      ...cloneCell(cell),
     }));
     const blanks = Array.from({ length: count }, () => createBlankCell());
     const suffix = row.slice(this.cursorColumn, Math.max(this.cursorColumn, this.columns - count)).map((cell) => ({
-      char: cell.char,
-      style: cloneStyle(cell.style),
+      ...cloneCell(cell),
     }));
     const nextRow = [...prefix, ...blanks, ...suffix].slice(0, this.columns);
 
@@ -413,12 +424,10 @@ export class TerminalEmulatorBuffer {
 
     const count = Math.min(amount, this.columns - this.cursorColumn);
     const prefix = row.slice(0, this.cursorColumn).map((cell) => ({
-      char: cell.char,
-      style: cloneStyle(cell.style),
+      ...cloneCell(cell),
     }));
     const suffix = row.slice(this.cursorColumn + count).map((cell) => ({
-      char: cell.char,
-      style: cloneStyle(cell.style),
+      ...cloneCell(cell),
     }));
     const nextRow = [...prefix, ...suffix];
 
@@ -653,7 +662,11 @@ export class TerminalEmulatorBuffer {
       style: cloneStyle(this.currentStyle),
     };
     if (width === 2 && this.cursorColumn + 1 < this.columns) {
-      row[this.cursorColumn + 1] = createBlankCell();
+      row[this.cursorColumn + 1] = {
+        char: "",
+        style: cloneStyle(DEFAULT_STYLE),
+        wideContinuation: true,
+      };
     }
 
     this.cursorColumn += width;
@@ -1032,19 +1045,13 @@ export class TerminalEmulatorBuffer {
 
   getVisibleCells(): TerminalCell[][] {
     return this.getActiveScreen().map((row) =>
-      row.map((cell) => ({
-        char: cell.char,
-        style: cloneStyle(cell.style),
-      })),
+      row.map((cell) => cloneCell(cell)),
     );
   }
 
   getScrollbackCells(): TerminalCell[][] {
     return this.scrollbackRows.map((row) =>
-      row.map((cell) => ({
-        char: cell.char,
-        style: cloneStyle(cell.style),
-      })),
+      row.map((cell) => cloneCell(cell)),
     );
   }
 

--- a/src/integrations/subprocess/runner.ts
+++ b/src/integrations/subprocess/runner.ts
@@ -411,6 +411,12 @@ const runWithNodePty = (
     if (request.input !== undefined) {
       emitEvent({ type: "prompt", data: request.input });
       ptyProcess.write(request.input);
+      // One-shot PTY prompts need an explicit submit/EOF signal so terminal
+      // applications that read stdin can finish instead of waiting forever.
+      if (!request.input.endsWith("\r") && !request.input.endsWith("\n")) {
+        ptyProcess.write("\r");
+      }
+      ptyProcess.write("\x04");
     }
   });
 };

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -43,6 +43,21 @@ describe("EmbeddedTerminalPane", () => {
     expect(output).toContain("world");
   });
 
+  it("renders Korean wide characters without placeholder spacing", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "한글",
+    });
+
+    pane.render(mockContext, mockRegion);
+
+    const output = mockScreen.write.mock.calls.map((call: any) => call[0]).join("\n");
+    expect(output).toContain("한글");
+    expect(output).not.toContain("한 글");
+  });
+
   it("preserves ANSI style information in raw chunks passed to the buffer", () => {
     const ansiChunk = "\x1b[32mhello\x1b[0m world";
     pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: ansiChunk });

--- a/tests/ts/unit/cli/tui/terminal-emulator.test.ts
+++ b/tests/ts/unit/cli/tui/terminal-emulator.test.ts
@@ -142,8 +142,16 @@ describe("TerminalEmulatorBuffer", () => {
     buffer.write("a\u0301🚀b");
 
     const snapshot = buffer.snapshot();
-    expect(snapshot.visibleRows[0]?.trim()).toBe("á🚀 b");
+    expect(snapshot.visibleRows[0]?.trim()).toBe("á🚀b");
     expect(snapshot.cursorColumn).toBe(4);
+  });
+
+  it("keeps wide characters contiguous in row text", () => {
+    const buffer = new TerminalEmulatorBuffer(8, 3);
+    buffer.write("한글");
+
+    const snapshot = buffer.snapshot();
+    expect(snapshot.visibleRows[0]?.slice(0, 2)).toBe("한글");
   });
 
   it("keeps mixed-width wrapping stable across line boundaries", () => {

--- a/tests/ts/unit/integrations/subprocess/runner.test.ts
+++ b/tests/ts/unit/integrations/subprocess/runner.test.ts
@@ -73,6 +73,46 @@ describe("createRealSubprocessRunner", () => {
     expect(result.transcript.events.filter((event) => event.type === "chunk").length).toBeGreaterThanOrEqual(2);
   });
 
+  it(
+    "submits one-shot PTY input so stdin-only commands can finish",
+    async () => {
+      const dir = tempDirs.at(-1)!;
+      const codexScript = join(dir, "codex");
+      writeFileSync(
+        codexScript,
+        [
+          "#!/usr/bin/env node",
+          'let input = "";',
+          'process.stdin.setEncoding("utf8");',
+          'process.stdin.on("data", (chunk) => { input += chunk; });',
+          'process.stdin.on("end", () => {',
+          "  process.stdout.write(input);",
+          "  process.exit(0);",
+          "});",
+          "process.stdin.resume();",
+        ].join("\n"),
+        "utf8",
+      );
+      chmodSync(codexScript, 0o755);
+
+      const runner = createPtySubprocessRunner();
+      const result = await runner.runWithTranscript({
+        command: "codex",
+        args: ["exec", "-", "--sandbox", "workspace-write"],
+        input: "hello\nworld",
+        env: {
+          ...process.env,
+          PATH: `${dir}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("hello");
+      expect(result.stdout).toContain("world");
+    },
+    10_000,
+  );
+
   it("streams Codex JSON output without waiting for a PTY wrapper", async () => {
     const dir = tempDirs.at(-1)!;
     const codexScript = join(dir, "codex");


### PR DESCRIPTION
## Summary
- skip wide-character continuation cells when rendering the embedded CLI pane
- keep Korean/CJK and emoji output contiguous instead of inserting placeholder spacing
- add regression coverage for terminal-emulator row text and embedded-pane rendering

## Notes
- this branch is based on the current local dev baseline, so it also carries the one-shot PTY submit fix already present locally

## Verification
- `npm run build`
- `npx vitest run tests/ts/unit/cli/tui/terminal-emulator.test.ts tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts --reporter=dot`