### PR TITLE
Implement cache improvements with new validity checks and hashing

### DIFF
--- a/docs/TRACK_A_CACHE_SAFETY.md
+++ b/docs/TRACK_A_CACHE_SAFETY.md
@@ -1,0 +1,514 @@
+# Track A — Cache Safety (P0-1)
+
+> 담당 범위: Cache Validation 강화 + Hash v2 마이그레이션
+> 짝 트랙: [TRACK_B_ACCOUNTING_GATE_PRIVACY.md](./TRACK_B_ACCOUNTING_GATE_PRIVACY.md)
+> 배경 문서: [DETOKS_EXECUTION_MEMORY_FLOW_AND_GAP.md](./DETOKS_EXECUTION_MEMORY_FLOW_AND_GAP.md)
+
+---
+
+## 목적
+
+현재 F2 task cache는 hit이 거의 나지 않는다. 원인은 hash 키에 `task.id`(실행 순서 식별자 `t1`, `t2`, …)가 들어 있기 때문이다. 앞에 task 하나만 추가/삭제되면 그 뒤 모든 task의 hash가 깨진다.
+
+이 트랙은 두 가지를 한 번에 해결한다:
+
+1. **Hash v2** — `task.id`를 제거하고 작업의 의미(type, normalizedIntent, adapter, 버전 등)만으로 hash를 만들어 F2 hit률 구조적 개선.
+2. **3단계 Validity** — 기존 valid/invalid 이진 분기를 `"auto" | "advise" | "skip"` 3단계로 교체해, adapter·git HEAD 불일치를 안전하게 처리.
+
+Track B와의 충돌 방지 경계선: **`orchestrator.ts`의 L547 이하는 절대 건드리지 않는다.** Track A가 손대는 영역은 L464–519(F1 cache)와 L947–988(F2 cache)뿐이다.
+
+---
+
+## 파일별 작업 목록
+
+| 파일 | 작업 유형 |
+|------|-----------|
+| `src/core/rag/hash.ts` | 함수 추가 |
+| `src/core/task-graph/TaskGraphProcessor.ts` | 함수 교체 |
+| `src/core/cache/cache-validator.ts` | 타입 추가 + 함수 시그니처 변경 |
+| `src/core/state/SessionStateManager.ts` | opts 확장 |
+| `src/core/pipeline/orchestrator.ts` L76–89 | stamp 필드 추가 |
+| `src/core/pipeline/orchestrator.ts` L464–519 | isSessionCacheValid 호출 갱신 |
+| `src/core/pipeline/orchestrator.ts` L947–988 | isTaskCacheValid 호출 갱신 + stamp |
+
+---
+
+## Step 1 — `src/core/rag/hash.ts`에 `hashTaskInputV2` 추가
+
+### 현재 상태
+
+파일 하단에 `computeProjectId` 함수로 끝난다.
+
+### 추가할 코드
+
+파일 맨 아래에 추가:
+
+```ts
+// task 캐시 키 v2 — task.id(실행 순서 식별자)를 제외하고
+// 작업 의미(type, normalizedIntent, adapter, 버전)로만 hash를 생성한다.
+// v1은 id 포함으로 인해 앞 task가 하나만 바뀌어도 이후 모든 hash가 깨지는 구조적 버그가 있었다.
+export const hashTaskInputV2 = (params: {
+  projectId: string;
+  type: string;
+  normalizedIntent: string;
+  adapter: string;
+  adapterModel: string;
+  detoksMajorVersion: number;
+}): string => {
+  const content = JSON.stringify(params);
+  return createHash("sha256").update(content).digest("hex").slice(0, 16);
+};
+```
+
+`normalizedIntent`는 Role1(prompt compiler)이 정규화한 task sentence다. 공백·문장 부호만 정규화하고 **파일 경로, 심볼명, 함수명 같은 식별자는 그대로 유지**한다 — 안 그러면 "run tests on A"와 "run tests on B"가 같은 hash로 충돌한다.
+
+---
+
+## Step 2 — `src/core/task-graph/TaskGraphProcessor.ts` hash 교체
+
+### 현재 상태 (L350–353)
+
+```ts
+private static computeInputHash(id: string, type: string, sentence: string): string {
+  const content = JSON.stringify({ id, type, sentence });
+  return createHash("sha256").update(content).digest("hex").slice(0, 16);
+}
+```
+
+### 변경 목표
+
+`hashTaskInputV2`를 호출하도록 교체한다. `TaskGraphProcessor`가 `projectId`, `adapter`, `adapterModel`을 알아야 하므로 이 값들을 어디서 받아야 하는지 파악해야 한다.
+
+`TaskGraphProcessor`가 호출되는 경로를 확인한다:
+
+```bash
+grep -n "TaskGraphProcessor" src/core/pipeline/orchestrator.ts
+```
+
+`processGraph` 또는 유사 정적 메서드가 orchestrator 안에서 호출될 것이다. 그 호출 시점에 `request.adapter`, `request.env?.ADAPTER_MODEL`, `projectId`가 이미 있으므로 context 객체를 추가 파라미터로 넘겨주는 방식으로 처리한다.
+
+**구체적 변경 방법:**
+
+1. `computeInputHash` 시그니처를 변경한다:
+
+   ```ts
+   private static computeInputHash(params: {
+     projectId: string;
+     type: string;
+     normalizedIntent: string;  // 기존 sentence → normalizedIntent로 rename
+     adapter: string;
+     adapterModel: string;
+     detoksMajorVersion: number;
+   }): string {
+     return hashTaskInputV2(params);
+   }
+   ```
+
+2. `createHash` import를 `hashTaskInputV2` import로 교체:
+
+   ```ts
+   // 기존
+   import { createHash } from "node:crypto";
+
+   // 변경 후 (createHash를 더 이상 직접 쓰지 않으면 제거)
+   import { hashTaskInputV2 } from "../rag/hash.js";
+   ```
+
+3. `computeInputHash`를 호출하는 내부 위치를 모두 찾아 새 시그니처에 맞게 파라미터를 전달한다.
+
+   `id`는 넘기지 않는다. `sentence` → `normalizedIntent`로 rename. `projectId`, `adapter`, `adapterModel`, `detoksMajorVersion`은 orchestrator에서 내려줘야 한다.
+
+4. v1 hash도 별도 필드(`input_hash_v1`)로 같이 저장해 7일 TTL 동안 후방 호환 조회가 가능하게 한다(선택적 구현 — 시간이 허용하면 추가).
+
+**`detoksMajorVersion`은 어디서 가져오나:**
+
+`package.json`의 `version` 필드의 major 번호를 사용한다. 상수로 정의하거나 import해서 쓴다:
+
+```ts
+// src/core/pipeline/orchestrator.ts 또는 공통 위치
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const DETOKS_MAJOR_VERSION: number = parseInt(
+  (require("../../../package.json") as { version: string }).version.split(".")[0] ?? "0",
+  10,
+);
+```
+
+---
+
+## Step 3 — `src/core/cache/cache-validator.ts` 3단계 Validity 교체
+
+### 현재 상태
+
+```ts
+export interface CacheValidationOpts {
+  project_id?: string;
+  recencyDays?: number;
+}
+
+export function isSessionCacheValid(session: SessionState, opts: CacheValidationOpts = {}): boolean
+export function isTaskCacheValid(taskResult: Record<string, unknown>, opts: CacheValidationOpts = {}): boolean
+```
+
+### 변경 후 전체 파일
+
+```ts
+import type { SessionState } from "../../schemas/pipeline.js";
+import { CACHE_TTL_DAYS } from "./cache-config.js";
+
+// "auto"   → 모든 조건 통과, 즉시 캐시 반환
+// "advise" → recency 경계 근처 / adapter 불일치 등 — 결과 반환 X, 유사 결과 안내만
+// "skip"   → 검증 실패, miss 처리
+export type CacheValidity = "auto" | "advise" | "skip";
+
+export interface CacheValidationOpts {
+  project_id?: string;
+  recencyDays?: number;
+  expected_adapter?: string;        // NEW
+  expected_adapter_model?: string;  // NEW
+  expected_git_head?: string;       // NEW
+  detoks_major_version?: number;    // NEW
+}
+
+export function isSessionCacheValid(
+  session: SessionState,
+  opts: CacheValidationOpts = {},
+): CacheValidity {
+  const { project_id, recencyDays = CACHE_TTL_DAYS, expected_adapter, expected_git_head } = opts;
+
+  if (project_id && session.shared_context.project_id !== project_id) return "skip";
+
+  const failedIds = (session.shared_context.failed_task_ids as string[] | undefined) ?? [];
+  if (failedIds.length > 0) return "skip";
+
+  if (session.completed_task_ids.length === 0) return "skip";
+
+  if (session.updated_at) {
+    const cutoff = Date.now() - recencyDays * 24 * 60 * 60 * 1000;
+    if (new Date(session.updated_at).getTime() < cutoff) return "skip";
+  }
+
+  // adapter 불일치 → advise (결과를 참고로 보여주지 않음 — 단, 안내 가능)
+  const storedAdapter = (session.shared_context as Record<string, unknown>).adapter as string | undefined;
+  if (expected_adapter && storedAdapter && storedAdapter !== expected_adapter) return "advise";
+
+  // git HEAD 불일치 → advise
+  const storedGitHead = (session.shared_context as Record<string, unknown>).git_head as string | undefined;
+  if (expected_git_head && storedGitHead && storedGitHead !== expected_git_head) return "advise";
+
+  return "auto";
+}
+
+export function isTaskCacheValid(
+  taskResult: Record<string, unknown>,
+  opts: CacheValidationOpts = {},
+): CacheValidity {
+  const { recencyDays = CACHE_TTL_DAYS, expected_adapter, expected_git_head } = opts;
+
+  if (taskResult.success !== true) return "skip";
+
+  if (typeof taskResult.completed_at === "string") {
+    const cutoff = Date.now() - recencyDays * 24 * 60 * 60 * 1000;
+    if (new Date(taskResult.completed_at).getTime() < cutoff) return "skip";
+  }
+
+  // adapter 불일치 → advise
+  if (expected_adapter && taskResult.adapter && taskResult.adapter !== expected_adapter) return "advise";
+
+  // git HEAD 불일치 → advise
+  if (expected_git_head && taskResult.git_head && taskResult.git_head !== expected_git_head) return "advise";
+
+  return "auto";
+}
+```
+
+### 주의사항
+
+- 기존 호출자가 `boolean`을 기대하는 경우가 있을 수 있다. 파일을 저장한 뒤 TypeScript 오류가 나는 위치를 전부 `=== "auto"` 또는 `!== "skip"` 패턴으로 교체한다.
+- orchestrator 이외의 호출자를 확인하는 명령:
+
+  ```bash
+  grep -rn "isSessionCacheValid\|isTaskCacheValid" src/
+  ```
+
+---
+
+## Step 4 — `src/core/state/SessionStateManager.ts` opts 확장
+
+### 변경 대상 메서드
+
+`findSuccessfulTaskByHash` (L399–436)의 opts 타입에 `adapter?`, `git_head?`를 추가하고 필터를 적용한다.
+
+```ts
+static async findSuccessfulTaskByHash(
+  taskHash: string,
+  opts: {
+    project_id?: string;
+    recencyDays?: number;
+    adapter?: string;      // NEW
+    git_head?: string;     // NEW
+  } = {},
+): Promise<{ taskResult: Record<string, unknown>; sessionId: string } | null> {
+  const { project_id, recencyDays = 7, adapter, git_head } = opts;
+  const cutoff = Date.now() - recencyDays * 24 * 60 * 60 * 1000;
+
+  // ... (기존 파일 스캔 로직) ...
+
+  for (const taskResult of Object.values(state.task_results)) {
+    const res = taskResult as Record<string, unknown>;
+    if (res.input_hash !== taskHash) continue;
+    if (res.success !== true) continue;
+    if (typeof res.completed_at === "string") {
+      if (new Date(res.completed_at).getTime() < cutoff) continue;
+    }
+    // NEW: adapter 필터 — 저장 시 adapter가 없으면(구 세션) 통과시켜 호환성 유지
+    if (adapter && res.adapter && res.adapter !== adapter) continue;
+    // NEW: git_head 필터 — 저장 시 git_head가 없으면(구 세션) 통과
+    if (git_head && res.git_head && res.git_head !== git_head) continue;
+    return { taskResult: res, sessionId: file.slice(0, -".json".length) };
+  }
+```
+
+구 세션(stamp 필드가 없는 것)은 항상 통과시켜야 한다. `if (adapter && res.adapter && ...)` 패턴이 이를 보장한다 — `res.adapter`가 없으면 두 번째 조건이 false가 되어 continue하지 않는다.
+
+`findSuccessfulSessionByInputHash` (L363–397)에도 동일하게 `adapter?` 필터를 추가한다.
+
+---
+
+## Step 5 — `orchestrator.ts` stamp 필드 추가 (`initSessionState` 영역)
+
+`initSessionState` 함수 (L76–89)에 `adapter`와 `git_head`를 stamp할 수 있도록 파라미터를 추가한다.
+
+현재:
+
+```ts
+function initSessionState(sessionId: string, rawInput: string, executionMode: string): SessionState
+```
+
+변경 후:
+
+```ts
+function initSessionState(
+  sessionId: string,
+  rawInput: string,
+  executionMode: string,
+  opts: { adapter?: string; adapterModel?: string; gitHead?: string } = {},
+): SessionState {
+  return {
+    shared_context: {
+      session_id: sessionId,
+      raw_input: rawInput,
+      ...(executionMode !== "stub" ? { raw_input_hash: hashRawInput(rawInput) } : {}),
+      ...(opts.adapter ? { adapter: opts.adapter } : {}),
+      ...(opts.adapterModel ? { adapter_model: opts.adapterModel } : {}),
+      ...(opts.gitHead ? { git_head: opts.gitHead } : {}),
+    },
+    task_results: {},
+    current_task_id: null,
+    completed_task_ids: [],
+    updated_at: new Date().toISOString(),
+  };
+}
+```
+
+`gitHead`는 `execSync("git rev-parse HEAD")` 결과를 사용한다. try-catch로 감싸 git이 없는 환경을 처리한다:
+
+```ts
+function resolveGitHead(cwd: string): string | undefined {
+  try {
+    return execSync("git rev-parse HEAD", {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim().slice(0, 8); // 8자리 단축 SHA
+  } catch {
+    return undefined;
+  }
+}
+```
+
+orchestrator 안 `initSessionState` 호출 위치 (L818):
+
+```ts
+state = initSessionState(sessionId, request.userRequest.raw_input, request.executionMode, {
+  adapter: request.adapter,
+  adapterModel: request.env?.ADAPTER_MODEL ?? process.env.ADAPTER_MODEL,
+  gitHead: resolveGitHead(request.userRequest.cwd ?? process.cwd()),
+});
+```
+
+---
+
+## Step 6 — `orchestrator.ts` F1 cache 블록 갱신 (L464–519)
+
+### 현재 상태 (L475, L507)
+
+```ts
+if (cachedSession && isSessionCacheValid(cachedSession, { project_id: projectId })) {
+  // ...
+  tokensSaved: 0,
+```
+
+### 변경 사항
+
+1. `isSessionCacheValid` 반환값이 `CacheValidity`로 바뀌었으므로 조건문 수정:
+
+   ```ts
+   const gitHead = resolveGitHead(request.userRequest.cwd ?? process.cwd());
+   const validity = isSessionCacheValid(cachedSession, {
+     project_id: projectId,
+     expected_adapter: request.adapter,
+     expected_git_head: gitHead,
+   });
+
+   if (validity === "auto") {
+     // 기존 cache hit 처리 — adapter 호출 0회, 즉시 반환
+     // ...
+   } else if (validity === "advise") {
+     // 조용히 miss로 처리 (advise 안내는 P1-1에서)
+     // validity === "advise"는 현재 단계에서 miss와 동일하게 처리
+   }
+   // validity === "skip" → 기존 miss 처리로 그대로 흐름
+   ```
+
+2. `tokensSaved: 0` → 실제 값 계산:
+
+   세션 캐시 hit 시 절감 토큰 = 그 세션이 실제로 실행했을 때 소비했을 토큰 추정치. 현재 저장된 세션에는 `token_metrics`가 있을 수 있다. 없으면 0으로 유지한다 (P0-2 Accounting이 이 필드를 채우기 시작한 뒤부터 의미있는 값이 나옴).
+
+   ```ts
+   const rawTokensSaved =
+     (cachedSession.shared_context as Record<string, unknown>).token_estimate_total as number | undefined;
+
+   return {
+     // ...
+     cacheHit: {
+       kind: "session" as const,
+       sourceSessionId: cachedSessionId,
+       cacheAge,
+       tokensSaved: rawTokensSaved ?? 0,
+     },
+   };
+   ```
+
+---
+
+## Step 7 — `orchestrator.ts` F2 cache 블록 갱신 (L947–988)
+
+### 현재 상태 (L954, L956)
+
+```ts
+if (cachedTask && isTaskCacheValid(cachedTask.taskResult, {})) {
+  state = markTaskCompleted(state, task.id, cachedOutput, task.type, task);
+```
+
+### 변경 사항
+
+1. `isTaskCacheValid` 호출에 adapter, git_head 전달:
+
+   ```ts
+   const gitHead = resolveGitHead(request.userRequest.cwd ?? process.cwd());
+   const adapterModel = request.env?.ADAPTER_MODEL ?? process.env.ADAPTER_MODEL;
+   const validity = isTaskCacheValid(cachedTask.taskResult, {
+     expected_adapter: request.adapter,
+     expected_adapter_model: adapterModel,
+     expected_git_head: gitHead,
+   });
+
+   if (validity !== "auto") {
+     // "advise" 또는 "skip" → cache miss로 처리
+     // "advise"는 현재 단계에서 silent miss (P1-1에서 안내 추가)
+     await emitActionTimelineWithLogging(
+       createActionTimelineEvent({
+         kind: "cache_miss",
+         source: "pipeline",
+         summary: `F2 캐시 ${validity} — task ${task.id} (adapter/git_head 불일치)`,
+         taskId: task.id,
+       }),
+     );
+     // miss로 넘어감 (아래 코드 계속 실행)
+   } else {
+     // validity === "auto" → 기존 cache hit 처리
+     state = markTaskCompleted(state, task.id, cachedOutput, task.type, task);
+     // ...
+     continue;
+   }
+   ```
+
+2. `markTaskCompleted` 호출에 stamp 필드 추가:
+
+   `markTaskCompleted` 함수 (L134–160)에서 `task_results[taskId]`에 stamp 필드를 추가한다:
+
+   ```ts
+   function markTaskCompleted(
+     state: SessionState,
+     taskId: string,
+     rawOutput: string,
+     taskType?: string,
+     task?: { title?: string; input_hash?: string; depends_on?: string[] },
+     stamp?: { adapter?: string; adapterModel?: string; gitHead?: string },  // NEW
+   ): SessionState {
+     const now = new Date().toISOString();
+     return {
+       ...state,
+       current_task_id: null,
+       completed_task_ids: [...state.completed_task_ids, taskId],
+       task_results: {
+         ...state.task_results,
+         [taskId]: {
+           task_id: taskId,
+           success: true,
+           summary: rawOutput.slice(0, 200),
+           raw_output: rawOutput,
+           ...(taskType ? { type: taskType } : {}),
+           ...extractRagMeta(task),
+           completed_at: now,
+           // NEW stamp 필드
+           ...(stamp?.adapter ? { adapter: stamp.adapter } : {}),
+           ...(stamp?.adapterModel ? { adapter_model: stamp.adapterModel } : {}),
+           ...(stamp?.gitHead ? { git_head: stamp.gitHead } : {}),
+         },
+       },
+       updated_at: now,
+     };
+   }
+   ```
+
+   orchestrator에서 `markTaskCompleted` 를 호출하는 두 곳 (L956, L1114)에 stamp를 넘긴다:
+
+   ```ts
+   const stamp = {
+     adapter: request.adapter,
+     adapterModel: request.env?.ADAPTER_MODEL ?? process.env.ADAPTER_MODEL,
+     gitHead: resolveGitHead(request.userRequest.cwd ?? process.cwd()),
+   };
+   state = markTaskCompleted(state, task.id, cachedOutput, task.type, task, stamp);
+   // ... (L1114도 동일)
+   state = markTaskCompleted(state, task.id, execResult.rawOutput, task.type, task, stamp);
+   ```
+
+   `resolveGitHead`는 매번 execSync를 호출하지 않도록 orchestrator 함수 진입부에서 한 번만 계산해 변수로 유지한다.
+
+---
+
+## 검증 체크리스트
+
+구현이 끝난 뒤 아래를 확인한다:
+
+- [ ] `tsc --noEmit` 에러 없음 (특히 `isSessionCacheValid`, `isTaskCacheValid` 반환 타입 변경 파급 효과)
+- [ ] `hashTaskInputV2` 단위 테스트: 같은 파라미터 → 같은 hash, `id`가 달라도 같은 hash
+- [ ] `isTaskCacheValid` 단위 테스트: adapter 불일치 → "advise", 모든 필드 일치 → "auto"
+- [ ] F2 cache hit 시나리오: `--execution-mode stub`으로 돌린 결과는 캐시 miss 처리 확인
+- [ ] 구 세션(stamp 필드 없음)에서 `findSuccessfulTaskByHash` → 여전히 hit 가능한지 확인
+
+---
+
+## 충돌 방지 체크리스트
+
+Track B와 동시에 작업할 때 지켜야 할 규칙:
+
+- [ ] `orchestrator.ts`에서 **L547 아래는 수정하지 않는다** (Stage B 이후 영역 = Track B 담당)
+- [ ] `src/core/utils/tokenAccounting.ts` 파일은 생성하지 않는다 (Track B 담당)
+- [ ] `src/cli/commands/memory.ts` 파일은 생성하지 않는다 (Track B 담당)
+- [ ] `src/core/utils/tokenMetrics.ts`는 수정하지 않는다 (Track B 담당)
+
+PR 순서: **Track A를 먼저 머지한다.** Track B의 Budget Gate가 `CacheValidity` 타입을 import해서 사용하기 때문에 A가 먼저 들어가야 B에서 타입 충돌이 없다.

--- a/docs/TRACK_B_ACCOUNTING_GATE_PRIVACY.md
+++ b/docs/TRACK_B_ACCOUNTING_GATE_PRIVACY.md
@@ -1,0 +1,740 @@
+# Track B — Accounting + Budget Gate + Privacy CLI (P0-2 + P0-3 + P0-4)
+
+> 담당 범위: Net Token/Cost Accounting, RAG Budget Gate, Privacy 최소 기능
+> 짝 트랙: [TRACK_A_CACHE_SAFETY.md](./TRACK_A_CACHE_SAFETY.md)
+> 배경 문서: [DETOKS_EXECUTION_MEMORY_FLOW_AND_GAP.md](./DETOKS_EXECUTION_MEMORY_FLOW_AND_GAP.md)
+
+---
+
+## 목적
+
+현재 RAG(semantic retrieval)가 항상 ON이고 그 결과를 모든 task prompt에 무조건 prepend한다([orchestrator.ts:1046-1047](../src/core/pipeline/orchestrator.ts#L1046)). cache hit이 적을수록 RAG가 추가하는 토큰이 절감 토큰보다 많아질 수 있고, 그 여부를 측정하는 카운터도 없다.
+
+이 트랙은 세 가지를 해결한다:
+
+1. **P0-2 Accounting** — 절감/추가 토큰을 분리 측정하고 USD net을 계산한다. 진짜 절감 여부를 숫자로 본다.
+2. **P0-3 Budget Gate** — DAG가 만들어진 뒤 실행 필요 task를 먼저 파악하고, 추가 토큰이 과하면 RAG context를 자동 차단한다.
+3. **P0-4 Privacy CLI** — `detoks memory disable`, `detoks memory purge --all` 두 명령과 첫 실행 1회 안내.
+
+Track A와의 충돌 방지 경계선: **`orchestrator.ts`의 L546 위는 절대 건드리지 않는다.** Track B가 손대는 orchestrator 영역은 L547–587(Stage B, 이동 대상)과 L1046–1047(Budget Gate 삽입)이다.
+
+---
+
+## 파일별 작업 목록
+
+| 파일 | 작업 유형 |
+|------|-----------|
+| `src/core/utils/tokenAccounting.ts` | **신규 생성** |
+| `src/core/utils/tokenMetrics.ts` | USD 함수 추가 |
+| `src/core/pipeline/orchestrator.ts` L547–587 | Stage B 블록 이동 |
+| `src/core/pipeline/orchestrator.ts` L1046–1047 | Budget Gate 래핑 |
+| `src/cli/commands/memory.ts` | **신규 생성** |
+| `src/cli/types.ts` | command union 확장 |
+| `src/cli/parse.ts` | memory 커맨드 파싱 추가 |
+| `src/cli/index.ts` | memory 커맨드 라우팅 추가 |
+
+---
+
+## Step 1 — 신규 파일: `src/core/utils/tokenAccounting.ts`
+
+이 파일은 새로 만든다. Track A와 겹치지 않는다.
+
+```ts
+import { countTokens } from "./tokenMetrics.js";
+
+// ── 토큰 회계 ────────────────────────────────────────────────────────────────
+// Token Safety Rule: net = saved_by_cache - added_by_rag - added_by_hints - added_by_compression
+// net이 음수일 수 있다는 사실을 명시적으로 인정하는 구조.
+
+export interface TokenAccounting {
+  tokensSavedByCache: number;        // F1/F2 hit으로 생략한 adapter 호출 토큰
+  tokensAddedByRagContext: number;   // Budget Gate를 통과해 prepend된 ragContext 토큰
+  tokensAddedByPatternHints: number; // (현재 0, 향후 prompt 주입 시 양수)
+  tokensAddedByCompression: number;  // compressor가 외부 LLM을 쓸 때만 양수 (현재 로컬→0)
+  netTokensSaved: number;            // 위 4개의 net
+}
+
+// ── USD 비용 회계 ─────────────────────────────────────────────────────────────
+// 1차 사용자 지표. 토큰 카운터는 디버깅 보조.
+
+export interface CostAccounting {
+  costSavedUsd: number;              // (saved_in × price_in + saved_out × price_out) / 1e6
+  costAddedUsd: number;              // added_in × price_in / 1e6
+  compressionCostUsd: number;        // 현재 0
+  netCostSavedUsd: number;           // costSavedUsd - costAddedUsd - compressionCostUsd
+}
+
+// ── P0-2에 묻어가는 light quality counters ─────────────────────────────────────
+// P1-2 Quality Metric 본격 구현의 1차 데이터 기반.
+
+export interface LightQualityCounters {
+  ragContextInjected: boolean;       // Budget Gate를 통과해 실제로 prepend됐는지
+  cacheHitRate: number;              // (F1 + F2 hit) / 전체 task 수
+}
+
+// ── 계산 함수 ─────────────────────────────────────────────────────────────────
+
+export function computeNetTokens(
+  saved: number,
+  addedRag: number,
+  addedHints = 0,
+  addedCompression = 0,
+): TokenAccounting {
+  const netTokensSaved = saved - addedRag - addedHints - addedCompression;
+  return {
+    tokensSavedByCache: saved,
+    tokensAddedByRagContext: addedRag,
+    tokensAddedByPatternHints: addedHints,
+    tokensAddedByCompression: addedCompression,
+    netTokensSaved,
+  };
+}
+
+export function countRagContextTokens(ragContextText: string): number {
+  if (!ragContextText) return 0;
+  return countTokens(ragContextText);
+}
+```
+
+---
+
+## Step 2 — `src/core/utils/tokenMetrics.ts`에 USD 계산 함수 추가
+
+기존 파일 끝에 추가한다. 기존 코드는 건드리지 않는다.
+
+```ts
+import type { LLMModelConfig } from "../llm-client/llm-models.js";
+import { LLM_MODELS } from "../llm-client/llm-models.js";
+
+export interface CostEstimate {
+  costSavedUsd: number;
+  costAddedUsd: number;
+  netCostSavedUsd: number;
+}
+
+// adapter 이름으로 llm-models.ts의 단가를 동적 lookup
+// 없으면 0 반환 (단가 미지원 모델은 토큰 카운터만 의미있음)
+function resolveModelConfig(adapter: string, adapterModel?: string): LLMModelConfig | undefined {
+  const key = adapterModel ?? adapter;
+  return LLM_MODELS[key] ?? Object.values(LLM_MODELS).find((m) => m.provider === adapter);
+}
+
+export function computeCostUsd(params: {
+  savedInTokens: number;
+  savedOutTokens: number;
+  addedInTokens: number;
+  adapter: string;
+  adapterModel?: string;
+}): CostEstimate {
+  const config = resolveModelConfig(params.adapter, params.adapterModel);
+  if (!config) {
+    return { costSavedUsd: 0, costAddedUsd: 0, netCostSavedUsd: 0 };
+  }
+
+  // llm-models.ts에 USD 단가가 없으면 추가하거나 하드코드
+  // 현재 LLMModelConfig에 promptCostPerMillion/completionCostPerMillion이 없다면
+  // 이 Step에서 LLMModelConfig 인터페이스에 optional 필드를 추가한다.
+  const priceIn = (config as Record<string, unknown>).promptCostPerMillion as number | undefined ?? 0;
+  const priceOut = (config as Record<string, unknown>).completionCostPerMillion as number | undefined ?? 0;
+
+  const costSavedUsd = (params.savedInTokens * priceIn + params.savedOutTokens * priceOut) / 1_000_000;
+  const costAddedUsd = (params.addedInTokens * priceIn) / 1_000_000;
+  const netCostSavedUsd = costSavedUsd - costAddedUsd;
+
+  return { costSavedUsd, costAddedUsd, netCostSavedUsd };
+}
+```
+
+**`LLMModelConfig`에 단가 필드가 없는 경우**: `src/core/llm-client/llm-models.ts`의 `LLMModelConfig` 인터페이스에 다음을 추가한다:
+
+```ts
+export interface LLMModelConfig {
+  // ... 기존 필드 ...
+  promptCostPerMillion?: number;      // USD per 1M input tokens
+  completionCostPerMillion?: number;  // USD per 1M output tokens
+}
+```
+
+그리고 알려진 모델에 값을 채운다(참고 기준, 실제 단가는 최신 공식 단가표로 확인):
+
+```ts
+'claude-3.5-sonnet': {
+  // ...
+  promptCostPerMillion: 3.00,
+  completionCostPerMillion: 15.00,
+},
+'claude-opus': {
+  // ...
+  promptCostPerMillion: 15.00,
+  completionCostPerMillion: 75.00,
+},
+'claude-haiku': {
+  // ...
+  promptCostPerMillion: 0.25,
+  completionCostPerMillion: 1.25,
+},
+```
+
+---
+
+## Step 3 — `orchestrator.ts` Stage B 블록 이동 (L547–587 → DAG 이후)
+
+### 현재 구조
+
+```
+L464–519  F1 session cache
+L521–545  F3 resume hint
+L547–587  ← Stage B (Semantic Retrieval) ← 이 블록 전체를 이동
+L589–~820 Prompt Compile → DAG 생성/검증 → initSessionState
+L820      state.task_graph = graph        ← 이 줄 직후로 이동
+```
+
+### 변경 방법
+
+1. L547–587 블록 전체를 **잘라낸다** (delete 아님, 이동).
+
+2. `ragSnippets`, `ragEmbedder`, `ragStore` 변수 선언 위치를 L547 위치에서 `let` 선언만 남기고 값 할당은 이동한 위치에서 한다:
+
+   ```ts
+   // L547 위치에 선언만 (값은 DAG 이후에서 할당)
+   let semanticContext: SemanticContextResult[] | undefined;
+   let ragSnippets: RagSnippet[] = [];
+   let ragEmbedder: EmbeddingService | undefined;
+   let ragStore: VectorStore | undefined;
+   ```
+
+3. L820(`state = applyProjectInfo(state, ...)`) 이후, F8–F14 Pattern Hint 블록(L829) **이전**에 이동한 Stage B 로직을 삽입한다.
+
+   이동한 코드는 기존과 거의 같지만 두 가지를 변경한다:
+
+   **a. 실행 필요 task(R) 먼저 파악 — F2 pre-scan:**
+
+   ```ts
+   // [E0] F2 cache pre-scan — 실행 필요 task 목록 R 확정
+   const f2Hits = new Map<string, Record<string, unknown>>(); // taskId → cachedTaskResult
+   const tasksNeedingExecution: typeof graph.tasks = [];
+   if (!request.noCache && !CACHE_DISABLED && request.executionMode !== "stub") {
+     const projectId = state.shared_context.project_id as string | undefined;
+     for (const task of graph.tasks) {
+       if (!task.input_hash) { tasksNeedingExecution.push(task); continue; }
+       const cachedTask = await SessionStateManager.findSuccessfulTaskByHash(
+         task.input_hash,
+         { ...(projectId ? { project_id: projectId } : {}), recencyDays: CACHE_TTL_DAYS },
+       );
+       if (cachedTask) {
+         f2Hits.set(task.id, cachedTask.taskResult);
+       } else {
+         tasksNeedingExecution.push(task);
+       }
+     }
+   } else {
+     tasksNeedingExecution.push(...graph.tasks);
+   }
+   ```
+
+   **b. per-task semantic search (세션 단위 → task 단위):**
+
+   기존 코드는 `raw_input` 하나로 top5를 검색해 `ragSnippets`에 담고 모든 task에 같은 것을 prepend했다.
+
+   이동한 코드에서는 **`tasksNeedingExecution`의 task별로 검색**한다:
+
+   ```ts
+   // [B'] 실행 필요 task에만 per-task semantic search
+   const perTaskSnippets = new Map<string, RagSnippet[]>(); // taskId → snippets
+
+   if (isRagEnabled() && request.executionMode !== "stub" && tasksNeedingExecution.length > 0) {
+     try {
+       const modelPath = getRagModelPath()!;
+       const cwd = request.userRequest.cwd ?? process.cwd();
+       const dbPath = getRagVectorDbPath(cwd);
+       ragEmbedder = new EmbeddingService(modelPath);
+       await ragEmbedder.init();
+       ragStore = new VectorStore(dbPath, RAG_EMBEDDING_DIMS);
+       ragStore.open();
+       const retriever = new SemanticRetriever(ragStore, ragEmbedder);
+       const sessionsDir = resolveSessionsDir(cwd);
+       const loader = new RagContextLoader(sessionsDir);
+
+       for (const task of tasksNeedingExecution) {
+         // explore/debug/update/analyze 타입에만 retrieval (execute/validate는 기본 skip)
+         if (!RAG_ELIGIBLE_TYPES.has(task.type)) continue;
+
+         const queryText = `${task.type} ${task.title}`;
+         const hits = await retriever.hybridSearch(queryText, 5);
+         if (hits.length > 0) {
+           const snippets = await loader.load(hits.slice(0, 1)); // top1 주입, top2 확장 옵션
+           if (snippets.length > 0) perTaskSnippets.set(task.id, snippets);
+         }
+       }
+
+       const totalHits = Array.from(perTaskSnippets.values()).reduce((s, v) => s + v.length, 0);
+       if (totalHits > 0) {
+         await emitProgressWithLogging({
+           stage: "State Manager",
+           status: "info",
+           message: `RAG: ${tasksNeedingExecution.length}개 task 중 ${perTaskSnippets.size}개 task에 과거 컨텍스트 발견`,
+         });
+       }
+     } catch (ragErr) {
+       logger.warn(`RAG retrieval 실패 (non-fatal): ${toErrorMessage(ragErr)}`);
+       await ragEmbedder?.dispose().catch(() => {});
+       ragStore?.close();
+       ragEmbedder = undefined;
+       ragStore = undefined;
+     }
+   }
+   ```
+
+   `RAG_ELIGIBLE_TYPES`는 파일 상단에 상수로 정의한다:
+
+   ```ts
+   const RAG_ELIGIBLE_TYPES = new Set(["explore", "analyze", "debug", "update", "create"]);
+   ```
+
+---
+
+## Step 4 — `orchestrator.ts` Budget Gate 삽입 (L1046–1047)
+
+### 현재 상태 (L1046–1047)
+
+```ts
+const ragContext = formatRagSnippetsForPrompt(ragSnippets);
+const prompt = `${responseLanguageInstruction}${ragContext ? `${ragContext}\n\n` : ""}[${task.type.toUpperCase()}] ...`;
+```
+
+### 변경 후
+
+1. Budget Gate 상수를 orchestrator 파일 상단(import 직후)에 추가:
+
+   ```ts
+   const COLD_START_THRESHOLD = parseInt(process.env.DETOKS_COLD_START_THRESHOLD ?? "5", 10);
+   const RAG_BREAK_EVEN_RATIO = parseFloat(process.env.DETOKS_RAG_BREAK_EVEN ?? "0.5");
+   const PER_TASK_TOKEN_CAP = parseInt(process.env.DETOKS_RAG_PER_TASK_CAP ?? "250", 10);
+   const PER_SESSION_TOKEN_CAP = parseInt(process.env.DETOKS_RAG_PER_SESSION_CAP ?? "500", 10);
+   ```
+
+2. per-task ragContext 결정 로직 — 실행 루프 내부(기존 L1046 위치)를 아래로 교체:
+
+   ```ts
+   // Budget Gate — per-task ragContext 결정
+   const taskSnippets = perTaskSnippets.get(task.id) ?? [];
+   const ragContextRaw = formatRagSnippetsForPrompt(taskSnippets);
+   const ragTokensForTask = countRagContextTokens(ragContextRaw);
+   const sessionRagTokensSoFar = tokensAddedByRagContext; // 누적값 (아래 Step에서 선언)
+
+   let ragContext = "";
+   if (ragContextRaw && ragTokensForTask > 0) {
+     const projectedAdded = sessionRagTokensSoFar + ragTokensForTask;
+     const projectedSaved = sumCachedTaskTokens(f2Hits);    // f2Hits는 Step 3에서 만든 Map
+     const sessionCount = await countPriorSessions(
+       state.shared_context.project_id as string | undefined,
+     );
+     const inColdStart = sessionCount < COLD_START_THRESHOLD;
+
+     const block =
+       projectedAdded > PER_SESSION_TOKEN_CAP ||
+       ragTokensForTask > PER_TASK_TOKEN_CAP ||
+       (!inColdStart && projectedAdded > projectedSaved * RAG_BREAK_EVEN_RATIO);
+
+     if (!block || request.forceRagContext) {
+       ragContext = ragContextRaw;
+       tokensAddedByRagContext += ragTokensForTask;
+       ragContextInjected = true;
+     }
+   }
+
+   const prompt = `${responseLanguageInstruction}${ragContext ? `${ragContext}\n\n` : ""}[${task.type.toUpperCase()}] ${task.title}\n\nContext: ${executionContext.context_summary}`;
+   ```
+
+3. 실행 루프 진입 전(for 루프 앞)에 Accounting 누적 변수를 선언한다:
+
+   ```ts
+   let tokensAddedByRagContext = 0;
+   let tokensSavedByCache = 0;
+   let cacheHitCount = 0;
+   let ragContextInjected = false;
+   ```
+
+4. F2 cache hit 시 `tokensSavedByCache` 누적:
+
+   F2 hit 처리 블록(기존 L956 근처) 안에서:
+
+   ```ts
+   const taskTokenEstimate =
+     (f2CachedResult.token_estimate_total as number | undefined) ?? 0;
+   tokensSavedByCache += taskTokenEstimate;
+   cacheHitCount += 1;
+   ```
+
+5. 실행 루프 종료 후, 최종 반환 직전에 `TokenAccounting`, `CostAccounting` 계산:
+
+   ```ts
+   const tokenAccounting = computeNetTokens(
+     tokensSavedByCache,
+     tokensAddedByRagContext,
+   );
+   const costAccounting = computeCostUsd({
+     savedInTokens: tokensSavedByCache,
+     savedOutTokens: 0, // output 토큰 estimate는 추후
+     addedInTokens: tokensAddedByRagContext,
+     adapter: request.adapter,
+     adapterModel: request.env?.ADAPTER_MODEL ?? process.env.ADAPTER_MODEL,
+   });
+   const lightQuality: LightQualityCounters = {
+     ragContextInjected,
+     cacheHitRate: graph.tasks.length > 0 ? cacheHitCount / graph.tasks.length : 0,
+   };
+   ```
+
+6. `return` 객체에 추가:
+
+   ```ts
+   return {
+     // ... 기존 필드 ...
+     tokenAccounting,
+     costAccounting,
+     lightQuality,
+   };
+   ```
+
+### 헬퍼 함수
+
+실행 루프 **위에서** 접근 가능한 위치(orchestrator.ts 상단 또는 별도 유틸)에 추가:
+
+```ts
+function sumCachedTaskTokens(f2Hits: Map<string, Record<string, unknown>>): number {
+  let total = 0;
+  for (const result of f2Hits.values()) {
+    const est = result.token_estimate_total as number | undefined;
+    if (est) total += est;
+  }
+  return total;
+}
+
+async function countPriorSessions(projectId: string | undefined): Promise<number> {
+  try {
+    const sessions = await SessionStateManager.listSessions();
+    if (!projectId) return sessions.length;
+    // project_id 필터는 listSessions가 지원하지 않으면 모든 세션 수로 근사
+    return sessions.length;
+  } catch {
+    return 0;
+  }
+}
+```
+
+`--force-rag-context` 플래그는 `request` 타입에 optional boolean을 추가한다:
+
+```ts
+// src/core/pipeline/types.ts 의 PipelineExecutionRequest 에 추가
+forceRagContext?: boolean;   // Budget Gate 무시, RAG context 강제 주입
+noRagContext?: boolean;      // RAG context 강제 OFF
+```
+
+---
+
+## Step 5 — 신규 파일: `src/cli/commands/memory.ts`
+
+```ts
+import { promises as fs } from "node:fs";
+import { join, homedir } from "node:path";
+import { SESSIONS_DIR } from "../../core/cache/cache-config.js";
+import { getRagVectorDbPath } from "../../core/rag/rag-config.js";
+
+const DISABLED_FLAG_FILE = join(homedir(), ".detoks", "disabled");
+
+export interface MemoryCommandResult {
+  ok: boolean;
+  action: "disable" | "purge-all";
+  message: string;
+}
+
+// detoks memory disable
+// ~/.detoks/disabled 파일을 생성. 다음 실행부터 저장/조회/인덱싱 모두 OFF.
+export async function runMemoryDisableCommand(): Promise<MemoryCommandResult> {
+  try {
+    await fs.mkdir(join(homedir(), ".detoks"), { recursive: true });
+    await fs.writeFile(DISABLED_FLAG_FILE, "", { flag: "w" });
+    return {
+      ok: true,
+      action: "disable",
+      message: `DeToks 메모리 기능이 비활성화되었습니다.\n파일: ${DISABLED_FLAG_FILE}\n재활성화: 파일을 삭제하거나 DETOKS_MEMORY=on 환경 변수를 설정하세요.`,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      action: "disable",
+      message: `비활성화 파일 생성 실패: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+// detoks memory purge --all
+// .state/sessions/*.json + .state/rag/vectors.db 일괄 삭제 (확인 프롬프트 포함).
+export async function runMemoryPurgeAllCommand(opts: {
+  skipConfirm?: boolean; // 테스트 환경 등에서 확인 생략용
+} = {}): Promise<MemoryCommandResult> {
+  if (!opts.skipConfirm) {
+    // Node.js에서 stdin 한 줄 읽기
+    const confirmed = await promptConfirm(
+      "⚠️  .state/sessions/ 전체와 벡터 DB를 영구 삭제합니다. 계속하시겠습니까? (yes/N): ",
+    );
+    if (!confirmed) {
+      return { ok: true, action: "purge-all", message: "취소되었습니다." };
+    }
+  }
+
+  const errors: string[] = [];
+  let deletedCount = 0;
+
+  // 1. session 파일 삭제
+  try {
+    const files = await fs.readdir(SESSIONS_DIR);
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        await fs.unlink(join(SESSIONS_DIR, file));
+        deletedCount++;
+      } catch (e) {
+        errors.push(`${file}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+  } catch {
+    // SESSIONS_DIR이 없으면 그냥 통과
+  }
+
+  // 2. 벡터 DB 삭제
+  try {
+    const dbPath = getRagVectorDbPath(process.cwd());
+    await fs.unlink(dbPath);
+    deletedCount++;
+  } catch {
+    // 벡터 DB가 없으면 통과
+  }
+
+  if (errors.length > 0) {
+    return {
+      ok: false,
+      action: "purge-all",
+      message: `일부 파일 삭제 실패:\n${errors.join("\n")}`,
+    };
+  }
+
+  return {
+    ok: true,
+    action: "purge-all",
+    message: `${deletedCount}개 파일을 삭제했습니다. DeToks 메모리가 초기화되었습니다.`,
+  };
+}
+
+async function promptConfirm(question: string): Promise<boolean> {
+  process.stdout.write(question);
+  return new Promise((resolve) => {
+    let answer = "";
+    process.stdin.setEncoding("utf-8");
+    process.stdin.resume();
+    process.stdin.once("data", (chunk) => {
+      answer = String(chunk).trim().toLowerCase();
+      process.stdin.pause();
+      resolve(answer === "yes" || answer === "y");
+    });
+  });
+}
+```
+
+**`SESSIONS_DIR`이 `cache-config.ts`에 export되어 있는지 확인**:
+
+```bash
+grep -n "SESSIONS_DIR\|export" src/core/cache/cache-config.ts
+```
+
+없으면 `cache-config.ts`에 추가한다:
+
+```ts
+export const SESSIONS_DIR = join(process.cwd(), ".state", "sessions");
+```
+
+`getRagVectorDbPath`는 `src/core/rag/rag-config.ts`에 이미 있다:
+
+```bash
+grep -n "getRagVectorDbPath" src/core/rag/rag-config.ts
+```
+
+---
+
+## Step 6 — `src/cli/types.ts` command union 확장
+
+### 현재 (L20–29)
+
+```ts
+command?:
+  | "session-list"
+  // ... 기존 ...
+  | "checkpoint-restore";
+```
+
+### 변경 후
+
+```ts
+command?:
+  | "session-list"
+  // ... 기존 항목 유지 ...
+  | "checkpoint-restore"
+  | "memory-disable"    // NEW
+  | "memory-purge-all"; // NEW
+```
+
+`memoryPurgeAll?: boolean` 필드도 `CliArgs`에 추가(parse에서 `--all` 플래그 처리용):
+
+```ts
+export interface CliArgs {
+  // ... 기존 필드 ...
+  memoryPurgeAll?: boolean;   // NEW: detoks memory purge --all 플래그
+  skipConfirm?: boolean;      // NEW: 테스트용 확인 생략
+}
+```
+
+---
+
+## Step 7 — `src/cli/parse.ts` memory 커맨드 파싱 추가
+
+`parseCliArgs` 함수 내부, `first === "session"` 블록 근처에 아래를 추가한다:
+
+```ts
+if (first === "memory") {
+  const sub = positionals[1];
+  if (sub === "disable") {
+    return {
+      mode: "run",
+      adapter,
+      executionMode,
+      verbose,
+      trace,
+      showHelp: false,
+      command: "memory-disable",
+    };
+  }
+  if (sub === "purge") {
+    const allFlag = positionals.includes("--all") || argv.includes("--all");
+    return {
+      mode: "run",
+      adapter,
+      executionMode,
+      verbose,
+      trace,
+      showHelp: false,
+      command: "memory-purge-all",
+      memoryPurgeAll: allFlag,
+      skipConfirm: argv.includes("--yes"),
+    };
+  }
+  throw new Error(`알 수 없는 memory 하위 명령: ${sub ?? "(없음)"}. detoks memory disable|purge --all`);
+}
+```
+
+`--all`은 positionals 배열에 들어가지 않도록 처리 흐름을 확인한다. `parseCliArgs` 안에서 `--all`이 positionals에 들어가지 않게 하려면 `--`로 시작하는 플래그 파싱 로직에서 `--all`을 처리하거나, 위처럼 `argv.includes("--all")`을 직접 확인한다.
+
+CLI usage 문자열(`CLI_USAGE_MAIN`)에도 두 줄을 추가한다:
+
+```ts
+"  detoks memory disable                DeToks 메모리 기능 전체 비활성화",
+"  detoks memory purge --all            세션 파일 및 벡터 DB 일괄 삭제",
+```
+
+---
+
+## Step 8 — `src/cli/index.ts` memory 커맨드 라우팅 추가
+
+import 블록에 추가:
+
+```ts
+import { runMemoryDisableCommand, runMemoryPurgeAllCommand } from "./commands/memory.js";
+```
+
+`main` 함수 안, 기존 `if (args.command === "checkpoint-restore")` 블록 이후에 추가:
+
+```ts
+if (args.command === "memory-disable") {
+  const result = await runMemoryDisableCommand();
+  console.log(args.human ? result.message : JSON.stringify(result, null, 2));
+  if (!result.ok) process.exitCode = 1;
+  return;
+}
+
+if (args.command === "memory-purge-all") {
+  const result = await runMemoryPurgeAllCommand({ skipConfirm: args.skipConfirm });
+  console.log(args.human ? result.message : JSON.stringify(result, null, 2));
+  if (!result.ok) process.exitCode = 1;
+  return;
+}
+```
+
+---
+
+## Step 9 — 첫 실행 1회 안내
+
+`orchestrator.ts` 진입부(F1 cache 이전, L464 앞)에 삽입한다. **이 코드는 L464 위에 들어가므로 Track A 담당 영역과 순서상 겹치지 않도록 주의한다. 한 줄만 추가하고 로직은 별도 함수로 분리한다.**
+
+```ts
+// 첫 실행 안내 (L464 직전에 삽입)
+await maybeShowFirstRunNotice(request.userRequest.cwd ?? process.cwd());
+```
+
+`maybeShowFirstRunNotice` 함수는 orchestrator 파일 상단에 정의:
+
+```ts
+const NOTICE_SHOWN_FILE = ".state/.detoks-notice-shown";
+
+async function maybeShowFirstRunNotice(cwd: string): Promise<void> {
+  const flagPath = join(cwd, NOTICE_SHOWN_FILE);
+  try {
+    await fs.access(flagPath);
+    return; // 이미 표시했음
+  } catch { /* 파일 없음 → 안내 필요 */ }
+
+  const notice = [
+    "[detoks] DeToks는 실행 메모리를 .state/sessions에 저장합니다.",
+    "[detoks] cross-project store에는 generalize 단계를 거친 익명 패턴만 들어갑니다.",
+    "[detoks] 비활성화: detoks memory disable / 일괄 삭제: detoks memory purge --all",
+  ].join("\n");
+
+  process.stderr.write(`${notice}\n`);
+
+  try {
+    await fs.mkdir(join(cwd, ".state"), { recursive: true });
+    await fs.writeFile(flagPath, new Date().toISOString(), "utf-8");
+  } catch { /* 쓰기 실패는 non-fatal */ }
+}
+```
+
+`fs` import가 orchestrator 상단에 없으면 추가한다:
+
+```ts
+import { promises as fs } from "node:fs";
+```
+
+---
+
+## 검증 체크리스트
+
+- [ ] `tsc --noEmit` 에러 없음
+- [ ] `detoks memory disable` 실행 → `~/.detoks/disabled` 파일 생성 확인
+- [ ] `detoks memory purge --all --yes` 실행(확인 생략) → `.state/sessions/*.json` 삭제 확인
+- [ ] `tokenAccounting.netTokensSaved`가 `PipelineExecutionResult`에 포함되는지 확인
+- [ ] Budget Gate: `DETOKS_RAG_PER_TASK_CAP=1 detoks run "..."` → ragContext가 빈 문자열로 차단되는지 확인
+- [ ] 벡터 DB 없는 환경에서도 Gate가 예외 없이 통과되는지 확인 (non-fatal 처리)
+- [ ] 첫 실행 시 안내 문구가 stderr에 출력되고, 두 번째 실행에서는 나오지 않는지 확인
+
+---
+
+## 충돌 방지 체크리스트
+
+Track A와 동시에 작업할 때 지켜야 할 규칙:
+
+- [ ] `orchestrator.ts` **L546 위는 건드리지 않는다** (F1, F3 블록 = Track A 담당)
+- [ ] `src/core/cache/cache-validator.ts`는 수정하지 않는다 (Track A 담당)
+- [ ] `src/core/rag/hash.ts`는 수정하지 않는다 (Track A 담당)
+- [ ] `src/core/task-graph/TaskGraphProcessor.ts`는 수정하지 않는다 (Track A 담당)
+- [ ] `markTaskCompleted` 함수 시그니처 변경은 Track A가 한다 — Track B는 **해당 함수를 호출만 한다**
+
+PR 순서: **Track A를 먼저 머지한다.** Track B의 Budget Gate에서 `CacheValidity` 타입을 참조하거나 Track A가 변경하는 `isTaskCacheValid` 반환값에 의존하는 부분이 있기 때문이다. Track A PR이 없으면 Track B 빌드가 깨질 수 있다.

--- a/src/core/cache/cache-validator.ts
+++ b/src/core/cache/cache-validator.ts
@@ -1,44 +1,62 @@
 import type { SessionState } from "../../schemas/pipeline.js";
 import { CACHE_TTL_DAYS } from "./cache-config.js";
 
+// "auto"   → 모든 조건 통과, 즉시 캐시 반환
+// "advise" → recency 경계 근처 / adapter·git HEAD 불일치 등
+//             결과 반환 X, 구 세션 기록으로만 취급 (P1에서 사용자 안내 추가 예정)
+// "skip"   → 검증 실패, miss 처리
+export type CacheValidity = "auto" | "advise" | "skip";
+
 export interface CacheValidationOpts {
   project_id?: string;
   recencyDays?: number;
+  expected_adapter?: string;
+  expected_adapter_model?: string;
+  expected_git_head?: string;
 }
 
 export function isSessionCacheValid(
   session: SessionState,
   opts: CacheValidationOpts = {},
-): boolean {
-  const { project_id, recencyDays = CACHE_TTL_DAYS } = opts;
+): CacheValidity {
+  const { project_id, recencyDays = CACHE_TTL_DAYS, expected_adapter, expected_git_head } = opts;
 
-  if (project_id && session.shared_context.project_id !== project_id) return false;
+  if (project_id && session.shared_context.project_id !== project_id) return "skip";
 
   const failedIds = (session.shared_context.failed_task_ids as string[] | undefined) ?? [];
-  if (failedIds.length > 0) return false;
+  if (failedIds.length > 0) return "skip";
 
-  if (session.completed_task_ids.length === 0) return false;
+  if (session.completed_task_ids.length === 0) return "skip";
 
   if (session.updated_at) {
     const cutoff = Date.now() - recencyDays * 24 * 60 * 60 * 1000;
-    if (new Date(session.updated_at).getTime() < cutoff) return false;
+    if (new Date(session.updated_at).getTime() < cutoff) return "skip";
   }
 
-  return true;
+  // 구 세션(stamp 필드 없음)은 adapter/git_head 필드 자체가 없으므로 비교 없이 통과
+  const ctx = session.shared_context as Record<string, unknown>;
+  if (expected_adapter && ctx.adapter && ctx.adapter !== expected_adapter) return "advise";
+  if (expected_git_head && ctx.git_head && ctx.git_head !== expected_git_head) return "advise";
+
+  return "auto";
 }
 
 export function isTaskCacheValid(
   taskResult: Record<string, unknown>,
   opts: CacheValidationOpts = {},
-): boolean {
-  const { recencyDays = CACHE_TTL_DAYS } = opts;
+): CacheValidity {
+  const { recencyDays = CACHE_TTL_DAYS, expected_adapter, expected_git_head } = opts;
 
-  if (taskResult.success !== true) return false;
+  if (taskResult.success !== true) return "skip";
 
   if (typeof taskResult.completed_at === "string") {
     const cutoff = Date.now() - recencyDays * 24 * 60 * 60 * 1000;
-    if (new Date(taskResult.completed_at).getTime() < cutoff) return false;
+    if (new Date(taskResult.completed_at).getTime() < cutoff) return "skip";
   }
 
-  return true;
+  // 구 세션(stamp 필드 없음)은 비교 없이 통과
+  if (expected_adapter && taskResult.adapter && taskResult.adapter !== expected_adapter) return "advise";
+  if (expected_git_head && taskResult.git_head && taskResult.git_head !== expected_git_head) return "advise";
+
+  return "auto";
 }

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1007,14 +1007,30 @@ export const orchestratePipeline = async (
 
       // F2: Task-level input_hash cache bypass (stub 모드 제외)
       if (!request.noCache && !CACHE_DISABLED && request.executionMode !== "stub" && task.input_hash) {
-        const projectId = state.shared_context.project_id as string | undefined;
+        const f2ProjectId = state.shared_context.project_id as string | undefined;
         const cachedTask = await SessionStateManager.findSuccessfulTaskByHash(
           task.input_hash,
-          { ...(projectId ? { project_id: projectId } : {}), recencyDays: CACHE_TTL_DAYS },
+          {
+            ...(f2ProjectId ? { project_id: f2ProjectId } : {}),
+            recencyDays: CACHE_TTL_DAYS,
+            adapter: request.adapter,
+            ...(gitHead ? { git_head: gitHead } : {}),
+          },
         );
-        if (cachedTask && isTaskCacheValid(cachedTask.taskResult, {})) {
-          const cachedOutput = (cachedTask.taskResult.raw_output as string) ?? "";
-          state = markTaskCompleted(state, task.id, cachedOutput, task.type, task);
+        const f2Validity = cachedTask
+          ? isTaskCacheValid(cachedTask.taskResult, {
+              expected_adapter: request.adapter,
+              ...(gitHead ? { expected_git_head: gitHead } : {}),
+            })
+          : "skip";
+
+        if (f2Validity === "auto") {
+          const cachedOutput = (cachedTask!.taskResult.raw_output as string) ?? "";
+          state = markTaskCompleted(state, task.id, cachedOutput, task.type, task, {
+            adapter: request.adapter,
+            ...(adapterModel ? { adapterModel } : {}),
+            ...(gitHead ? { gitHead } : {}),
+          });
           state = applySessionTokenMetrics(
             state,
             request.userRequest.raw_input,
@@ -1026,7 +1042,7 @@ export const orchestratePipeline = async (
             createActionTimelineEvent({
               kind: "cache_hit",
               source: "pipeline",
-              summary: `F2 캐시 hit — task ${task.id} (세션 ${cachedTask.sessionId})`,
+              summary: `F2 캐시 hit — task ${task.id} (세션 ${cachedTask!.sessionId})`,
               taskId: task.id,
             }),
           );
@@ -1038,11 +1054,15 @@ export const orchestratePipeline = async (
           });
           continue;
         }
+
+        // "advise": adapter·git HEAD 불일치 — P0에서는 miss로 처리
         await emitActionTimelineWithLogging(
           createActionTimelineEvent({
             kind: "cache_miss",
             source: "pipeline",
-            summary: `F2 캐시 miss — task ${task.id} hash ${task.input_hash}`,
+            summary: f2Validity === "advise"
+              ? `F2 캐시 advise — adapter 또는 git HEAD 불일치 (task ${task.id})`
+              : `F2 캐시 miss — task ${task.id} hash ${task.input_hash}`,
             taskId: task.id,
           }),
         );
@@ -1119,7 +1139,6 @@ export const orchestratePipeline = async (
       });
 
       PipelineTracer.startStage(`Executor:${task.id}`);
-      const adapterModel = request.env?.ADAPTER_MODEL ?? process.env.ADAPTER_MODEL;
       const execResult = await executeWithAdapter({
         adapter: request.adapter,
         mode: request.mode,
@@ -1172,7 +1191,11 @@ export const orchestratePipeline = async (
           message: `Executor(${task.id}) 완료`,
         });
         failedTaskIds.delete(task.id);
-        state = markTaskCompleted(state, task.id, execResult.rawOutput, task.type, task);
+        state = markTaskCompleted(state, task.id, execResult.rawOutput, task.type, task, {
+          adapter: request.adapter,
+          ...(adapterModel ? { adapterModel } : {}),
+          ...(gitHead ? { gitHead } : {}),
+        });
         state = applySessionTokenMetrics(
           state,
           request.userRequest.raw_input,

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { execSync } from "node:child_process";
 import { DAGValidator } from "../task-graph/DAGValidator.js";
 import { DependencyResolver } from "../task-graph/DependencyResolver.js";
 import { ParallelClassifier } from "../task-graph/ParallelClassifier.js";
@@ -21,7 +22,7 @@ import {
   type TokenReductionSnapshot,
 } from "../utils/tokenMetrics.js";
 import { getLLMModelConfig } from "../llm-client/llm-models.js";
-import { computeProjectId, hashRawInput } from "../rag/hash.js";
+import { computeProjectId, hashRawInput, hashTaskInputV2 } from "../rag/hash.js";
 import { CACHE_DISABLED, CACHE_TTL_DAYS } from "../cache/cache-config.js";
 import { isSessionCacheValid, isTaskCacheValid } from "../cache/cache-validator.js";
 import { isRagEnabled, getRagModelPath, getRagVectorDbPath, RAG_EMBEDDING_DIMS } from "../rag/rag-config.js";
@@ -71,6 +72,23 @@ function resolveModelName(adapter: string, env?: NodeJS.ProcessEnv): string {
 
 function generateSessionId(): string {
   return createHash("sha256").update(String(Date.now())).digest("hex").slice(0, 12);
+}
+
+// package.json major 버전 — cache key의 detoksMajorVersion으로 사용.
+// major 버전이 올라갈 때만 기존 캐시가 자동 무효화된다.
+const DETOKS_MAJOR_VERSION = 1;
+
+// git HEAD short SHA (8자). git이 없는 환경이면 undefined.
+function resolveGitHead(cwd: string): string | undefined {
+  try {
+    return execSync("git rev-parse HEAD", {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim().slice(0, 8);
+  } catch {
+    return undefined;
+  }
 }
 
 function initSessionState(sessionId: string, rawInput: string, executionMode: string): SessionState {
@@ -461,13 +479,16 @@ export const orchestratePipeline = async (
     }
   };
 
+  // projectId / gitHead — F1·F3 cache lookup과 hash v2 re-map에서 공통으로 사용
+  const projectId =
+    request.projectInfo?.projectId ??
+    computeProjectId(request.userRequest.cwd ?? process.cwd());
+  const gitHead = resolveGitHead(request.userRequest.cwd ?? process.cwd());
+
   // ── F1: Cross-session input_hash cache bypass ────────────────────────────
   // stub 모드는 테스트/개발용이므로 캐시 우회 대상에서 제외
   if (!request.noCache && !CACHE_DISABLED && request.executionMode !== "stub") {
     const inputHash = hashRawInput(request.userRequest.raw_input);
-    const projectId =
-      request.projectInfo?.projectId ??
-      computeProjectId(request.userRequest.cwd ?? process.cwd());
     const cachedSession = await SessionStateManager.findSuccessfulSessionByInputHash(
       inputHash,
       { project_id: projectId, recencyDays: CACHE_TTL_DAYS },
@@ -522,9 +543,6 @@ export const orchestratePipeline = async (
   let resumeHint: ResumeHintInfo | undefined;
   if (!request.noCache && !CACHE_DISABLED && request.executionMode !== "stub") {
     const inputHash = hashRawInput(request.userRequest.raw_input);
-    const projectId =
-      request.projectInfo?.projectId ??
-      computeProjectId(request.userRequest.cwd ?? process.cwd());
     const incompleteSession = await SessionStateManager.findIncompleteSessionByInputHash(
       inputHash,
       { project_id: projectId },
@@ -679,7 +697,22 @@ export const orchestratePipeline = async (
   });
   PipelineTracer.startStage("TaskGraphBuilder");
   const compiledSentences = TaskSentenceSplitter.split(role2PromptInput.compiled_prompt);
-  const graph = TaskGraphProcessor.process(compiledSentences);
+  const rawGraph = TaskGraphProcessor.process(compiledSentences);
+  const adapterModel = request.env?.ADAPTER_MODEL ?? process.env.ADAPTER_MODEL ?? "";
+  const graph = {
+    ...rawGraph,
+    tasks: rawGraph.tasks.map((task) => ({
+      ...task,
+      input_hash: hashTaskInputV2({
+        projectId,
+        type: task.type,
+        normalizedIntent: task.title,
+        adapter: request.adapter,
+        adapterModel,
+        detoksMajorVersion: DETOKS_MAJOR_VERSION,
+      }),
+    })),
+  };
   await PipelineTracer.trace({
     sessionId, stage: "TaskGraphBuilder", role: "role2.1", phase: "output",
     dataType: "TaskGraph", data: graph,

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -503,13 +503,21 @@ export const orchestratePipeline = async (
     const inputHash = hashRawInput(request.userRequest.raw_input);
     const cachedSession = await SessionStateManager.findSuccessfulSessionByInputHash(
       inputHash,
-      { project_id: projectId, recencyDays: CACHE_TTL_DAYS },
+      { project_id: projectId, recencyDays: CACHE_TTL_DAYS, adapter: request.adapter },
     );
-    if (cachedSession && isSessionCacheValid(cachedSession, { project_id: projectId })) {
-      const cacheAge = cachedSession.updated_at
-        ? Date.now() - new Date(cachedSession.updated_at).getTime()
+    const f1Validity = cachedSession
+      ? isSessionCacheValid(cachedSession, {
+          project_id: projectId,
+          expected_adapter: request.adapter,
+          ...(gitHead ? { expected_git_head: gitHead } : {}),
+        })
+      : "skip";
+
+    if (f1Validity === "auto") {
+      const cacheAge = cachedSession!.updated_at
+        ? Date.now() - new Date(cachedSession!.updated_at).getTime()
         : 0;
-      const cachedSessionId = cachedSession.shared_context.session_id;
+      const cachedSessionId = cachedSession!.shared_context.session_id;
       await emitActionTimelineWithLogging(
         createActionTimelineEvent({
           kind: "cache_hit",
@@ -517,21 +525,21 @@ export const orchestratePipeline = async (
           summary: `F1 캐시 hit — 세션 ${cachedSessionId} (${Math.round(cacheAge / 86400000)}일 전)`,
         }),
       );
-      const { rawOutputText, summaryText } = collectTaskOutputText(cachedSession);
+      const { rawOutputText, summaryText } = collectTaskOutputText(cachedSession!);
       return {
         ok: true,
         mode: request.mode,
         adapter: request.adapter,
-        summary: cachedSession.last_summary ?? summaryText.slice(0, 200),
-        nextAction: cachedSession.next_action ?? "캐시된 결과를 반환했습니다.",
+        summary: cachedSession!.last_summary ?? summaryText.slice(0, 200),
+        nextAction: cachedSession!.next_action ?? "캐시된 결과를 반환했습니다.",
         originalPrompt: request.userRequest.raw_input,
         stages: buildPipelineStages(true),
         rawOutput: rawOutputText,
         sessionId: cachedSessionId,
-        taskRecords: cachedSession.completed_task_ids.map((id) => ({
+        taskRecords: cachedSession!.completed_task_ids.map((id) => ({
           taskId: id,
           status: "completed" as const,
-          rawOutput: (cachedSession.task_results[id] as Record<string, unknown>)?.raw_output as string ?? "",
+          rawOutput: (cachedSession!.task_results[id] as Record<string, unknown>)?.raw_output as string ?? "",
         })),
         cacheHit: {
           kind: "session" as const,
@@ -542,11 +550,15 @@ export const orchestratePipeline = async (
         ...(actionTimeline.length ? { actionTimeline } : {}),
       };
     }
+
+    // "advise": adapter·git HEAD 불일치 — P0에서는 miss로 처리 (P1에서 사용자 안내 추가 예정)
     await emitActionTimelineWithLogging(
       createActionTimelineEvent({
         kind: "cache_miss",
         source: "pipeline",
-        summary: `F1 캐시 miss — hash ${inputHash}`,
+        summary: f1Validity === "advise"
+          ? `F1 캐시 advise — adapter 또는 git HEAD 불일치 (hash ${inputHash})`
+          : `F1 캐시 miss — hash ${inputHash}`,
       }),
     );
   }

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -91,13 +91,21 @@ function resolveGitHead(cwd: string): string | undefined {
   }
 }
 
-function initSessionState(sessionId: string, rawInput: string, executionMode: string): SessionState {
+function initSessionState(
+  sessionId: string,
+  rawInput: string,
+  executionMode: string,
+  stamp: { adapter?: string; adapterModel?: string; gitHead?: string } = {},
+): SessionState {
   return {
     shared_context: {
       session_id: sessionId,
       raw_input: rawInput,
       // stub 모드 세션은 캐시 조회 대상에서 제외 — real 모드가 stub 결과를 캐시 hit으로 받는 오염 방지
       ...(executionMode !== "stub" ? { raw_input_hash: hashRawInput(rawInput) } : {}),
+      ...(stamp.adapter ? { adapter: stamp.adapter } : {}),
+      ...(stamp.adapterModel ? { adapter_model: stamp.adapterModel } : {}),
+      ...(stamp.gitHead ? { git_head: stamp.gitHead } : {}),
     },
     task_results: {},
     current_task_id: null,
@@ -155,6 +163,7 @@ function markTaskCompleted(
   rawOutput: string,
   taskType?: string,
   task?: { title?: string; input_hash?: string; depends_on?: string[] },
+  stamp: { adapter?: string; adapterModel?: string; gitHead?: string } = {},
 ): SessionState {
   const now = new Date().toISOString();
   return {
@@ -171,6 +180,9 @@ function markTaskCompleted(
         ...(taskType ? { type: taskType } : {}),
         ...extractRagMeta(task),
         completed_at: now,
+        ...(stamp.adapter ? { adapter: stamp.adapter } : {}),
+        ...(stamp.adapterModel ? { adapter_model: stamp.adapterModel } : {}),
+        ...(stamp.gitHead ? { git_head: stamp.gitHead } : {}),
       },
     },
     updated_at: now,
@@ -848,7 +860,11 @@ export const orchestratePipeline = async (
     const loadedFailedIds = (state.shared_context.failed_task_ids as string[]) || [];
     loadedFailedIds.forEach((id) => failedTaskIds.add(id));
   } else {
-    state = initSessionState(sessionId, request.userRequest.raw_input, request.executionMode);
+    state = initSessionState(sessionId, request.userRequest.raw_input, request.executionMode, {
+      adapter: request.adapter,
+      ...(adapterModel ? { adapterModel } : {}),
+      ...(gitHead ? { gitHead } : {}),
+    });
   }
   state = applyProjectInfo(state, request.projectInfo, request.userRequest.cwd);
   // RAG Phase 2: 전체 DAG 보존 (Task의 input_hash, depends_on, priority 등 완전 보존)

--- a/src/core/rag/hash.ts
+++ b/src/core/rag/hash.ts
@@ -55,3 +55,19 @@ export const computeProjectId = (cwd: string): string => {
 
   return `path-${createHash("sha256").update(absoluteCwd).digest("hex").slice(0, 12)}`;
 };
+
+// task cache 키 v2 — task.id(실행 순서 식별자 t1/t2/…)를 제외하고
+// 작업 의미(type, normalizedIntent, adapter, 버전)만으로 hash를 생성한다.
+// v1은 id 포함으로 인해 앞 task가 하나만 바뀌어도 이후 모든 hash가 깨지는 구조적 문제가 있었다.
+// normalizedIntent는 공백·문장 부호만 정규화하고 파일 경로·심볼명 등 식별자는 그대로 보존해야 한다.
+export const hashTaskInputV2 = (params: {
+  projectId: string;
+  type: string;
+  normalizedIntent: string;
+  adapter: string;
+  adapterModel: string;
+  detoksMajorVersion: number;
+}): string => {
+  const content = JSON.stringify(params);
+  return createHash("sha256").update(content).digest("hex").slice(0, 16);
+};

--- a/src/core/state/SessionStateManager.ts
+++ b/src/core/state/SessionStateManager.ts
@@ -362,9 +362,9 @@ export class SessionStateManager {
 
   static async findSuccessfulSessionByInputHash(
     hash: string,
-    opts: { project_id?: string; recencyDays?: number } = {},
+    opts: { project_id?: string; recencyDays?: number; adapter?: string } = {},
   ): Promise<SessionState | null> {
-    const { project_id, recencyDays = 7 } = opts;
+    const { project_id, recencyDays = 7, adapter } = opts;
     const cutoff = Date.now() - recencyDays * 24 * 60 * 60 * 1000;
 
     let files: string[];
@@ -388,6 +388,10 @@ export class SessionStateManager {
         const failedIds = (state.shared_context.failed_task_ids as string[] | undefined) ?? [];
         if (failedIds.length > 0) continue;
 
+        // 구 세션(adapter stamp 없음)은 필드 자체가 없으므로 비교 없이 통과
+        const ctx = state.shared_context as Record<string, unknown>;
+        if (adapter && ctx.adapter && ctx.adapter !== adapter) continue;
+
         return state;
       } catch {
         continue;
@@ -398,9 +402,9 @@ export class SessionStateManager {
 
   static async findSuccessfulTaskByHash(
     taskHash: string,
-    opts: { project_id?: string; recencyDays?: number } = {},
+    opts: { project_id?: string; recencyDays?: number; adapter?: string; git_head?: string } = {},
   ): Promise<{ taskResult: Record<string, unknown>; sessionId: string } | null> {
-    const { project_id, recencyDays = 7 } = opts;
+    const { project_id, recencyDays = 7, adapter, git_head } = opts;
     const cutoff = Date.now() - recencyDays * 24 * 60 * 60 * 1000;
 
     let files: string[];
@@ -426,6 +430,9 @@ export class SessionStateManager {
           if (typeof res.completed_at === "string") {
             if (new Date(res.completed_at).getTime() < cutoff) continue;
           }
+          // 구 세션(stamp 필드 없음)은 필드 자체가 없으므로 비교 없이 통과
+          if (adapter && res.adapter && res.adapter !== adapter) continue;
+          if (git_head && res.git_head && res.git_head !== git_head) continue;
           return { taskResult: res, sessionId: file.slice(0, -".json".length) };
         }
       } catch {

--- a/tests/ts/unit/core/cache/cache-validator.test.ts
+++ b/tests/ts/unit/core/cache/cache-validator.test.ts
@@ -17,62 +17,98 @@ const makeSession = (overrides: Partial<SessionState> & { shared_context?: Recor
 });
 
 describe("isSessionCacheValid", () => {
-  it("유효한 세션은 true 반환", () => {
-    expect(isSessionCacheValid(makeSession())).toBe(true);
+  it("유효한 세션은 auto 반환", () => {
+    expect(isSessionCacheValid(makeSession())).toBe("auto");
   });
 
-  it("project_id 불일치 시 false", () => {
+  it("project_id 불일치 시 skip", () => {
     const session = makeSession({ shared_context: { session_id: "s1", project_id: "git-xyz" } });
-    expect(isSessionCacheValid(session, { project_id: "git-abc123" })).toBe(false);
+    expect(isSessionCacheValid(session, { project_id: "git-abc123" })).toBe("skip");
   });
 
-  it("project_id 일치 시 true", () => {
+  it("project_id 일치 시 auto", () => {
     const session = makeSession({ shared_context: { session_id: "s1", project_id: "git-abc123" } });
-    expect(isSessionCacheValid(session, { project_id: "git-abc123" })).toBe(true);
+    expect(isSessionCacheValid(session, { project_id: "git-abc123" })).toBe("auto");
   });
 
-  it("failed_task_ids가 있으면 false", () => {
+  it("failed_task_ids가 있으면 skip", () => {
     const session = makeSession({ shared_context: { session_id: "s1", failed_task_ids: ["t1"] } });
-    expect(isSessionCacheValid(session)).toBe(false);
+    expect(isSessionCacheValid(session)).toBe("skip");
   });
 
-  it("completed_task_ids가 비어있으면 false", () => {
+  it("completed_task_ids가 비어있으면 skip", () => {
     const session = makeSession({ completed_task_ids: [] });
-    expect(isSessionCacheValid(session)).toBe(false);
+    expect(isSessionCacheValid(session)).toBe("skip");
   });
 
-  it("TTL 초과 시 false", () => {
+  it("TTL 초과 시 skip", () => {
     const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
     const session = makeSession({ updated_at: old });
-    expect(isSessionCacheValid(session, { recencyDays: 7 })).toBe(false);
+    expect(isSessionCacheValid(session, { recencyDays: 7 })).toBe("skip");
   });
 
-  it("TTL 이내이면 true", () => {
+  it("TTL 이내이면 auto", () => {
     const recent = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
     const session = makeSession({ updated_at: recent });
-    expect(isSessionCacheValid(session, { recencyDays: 7 })).toBe(true);
+    expect(isSessionCacheValid(session, { recencyDays: 7 })).toBe("auto");
+  });
+
+  it("adapter 불일치 시 advise (stamp 있는 세션)", () => {
+    const session = makeSession({ shared_context: { session_id: "s1", project_id: "git-abc123", adapter: "codex" } });
+    expect(isSessionCacheValid(session, { expected_adapter: "claude" })).toBe("advise");
+  });
+
+  it("adapter 일치 시 auto", () => {
+    const session = makeSession({ shared_context: { session_id: "s1", project_id: "git-abc123", adapter: "claude" } });
+    expect(isSessionCacheValid(session, { expected_adapter: "claude" })).toBe("auto");
+  });
+
+  it("stamp 없는 구 세션은 adapter 불일치여도 auto (후방 호환)", () => {
+    const session = makeSession(); // adapter stamp 없음
+    expect(isSessionCacheValid(session, { expected_adapter: "claude" })).toBe("auto");
+  });
+
+  it("git_head 불일치 시 advise (stamp 있는 세션)", () => {
+    const session = makeSession({ shared_context: { session_id: "s1", project_id: "git-abc123", git_head: "aabbccdd" } });
+    expect(isSessionCacheValid(session, { expected_git_head: "11223344" })).toBe("advise");
   });
 });
 
 describe("isTaskCacheValid", () => {
-  it("success=true이고 최근이면 true", () => {
+  it("success=true이고 최근이면 auto", () => {
     const result = {
       success: true,
       completed_at: new Date().toISOString(),
     };
-    expect(isTaskCacheValid(result)).toBe(true);
+    expect(isTaskCacheValid(result)).toBe("auto");
   });
 
-  it("success=false이면 false", () => {
-    expect(isTaskCacheValid({ success: false })).toBe(false);
+  it("success=false이면 skip", () => {
+    expect(isTaskCacheValid({ success: false })).toBe("skip");
   });
 
-  it("completed_at TTL 초과 시 false", () => {
+  it("completed_at TTL 초과 시 skip", () => {
     const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
-    expect(isTaskCacheValid({ success: true, completed_at: old }, { recencyDays: 7 })).toBe(false);
+    expect(isTaskCacheValid({ success: true, completed_at: old }, { recencyDays: 7 })).toBe("skip");
   });
 
-  it("completed_at 없어도 success=true면 통과", () => {
-    expect(isTaskCacheValid({ success: true })).toBe(true);
+  it("completed_at 없어도 success=true면 auto", () => {
+    expect(isTaskCacheValid({ success: true })).toBe("auto");
+  });
+
+  it("adapter 불일치 시 advise (stamp 있는 task)", () => {
+    expect(isTaskCacheValid({ success: true, adapter: "codex" }, { expected_adapter: "claude" })).toBe("advise");
+  });
+
+  it("adapter 일치 시 auto", () => {
+    expect(isTaskCacheValid({ success: true, adapter: "claude" }, { expected_adapter: "claude" })).toBe("auto");
+  });
+
+  it("stamp 없는 구 task는 adapter 불일치여도 auto (후방 호환)", () => {
+    expect(isTaskCacheValid({ success: true }, { expected_adapter: "claude" })).toBe("auto");
+  });
+
+  it("git_head 불일치 시 advise (stamp 있는 task)", () => {
+    expect(isTaskCacheValid({ success: true, git_head: "aabbccdd" }, { expected_git_head: "11223344" })).toBe("advise");
   });
 });


### PR DESCRIPTION
## 요약

- `hashTaskInputV2` 추가 — `task.id`(실행 순서 식별자)를 cache key에서 제거하고, `(projectId, type, normalizedIntent, adapter, adapterModel, detoksMajorVersion)`만으로 hash를 구성해 F2 hit률 구조적 개선
- `CacheValidity = "auto" | "advise" | "skip"` 3단계 분기 도입 — 기존 `boolean` 반환을 교체하고 adapter·git HEAD 불일치를 `"advise"`로 처리
- `orchestrator.ts`에서 `TaskGraphProcessor.process()` 결과를 즉시 v2 hash로 re-map (기존 코드 최소 변경)
- 신규 세션과 완료 task에 `adapter`, `adapter_model`, `git_head` stamp 기록
- `SessionStateManager` lookup opts에 `adapter`, `git_head` 필터 추가 — 구 세션(stamp 없음)은 비교 없이 통과해 후방 호환 유지
- F1·F2 cache 블록을 `CacheValidity` 기반으로 갱신, `resolveGitHead()`, `DETOKS_MAJOR_VERSION` 추가

## 관련 이슈

- Closes #245 

## 변경 유형

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩터링
- [ ] 문서 수정
- [ ] 테스트 추가/수정

## 영향 범위

- 영향받는 모듈:
  - `src/core/rag/hash.ts`
  - `src/core/cache/cache-validator.ts`
  - `src/core/pipeline/orchestrator.ts`
  - `src/core/state/SessionStateManager.ts`
- 영향받지 않는 모듈:
  - `src/core/task-graph/TaskGraphProcessor.ts` (process() 반환 후 re-map, 내부 미변경)
  - `src/core/rag/` 나머지 파일
  - adapter 실행 경계

## 변경 후 cache 흐름

```text
raw_input
  → F1: findSuccessfulSessionByInputHash (adapter 필터 추가)
       → isSessionCacheValid → CacheValidity
           "auto"   → 즉시 반환
           "advise" → miss + advise 로그 (P1에서 안내 추가 예정)
           "skip"   → miss
  → TaskGraphProcessor.process()
       → tasks.map: hashTaskInputV2 re-map (task.id 제외)
  → 실행 루프 (per task)
       → F2: findSuccessfulTaskByHash (adapter·git_head 필터 추가)
           → isTaskCacheValid → CacheValidity
               "auto"   → markTaskCompleted (stamp 포함)
               "advise" → miss + advise 로그
               "skip"   → miss
       → 실제 실행 성공: markTaskCompleted (stamp 포함)
```

## 핵심 변경

### hash v2 — task.id 제거

```ts
// 이전 (hash.ts 내부)
sha256({ id, type, sentence })   // id = "t1"/"t2"... → 위치 변경 시 전체 hash 깨짐

// 이후 (hashTaskInputV2)
sha256({ projectId, type, normalizedIntent, adapter, adapterModel, detoksMajorVersion })
```

re-map은 orchestrator에서 `process()` 직후 수행한다. `TaskGraphProcessor.ts`는 미변경.

```ts
const rawGraph = TaskGraphProcessor.process(compiledSentences);
const graph = {
  ...rawGraph,
  tasks: rawGraph.tasks.map((task) => ({
    ...task,
    input_hash: hashTaskInputV2({ projectId, type: task.type, normalizedIntent: task.title, ... }),
  })),
};
```

### CacheValidity 3단계 분기

```ts
// 이전
isSessionCacheValid(...): boolean
isTaskCacheValid(...): boolean

// 이후
isSessionCacheValid(...): CacheValidity   // "auto" | "advise" | "skip"
isTaskCacheValid(...): CacheValidity
```

구 세션(stamp 필드 없음)은 `if (expected_adapter && storedAdapter && ...)` 패턴으로 필드 부재 시 비교 없이 통과.

### Stamp 기록

```ts
// initSessionState: shared_context에 기록
{ adapter, adapter_model, git_head }

// markTaskCompleted: task_results[taskId]에 기록
{ adapter, adapter_model, git_head }
```

`git_head`는 `git rev-parse HEAD` 8자리 단축 SHA. git이 없는 환경에서는 기록 생략.

## 테스트 방법

1. 빌드

```bash
npm run build
```

2. 타입 체크

```bash
npx tsc --noEmit
```

3. hash v2 동작 확인 — 같은 파라미터는 같은 hash, id가 달라도 같은 hash

```bash
node -e "
import('./src/core/rag/hash.js').then(({ hashTaskInputV2 }) => {
  const base = { projectId: 'proj', type: 'explore', normalizedIntent: 'run tests', adapter: 'claude', adapterModel: 'claude-3.5-sonnet', detoksMajorVersion: 1 };
  console.log(hashTaskInputV2(base) === hashTaskInputV2(base) ? 'PASS: 동일 hash' : 'FAIL');
});
"
```

4. 관련 단위 테스트

```bash
npm test -- tests/ts/unit/core/cache/cache-validator.test.ts
```

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] `tsc --noEmit` 오류 없음을 확인했습니다
- [ ] 필요한 테스트를 추가/수정했습니다
- [x] 구 세션(stamp 필드 없음) 후방 호환성을 확인했습니다
- [x] Track B(`orchestrator.ts` L547 이하)와 충돌 없음을 확인했습니다
- [x] 리뷰하기 좋은 크기로 커밋을 분리했습니다

## 스크린샷 / 로그

```text
> npx tsc --noEmit

(0 errors)
```

## 커밋 목록

| 커밋 | 내용 |
|------|------|
| `e5b3bf0` | feat(cache): add hashTaskInputV2 — task.id 제거로 F2 hit률 구조적 개선 |
| `a92784b` | feat(cache): CacheValidity 3단계 분기 — auto/advise/skip |
| `89276d4` | feat(cache): orchestrator에 hash v2 re-map 적용 — task.id 의존성 제거 |
| `537b649` | feat(cache): SessionStateManager lookup opts에 adapter·git_head 필터 추가 |
| `9fcd690` | feat(cache): initSessionState·markTaskCompleted에 adapter/git_head stamp 추가 |
| `df99830` | feat(cache): F1 cache block — CacheValidity 3단계 분기 적용 |
| `86dd8f1` | feat(cache): F2 cache block — CacheValidity 3단계 분기 + stamp 전달 |

## 리뷰어 참고사항

- `"advise"` 모드는 P0에서 miss와 동일하게 처리하고 로그만 다르게 찍는다. "유사 결과 발견" 안내 UX는 P1-1에서 추가 예정.
- `DETOKS_MAJOR_VERSION = 1`은 현재 하드코드 상수. major 버전 변경 시 이 값을 업데이트하면 기존 캐시가 자동 무효화된다.
- Track B(`Accounting + Budget Gate + Privacy`)는 `orchestrator.ts` L547 이하를 수정하므로 이 PR과 충돌하지 않는다. Track A PR을 먼저 머지한 뒤 Track B PR을 올리는 순서를 권장한다.
