### PR TITLE
Add token accounting features and privacy enhancements

### DIFF
--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -1,0 +1,105 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { resolveSessionsDir } from "../../core/state/SessionStateManager.js";
+import { getRagVectorDbPath } from "../../core/rag/rag-config.js";
+
+const DISABLED_FLAG_FILE = join(homedir(), ".detoks", "disabled");
+
+export interface MemoryCommandResult {
+  ok: boolean;
+  action: "disable" | "purge-all";
+  message: string;
+}
+
+// detoks memory disable
+// ~/.detoks/disabled 파일을 생성. 다음 실행부터 저장/조회/인덱싱 모두 OFF.
+export async function runMemoryDisableCommand(): Promise<MemoryCommandResult> {
+  try {
+    await fs.mkdir(join(homedir(), ".detoks"), { recursive: true });
+    await fs.writeFile(DISABLED_FLAG_FILE, "", { flag: "w" });
+    return {
+      ok: true,
+      action: "disable",
+      message: `DeToks 메모리 기능이 비활성화되었습니다.\n파일: ${DISABLED_FLAG_FILE}\n재활성화: 파일을 삭제하거나 DETOKS_MEMORY=on 환경 변수를 설정하세요.`,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      action: "disable",
+      message: `비활성화 파일 생성 실패: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+// detoks memory purge --all
+// .state/sessions/*.json + .state/rag/vectors.db 일괄 삭제 (확인 프롬프트 포함).
+export async function runMemoryPurgeAllCommand(opts: {
+  skipConfirm?: boolean;
+} = {}): Promise<MemoryCommandResult> {
+  if (!opts.skipConfirm) {
+    const confirmed = await promptConfirm(
+      "⚠️  .state/sessions/ 전체와 벡터 DB를 영구 삭제합니다. 계속하시겠습니까? (yes/N): ",
+    );
+    if (!confirmed) {
+      return { ok: true, action: "purge-all", message: "취소되었습니다." };
+    }
+  }
+
+  const errors: string[] = [];
+  let deletedCount = 0;
+
+  // 1. session 파일 삭제
+  const sessionsDir = resolveSessionsDir(process.cwd());
+  try {
+    const files = await fs.readdir(sessionsDir);
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        await fs.unlink(join(sessionsDir, file));
+        deletedCount++;
+      } catch (e) {
+        errors.push(`${file}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+  } catch {
+    // sessionsDir이 없으면 그냥 통과
+  }
+
+  // 2. 벡터 DB 삭제
+  try {
+    const dbPath = getRagVectorDbPath(process.cwd());
+    await fs.unlink(dbPath);
+    deletedCount++;
+  } catch {
+    // 벡터 DB가 없으면 통과
+  }
+
+  if (errors.length > 0) {
+    return {
+      ok: false,
+      action: "purge-all",
+      message: `일부 파일 삭제 실패:\n${errors.join("\n")}`,
+    };
+  }
+
+  return {
+    ok: true,
+    action: "purge-all",
+    message: `${deletedCount}개 파일을 삭제했습니다. DeToks 메모리가 초기화되었습니다.`,
+  };
+}
+
+async function promptConfirm(question: string): Promise<boolean> {
+  process.stdout.write(question);
+  return new Promise((resolve) => {
+    let answer = "";
+    process.stdin.setEncoding("utf-8");
+    process.stdin.resume();
+    process.stdin.once("data", (chunk) => {
+      answer = String(chunk).trim().toLowerCase();
+      process.stdin.pause();
+      resolve(answer === "yes" || answer === "y");
+    });
+  });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,7 @@ import { runSessionResetCommand } from "./commands/session-reset.js";
 import { runModelResetCommand } from "./commands/model-reset.js";
 import { runSessionForkCommand } from "./commands/session-fork.js";
 import { runCheckpointRestoreCommand } from "./commands/checkpoint-restore.js";
+import { runMemoryDisableCommand, runMemoryPurgeAllCommand } from "./commands/memory.js";
 import { startRepl } from "./repl/index.js";
 import { colors } from "./colors.js";
 import { runModelSetupIfNeeded } from "./model-setup/index.js";
@@ -147,6 +148,22 @@ const main = async (): Promise<void> => {
     if (!result.ok) {
       process.exitCode = 1;
     }
+    return;
+  }
+
+  if (args.command === "memory-disable") {
+    const result = await runMemoryDisableCommand();
+    console.log(args.human ? result.message : JSON.stringify(result, null, 2));
+    if (!result.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (args.command === "memory-purge-all") {
+    const result = await runMemoryPurgeAllCommand(
+      ...(args.skipConfirm ? [{ skipConfirm: true as const }] : [{}]),
+    );
+    console.log(args.human ? result.message : JSON.stringify(result, null, 2));
+    if (!result.ok) process.exitCode = 1;
     return;
   }
 

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -41,6 +41,8 @@ const CLI_USAGE_MAIN = [
   "  detoks checkpoint list <session-id>",
   "  detoks checkpoint show <checkpoint-id>",
   "  detoks checkpoint restore <checkpoint-id>",
+  "  detoks memory disable                DeToks 메모리 기능 전체 비활성화",
+  "  detoks memory purge --all            세션 파일 및 벡터 DB 일괄 삭제",
   "  detoks repl --help",
   "  detoks --help",
   "",
@@ -652,6 +654,35 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     }
 
     throw new Error(`지원하지 않는 체크포인트 명령입니다. ${topicHelpHint("detoks checkpoint list --help")}, ${topicHelpHint("detoks checkpoint show --help")}, ${topicHelpHint("detoks checkpoint restore --help")}를 확인하세요.`);
+  }
+
+  if (first === "memory") {
+    const sub = positionals[1];
+    if (sub === "disable") {
+      return {
+        mode: "run",
+        adapter,
+        executionMode,
+        verbose,
+        trace,
+        showHelp: false,
+        command: "memory-disable",
+      };
+    }
+    if (sub === "purge") {
+      return {
+        mode: "run",
+        adapter,
+        executionMode,
+        verbose,
+        trace,
+        showHelp: false,
+        command: "memory-purge-all",
+        memoryPurgeAll: argv.includes("--all"),
+        skipConfirm: argv.includes("--yes"),
+      };
+    }
+    throw new Error(`알 수 없는 memory 하위 명령: ${sub ?? "(없음)"}. detoks memory disable | purge --all`);
   }
 
   if (first === "repl") {

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -26,7 +26,9 @@ export interface CliArgs {
     | "model-reset"
     | "checkpoint-list"
     | "checkpoint-show"
-    | "checkpoint-restore";
+    | "checkpoint-restore"
+    | "memory-disable"
+    | "memory-purge-all";
   prompt?: string;
   sessionId?: string;
   newSessionId?: string;
@@ -53,6 +55,8 @@ export interface CliArgs {
     | "checkpoint-list"
     | "checkpoint-show"
     | "checkpoint-restore";
+  memoryPurgeAll?: boolean;
+  skipConfirm?: boolean;
 }
 
 export type NormalizedCliRequest = PipelineExecutionRequest;

--- a/src/core/llm-client/llm-models.ts
+++ b/src/core/llm-client/llm-models.ts
@@ -9,6 +9,8 @@ export interface LLMModelConfig {
     safetyMargin: number;
   };
   maxBatchInputTokens?: number;
+  promptCostPerMillion?: number;      // USD per 1M input tokens
+  completionCostPerMillion?: number;  // USD per 1M output tokens
 }
 
 export const LLM_MODELS: Record<string, LLMModelConfig> = {
@@ -20,6 +22,8 @@ export const LLM_MODELS: Record<string, LLMModelConfig> = {
     tokenEncoderType: 'o200k_base',
     reservedTokens: { systemPrompt: 500, outputBuffer: 4000, safetyMargin: 500 },
     maxBatchInputTokens: 180000,
+    promptCostPerMillion: 3.00,
+    completionCostPerMillion: 15.00,
   },
   'claude-opus': {
     modelName: 'claude-3-opus-20250514',
@@ -28,6 +32,8 @@ export const LLM_MODELS: Record<string, LLMModelConfig> = {
     tokenEncoderType: 'o200k_base',
     reservedTokens: { systemPrompt: 500, outputBuffer: 4000, safetyMargin: 500 },
     maxBatchInputTokens: 180000,
+    promptCostPerMillion: 15.00,
+    completionCostPerMillion: 75.00,
   },
   'claude-haiku': {
     modelName: 'claude-3-haiku-20240307',
@@ -36,6 +42,8 @@ export const LLM_MODELS: Record<string, LLMModelConfig> = {
     tokenEncoderType: 'o200k_base',
     reservedTokens: { systemPrompt: 300, outputBuffer: 1000, safetyMargin: 200 },
     maxBatchInputTokens: 180000,
+    promptCostPerMillion: 0.25,
+    completionCostPerMillion: 1.25,
   },
 
   // ── OpenAI GPT

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
 import { execSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
 import { DAGValidator } from "../task-graph/DAGValidator.js";
 import { DependencyResolver } from "../task-graph/DependencyResolver.js";
 import { ParallelClassifier } from "../task-graph/ParallelClassifier.js";
@@ -109,6 +111,29 @@ async function countPriorSessions(projectId: string | undefined): Promise<number
   } catch {
     return 0;
   }
+}
+
+const NOTICE_SHOWN_FILE = ".state/.detoks-notice-shown";
+
+async function maybeShowFirstRunNotice(cwd: string): Promise<void> {
+  const flagPath = join(cwd, NOTICE_SHOWN_FILE);
+  try {
+    await fs.access(flagPath);
+    return; // 이미 표시했음
+  } catch { /* 파일 없음 → 안내 필요 */ }
+
+  const notice = [
+    "[detoks] DeToks는 실행 메모리를 .state/sessions에 저장합니다.",
+    "[detoks] cross-project store에는 generalize 단계를 거친 익명 패턴만 들어갑니다.",
+    "[detoks] 비활성화: detoks memory disable / 일괄 삭제: detoks memory purge --all",
+  ].join("\n");
+
+  process.stderr.write(`${notice}\n`);
+
+  try {
+    await fs.mkdir(join(cwd, ".state"), { recursive: true });
+    await fs.writeFile(flagPath, new Date().toISOString(), "utf-8");
+  } catch { /* 쓰기 실패는 non-fatal */ }
 }
 
 // git HEAD short SHA (8자). git이 없는 환경이면 undefined.
@@ -523,6 +548,9 @@ export const orchestratePipeline = async (
       request.onProgress(event);
     }
   };
+
+  // 첫 실행 1회 안내 (non-fatal, stderr)
+  await maybeShowFirstRunNotice(request.userRequest.cwd ?? process.cwd());
 
   // projectId / gitHead — F1·F3 cache lookup과 hash v2 re-map에서 공통으로 사용
   const projectId =

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -83,6 +83,34 @@ const DETOKS_MAJOR_VERSION = 1;
 // per-task semantic retrieval 대상 task 타입. execute/validate는 기본 skip.
 const RAG_ELIGIBLE_TYPES = new Set(["explore", "analyze", "debug", "update", "create"]);
 
+// Budget Gate 상수 — 환경변수로 override 가능
+const COLD_START_THRESHOLD = parseInt(process.env.DETOKS_COLD_START_THRESHOLD ?? "5", 10);
+const RAG_BREAK_EVEN_RATIO = parseFloat(process.env.DETOKS_RAG_BREAK_EVEN ?? "0.5");
+const PER_TASK_TOKEN_CAP = parseInt(process.env.DETOKS_RAG_PER_TASK_CAP ?? "250", 10);
+const PER_SESSION_TOKEN_CAP = parseInt(process.env.DETOKS_RAG_PER_SESSION_CAP ?? "500", 10);
+
+function sumCachedTaskTokens(hits: Map<string, Record<string, unknown>>): number {
+  let total = 0;
+  for (const result of hits.values()) {
+    const est = result.token_estimate_total as number | undefined;
+    if (est) total += est;
+  }
+  return total;
+}
+
+async function countPriorSessions(projectId: string | undefined): Promise<number> {
+  try {
+    const sessions = await SessionStateManager.listSessions();
+    if (!projectId) return sessions.length;
+    return sessions.filter((s) => {
+      const pid = (s as unknown as Record<string, unknown>).project_id;
+      return pid === projectId;
+    }).length;
+  } catch {
+    return 0;
+  }
+}
+
 // git HEAD short SHA (8자). git이 없는 환경이면 undefined.
 function resolveGitHead(cwd: string): string | undefined {
   try {
@@ -994,6 +1022,11 @@ export const orchestratePipeline = async (
   }
 
   // ── Step 6: 실행 루프 ────────────────────────────────────────────────────
+  let tokensAddedByRagContext = 0;
+  let tokensSavedByCache = 0;
+  let cacheHitCount = 0;
+  let ragContextInjected = false;
+
   for (const { stage, tasks } of stages) {
     logger.info(`단계 ${stage} 실행 중 — 작업 ${tasks.length}개`);
 
@@ -1069,6 +1102,9 @@ export const orchestratePipeline = async (
 
         if (f2Validity === "auto") {
           const cachedOutput = (cachedTask!.taskResult.raw_output as string) ?? "";
+          const taskTokenEst = (cachedTask!.taskResult.token_estimate_total as number | undefined) ?? 0;
+          tokensSavedByCache += taskTokenEst;
+          cacheHitCount += 1;
           state = markTaskCompleted(state, task.id, cachedOutput, task.type, task, {
             adapter: request.adapter,
             ...(adapterModel ? { adapterModel } : {}),
@@ -1167,7 +1203,30 @@ export const orchestratePipeline = async (
         compiledPrompt.language !== "en"
           ? "Respond entirely in Korean.\n\n"
           : "";
-      const ragContext = formatRagSnippetsForPrompt(perTaskSnippets.get(task.id) ?? []);
+
+      // Budget Gate — per-task ragContext 결정
+      const taskSnippets = perTaskSnippets.get(task.id) ?? [];
+      const ragContextRaw = formatRagSnippetsForPrompt(taskSnippets);
+      const ragTokensForTask = countRagContextTokens(ragContextRaw);
+      let ragContext = "";
+      if (ragContextRaw && ragTokensForTask > 0) {
+        const projectedAdded = tokensAddedByRagContext + ragTokensForTask;
+        const projectedSaved = sumCachedTaskTokens(f2PreScanHits);
+        const sessionCount = await countPriorSessions(
+          state.shared_context.project_id as string | undefined,
+        );
+        const inColdStart = sessionCount < COLD_START_THRESHOLD;
+        const block =
+          projectedAdded > PER_SESSION_TOKEN_CAP ||
+          ragTokensForTask > PER_TASK_TOKEN_CAP ||
+          (!inColdStart && projectedAdded > projectedSaved * RAG_BREAK_EVEN_RATIO);
+        if (!block) {
+          ragContext = ragContextRaw;
+          tokensAddedByRagContext += ragTokensForTask;
+          ragContextInjected = true;
+        }
+      }
+
       const prompt = `${responseLanguageInstruction}${ragContext ? `${ragContext}\n\n` : ""}[${task.type.toUpperCase()}] ${task.title}\n\nContext: ${executionContext.context_summary}`;
       logger.info(`작업 [${task.id}] 실행 중 type=${task.type}`);
       await emitProgressWithLogging( {
@@ -1318,6 +1377,26 @@ export const orchestratePipeline = async (
     }
   }
 
+  // ── Token/Cost Accounting 집계 ────────────────────────────────────────────
+  const tokenAccounting = computeNetTokens(tokensSavedByCache, tokensAddedByRagContext);
+  const costEstimate = computeCostUsd({
+    savedInTokens: tokensSavedByCache,
+    savedOutTokens: 0,
+    addedInTokens: tokensAddedByRagContext,
+    adapter: request.adapter,
+    ...(adapterModel ? { adapterModel } : {}),
+  });
+  const costAccounting: import("../utils/tokenAccounting.js").CostAccounting = {
+    costSavedUsd: costEstimate.costSavedUsd,
+    costAddedUsd: costEstimate.costAddedUsd,
+    compressionCostUsd: 0,
+    netCostSavedUsd: costEstimate.netCostSavedUsd,
+  };
+  const lightQuality: import("../utils/tokenAccounting.js").LightQualityCounters = {
+    ragContextInjected,
+    cacheHitRate: graph.tasks.length > 0 ? cacheHitCount / graph.tasks.length : 0,
+  };
+
   return {
     ok: allOk,
     mode: request.mode,
@@ -1344,5 +1423,8 @@ export const orchestratePipeline = async (
     progressLog,
     ...(resumeHint ? { resumeHint } : {}),
     ...(semanticContext ? { semanticContext } : {}),
+    tokenAccounting,
+    costAccounting,
+    lightQuality,
   };
 };

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -18,9 +18,11 @@ import { translateVisibleText } from "../utils/visibleText.js";
 import {
   buildTokenMetrics,
   buildTokenReductionSnapshot,
+  computeCostUsd,
   type TokenMetricsSnapshot,
   type TokenReductionSnapshot,
 } from "../utils/tokenMetrics.js";
+import { computeNetTokens, countRagContextTokens } from "../utils/tokenAccounting.js";
 import { getLLMModelConfig } from "../llm-client/llm-models.js";
 import { computeProjectId, hashRawInput, hashTaskInputV2 } from "../rag/hash.js";
 import { CACHE_DISABLED, CACHE_TTL_DAYS } from "../cache/cache-config.js";
@@ -77,6 +79,9 @@ function generateSessionId(): string {
 // package.json major 버전 — cache key의 detoksMajorVersion으로 사용.
 // major 버전이 올라갈 때만 기존 캐시가 자동 무효화된다.
 const DETOKS_MAJOR_VERSION = 1;
+
+// per-task semantic retrieval 대상 task 타입. execute/validate는 기본 skip.
+const RAG_ELIGIBLE_TYPES = new Set(["explore", "analyze", "debug", "update", "create"]);
 
 // git HEAD short SHA (8자). git이 없는 환경이면 undefined.
 function resolveGitHead(cwd: string): string | undefined {
@@ -586,47 +591,11 @@ export const orchestratePipeline = async (
     }
   }
 
-  // ── F4~F7: Semantic retrieval (RAG Phase 2A) — BGE-M3 + sqlite-vec ───────
+  // ── F4~F7: 변수 선언 — 실제 retrieval은 DAG 확정 후 (per-task 검색) ──────
   let semanticContext: SemanticContextResult[] | undefined;
-  let ragSnippets: RagSnippet[] = [];
   let ragEmbedder: EmbeddingService | undefined;
   let ragStore: VectorStore | undefined;
-  if (isRagEnabled() && request.executionMode !== "stub") {
-    try {
-      const modelPath = getRagModelPath()!;
-      const cwd = request.userRequest.cwd ?? process.cwd();
-      const dbPath = getRagVectorDbPath(cwd);
-      ragEmbedder = new EmbeddingService(modelPath);
-      await ragEmbedder.init();
-      ragStore = new VectorStore(dbPath, RAG_EMBEDDING_DIMS);
-      ragStore.open();
-      const retriever = new SemanticRetriever(ragStore, ragEmbedder);
-      const hits = await retriever.hybridSearch(request.userRequest.raw_input, 5);
-      if (hits.length > 0) {
-        semanticContext = hits.map((h) => ({
-          id: h.id,
-          distance: h.distance,
-          kind: h.meta.kind as SemanticContextResult["kind"],
-          session_id: h.meta.session_id as string,
-          ...(h.meta.task_id ? { task_id: h.meta.task_id as string } : {}),
-        }));
-        const sessionsDir = resolveSessionsDir(cwd);
-        const loader = new RagContextLoader(sessionsDir);
-        ragSnippets = await loader.load(hits.slice(0, 3));
-        await emitProgressWithLogging({
-          stage: "State Manager",
-          status: "info",
-          message: `RAG: 유사 과거 컨텍스트 ${hits.length}건 발견 (스니펫 ${ragSnippets.length}건 로딩)`,
-        });
-      }
-    } catch (ragErr) {
-      logger.warn(`RAG retrieval 실패 (non-fatal): ${toErrorMessage(ragErr)}`);
-      await ragEmbedder?.dispose().catch(() => {});
-      ragStore?.close();
-      ragEmbedder = undefined;
-      ragStore = undefined;
-    }
-  }
+  const perTaskSnippets = new Map<string, RagSnippet[]>();
 
   // ── Step 1: Prompt compile + Role 2.1 handoff 생성 (Role 1) ──────────────
   let compiledPrompt;
@@ -887,6 +856,80 @@ export const orchestratePipeline = async (
     message: "State Manager: 세션 상태 준비 완료",
   });
 
+  // ── [E0] F2 pre-scan + F4~F7: per-task semantic retrieval ────────────────
+  // DAG가 확정된 뒤 실행 필요 task를 먼저 파악하고, 그 task에만 RAG 검색을 수행한다.
+  const f2PreScanHits = new Map<string, Record<string, unknown>>();
+  const tasksNeedingExecution: typeof graph.tasks = [];
+  if (!request.noCache && !CACHE_DISABLED && request.executionMode !== "stub") {
+    const prescanProjectId = state.shared_context.project_id as string | undefined;
+    for (const task of graph.tasks) {
+      if (!task.input_hash) { tasksNeedingExecution.push(task); continue; }
+      const cachedTask = await SessionStateManager.findSuccessfulTaskByHash(
+        task.input_hash,
+        {
+          ...(prescanProjectId ? { project_id: prescanProjectId } : {}),
+          recencyDays: CACHE_TTL_DAYS,
+          adapter: request.adapter,
+          ...(gitHead ? { git_head: gitHead } : {}),
+        },
+      );
+      if (cachedTask) {
+        f2PreScanHits.set(task.id, cachedTask.taskResult);
+      } else {
+        tasksNeedingExecution.push(task);
+      }
+    }
+  } else {
+    tasksNeedingExecution.push(...graph.tasks);
+  }
+
+  if (isRagEnabled() && request.executionMode !== "stub" && tasksNeedingExecution.length > 0) {
+    try {
+      const modelPath = getRagModelPath()!;
+      const cwd = request.userRequest.cwd ?? process.cwd();
+      const dbPath = getRagVectorDbPath(cwd);
+      ragEmbedder = new EmbeddingService(modelPath);
+      await ragEmbedder.init();
+      ragStore = new VectorStore(dbPath, RAG_EMBEDDING_DIMS);
+      ragStore.open();
+      const retriever = new SemanticRetriever(ragStore, ragEmbedder);
+      const sessionsDir = resolveSessionsDir(cwd);
+      const loader = new RagContextLoader(sessionsDir);
+
+      for (const task of tasksNeedingExecution) {
+        if (!RAG_ELIGIBLE_TYPES.has(task.type)) continue;
+        const queryText = `${task.type} ${task.title}`;
+        const hits = await retriever.hybridSearch(queryText, 5);
+        if (hits.length > 0) {
+          semanticContext = hits.map((h) => ({
+            id: h.id,
+            distance: h.distance,
+            kind: h.meta.kind as SemanticContextResult["kind"],
+            session_id: h.meta.session_id as string,
+            ...(h.meta.task_id ? { task_id: h.meta.task_id as string } : {}),
+          }));
+          const snippets = await loader.load(hits.slice(0, 1));
+          if (snippets.length > 0) perTaskSnippets.set(task.id, snippets);
+        }
+      }
+
+      const totalSnippets = Array.from(perTaskSnippets.values()).reduce((s, v) => s + v.length, 0);
+      if (totalSnippets > 0) {
+        await emitProgressWithLogging({
+          stage: "State Manager",
+          status: "info",
+          message: `RAG: ${tasksNeedingExecution.length}개 task 중 ${perTaskSnippets.size}개 task에 과거 컨텍스트 발견`,
+        });
+      }
+    } catch (ragErr) {
+      logger.warn(`RAG retrieval 실패 (non-fatal): ${toErrorMessage(ragErr)}`);
+      await ragEmbedder?.dispose().catch(() => {});
+      ragStore?.close();
+      ragEmbedder = undefined;
+      ragStore = undefined;
+    }
+  }
+
   // ── F8~F14: 프로젝트별 패턴 학습 (non-fatal) ─────────────────────────────
   if (request.executionMode !== "stub") {
     const cwd = request.userRequest.cwd ?? process.cwd();
@@ -1124,7 +1167,7 @@ export const orchestratePipeline = async (
         compiledPrompt.language !== "en"
           ? "Respond entirely in Korean.\n\n"
           : "";
-      const ragContext = formatRagSnippetsForPrompt(ragSnippets);
+      const ragContext = formatRagSnippetsForPrompt(perTaskSnippets.get(task.id) ?? []);
       const prompt = `${responseLanguageInstruction}${ragContext ? `${ragContext}\n\n` : ""}[${task.type.toUpperCase()}] ${task.title}\n\nContext: ${executionContext.context_summary}`;
       logger.info(`작업 [${task.id}] 실행 중 type=${task.type}`);
       await emitProgressWithLogging( {

--- a/src/core/pipeline/types.ts
+++ b/src/core/pipeline/types.ts
@@ -7,6 +7,7 @@ import type { PtyTranscript } from "../../integrations/subprocess/types.js";
 import type { PtyEvent } from "../../integrations/subprocess/types.js";
 import type { ActionTimelineEvent, ActionTimelineSink } from "../timeline/types.js";
 import type { TokenReductionSnapshot } from "../utils/tokenMetrics.js";
+import type { TokenAccounting, CostAccounting, LightQualityCounters } from "../utils/tokenAccounting.js";
 
 export const AdapterValues = ["codex", "gemini", "claude"] as const;
 export type Adapter = (typeof AdapterValues)[number];
@@ -118,4 +119,7 @@ export interface PipelineExecutionResult {
   cacheHit?: CacheHitInfo;
   resumeHint?: ResumeHintInfo;
   semanticContext?: SemanticContextResult[];
+  tokenAccounting?: TokenAccounting;
+  costAccounting?: CostAccounting;
+  lightQuality?: LightQualityCounters;
 }

--- a/src/core/utils/tokenAccounting.ts
+++ b/src/core/utils/tokenAccounting.ts
@@ -1,0 +1,44 @@
+import { countTokens } from "./tokenMetrics.js";
+
+// Token Safety Rule: net = saved_by_cache - added_by_rag - added_by_hints - added_by_compression
+// net이 음수일 수 있다는 사실을 명시적으로 인정하는 구조.
+
+export interface TokenAccounting {
+  tokensSavedByCache: number;
+  tokensAddedByRagContext: number;
+  tokensAddedByPatternHints: number;
+  tokensAddedByCompression: number;
+  netTokensSaved: number;
+}
+
+export interface CostAccounting {
+  costSavedUsd: number;
+  costAddedUsd: number;
+  compressionCostUsd: number;
+  netCostSavedUsd: number;
+}
+
+export interface LightQualityCounters {
+  ragContextInjected: boolean;
+  cacheHitRate: number;
+}
+
+export function computeNetTokens(
+  saved: number,
+  addedRag: number,
+  addedHints = 0,
+  addedCompression = 0,
+): TokenAccounting {
+  return {
+    tokensSavedByCache: saved,
+    tokensAddedByRagContext: addedRag,
+    tokensAddedByPatternHints: addedHints,
+    tokensAddedByCompression: addedCompression,
+    netTokensSaved: saved - addedRag - addedHints - addedCompression,
+  };
+}
+
+export function countRagContextTokens(ragContextText: string): number {
+  if (!ragContextText) return 0;
+  return countTokens(ragContextText);
+}

--- a/src/core/utils/tokenMetrics.ts
+++ b/src/core/utils/tokenMetrics.ts
@@ -1,4 +1,6 @@
 import { get_encoding } from "tiktoken";
+import type { LLMModelConfig } from "../llm-client/llm-models.js";
+import { LLM_MODELS } from "../llm-client/llm-models.js";
 
 export const TOKEN_METRIC_MODEL = "o200k_base" as const;
 
@@ -124,4 +126,38 @@ export function formatTokenReductionSnapshot(
     `→ ${formatCount(reduction.optimizedTokens)}토큰`,
     `(절감 ${formatCount(reduction.savedTokens)}토큰, ${reduction.savedPercent.toFixed(1)}%)`,
   ].join(" ");
+}
+
+// ── USD 비용 계산 ─────────────────────────────────────────────────────────────
+
+export interface CostEstimate {
+  costSavedUsd: number;
+  costAddedUsd: number;
+  netCostSavedUsd: number;
+}
+
+function resolveModelConfig(adapter: string, adapterModel?: string): LLMModelConfig | undefined {
+  const key = adapterModel ?? adapter;
+  return LLM_MODELS[key] ?? Object.values(LLM_MODELS).find((m) => m.provider === adapter);
+}
+
+export function computeCostUsd(params: {
+  savedInTokens: number;
+  savedOutTokens: number;
+  addedInTokens: number;
+  adapter: string;
+  adapterModel?: string;
+}): CostEstimate {
+  const config = resolveModelConfig(params.adapter, params.adapterModel);
+  if (!config) {
+    return { costSavedUsd: 0, costAddedUsd: 0, netCostSavedUsd: 0 };
+  }
+
+  const priceIn = config.promptCostPerMillion ?? 0;
+  const priceOut = config.completionCostPerMillion ?? 0;
+
+  const costSavedUsd = (params.savedInTokens * priceIn + params.savedOutTokens * priceOut) / 1_000_000;
+  const costAddedUsd = (params.addedInTokens * priceIn) / 1_000_000;
+
+  return { costSavedUsd, costAddedUsd, netCostSavedUsd: costSavedUsd - costAddedUsd };
 }


### PR DESCRIPTION
## 요약

- `tokenAccounting.ts` 신규 생성 — `TokenAccounting`, `CostAccounting`, `LightQualityCounters` 인터페이스 + `computeNetTokens()`, `countRagContextTokens()` 함수
- `llm-models.ts`에 `promptCostPerMillion?`, `completionCostPerMillion?` 단가 필드 추가, Anthropic 3개 모델 단가 채움
- `tokenMetrics.ts`에 `computeCostUsd()` 추가 — adapter 이름으로 llm-models 단가를 동적 lookup
- `PipelineExecutionResult`에 `tokenAccounting`, `costAccounting`, `lightQuality` optional 필드 추가
- RAG Stage B를 DAG 확정 후로 이동 — F2 pre-scan으로 실행 필요 task를 먼저 파악하고, `RAG_ELIGIBLE_TYPES` task에만 per-task 검색 수행 (`perTaskSnippets` Map)
- Budget Gate 삽입 — per-task ragContext 차단 (`PER_TASK_TOKEN_CAP`/`PER_SESSION_TOKEN_CAP`/`RAG_BREAK_EVEN_RATIO`), 환경변수 override 지원
- F2 hit 시 `tokensSavedByCache` 누적, 실행 루프 종료 후 `tokenAccounting`/`costAccounting`/`lightQuality` 집계 후 반환
- `src/cli/commands/memory.ts` 신규 — `detoks memory disable` (flag 파일 생성), `detoks memory purge --all` (세션 + 벡터 DB 삭제)
- `types.ts`/`parse.ts`/`index.ts` — memory 커맨드 라우팅 추가, usage 문자열 2줄 추가
- `maybeShowFirstRunNotice()` — 첫 실행 1회 stderr 안내, `.state/.detoks-notice-shown` 플래그로 중복 방지

## 관련 이슈

- Closes #248 

## 변경 유형

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩터링
- [ ] 문서 수정
- [ ] 테스트 추가/수정

## 영향 범위

- 영향받는 모듈:
  - `src/core/utils/tokenAccounting.ts` (신규)
  - `src/core/utils/tokenMetrics.ts`
  - `src/core/llm-client/llm-models.ts`
  - `src/core/pipeline/types.ts`
  - `src/core/pipeline/orchestrator.ts`
  - `src/cli/commands/memory.ts` (신규)
  - `src/cli/types.ts`
  - `src/cli/parse.ts`
  - `src/cli/index.ts`
- 영향받지 않는 모듈:
  - `src/core/cache/cache-validator.ts` (Track A 담당)
  - `src/core/rag/hash.ts` (Track A 담당)
  - `src/core/task-graph/TaskGraphProcessor.ts`
  - adapter 실행 경계

## 변경 후 RAG + Accounting 흐름

```text
raw_input
  → F1: session cache (Track A)
  → TaskGraphProcessor.process() + hash v2 re-map (Track A)
  → initSessionState / applyProjectInfo
  → state.task_graph = graph
  → [E0] F2 pre-scan — f2PreScanHits Map + tasksNeedingExecution 확정
  → F4~F7: tasksNeedingExecution × RAG_ELIGIBLE_TYPES → perTaskSnippets Map
  → 실행 루프 (per task)
       → F2 task cache (Track A):
           hit → tokensSavedByCache 누적, cacheHitCount++, continue
       → Budget Gate:
           taskSnippets = perTaskSnippets.get(task.id)
           ragTokens 계산 → 조건 충족 시 ragContext 차단
           통과 시 → ragContext 주입, tokensAddedByRagContext 누적
       → adapter 실행
  → 루프 종료: computeNetTokens / computeCostUsd / lightQuality 집계
  → return { tokenAccounting, costAccounting, lightQuality, ... }
```

## 핵심 변경

### RAG Stage B 이동 — per-task 검색

```ts
// 이전: DAG 생성 전, raw_input 1회 검색 → 모든 task에 같은 snippets
const hits = await retriever.hybridSearch(request.userRequest.raw_input, 5);
ragSnippets = await loader.load(hits.slice(0, 3));

// 이후: DAG 확정 후, 실행 필요 task별 검색
for (const task of tasksNeedingExecution) {
  if (!RAG_ELIGIBLE_TYPES.has(task.type)) continue;
  const hits = await retriever.hybridSearch(`${task.type} ${task.title}`, 5);
  if (hits.length > 0) perTaskSnippets.set(task.id, snippets);
}
```

### Budget Gate

```ts
const block =
  projectedAdded > PER_SESSION_TOKEN_CAP || // 세션 누적 상한
  ragTokensForTask > PER_TASK_TOKEN_CAP || // task 단위 상한
  (!inColdStart && projectedAdded > projectedSaved * RAG_BREAK_EVEN_RATIO); // 손익분기

if (!block) {
  ragContext = ragContextRaw;
  tokensAddedByRagContext += ragTokensForTask;
}
```

cold start(`sessionCount < COLD_START_THRESHOLD = 5`)에서는 손익분기 조건을 적용하지 않는다.

### Privacy CLI

```bash
detoks memory disable        # ~/.detoks/disabled 생성
detoks memory purge --all    # .state/sessions/*.json + 벡터 DB 삭제
detoks memory purge --all --yes  # 확인 생략 (테스트/스크립트용)
```

### 첫 실행 안내

```text
[detoks] DeToks는 실행 메모리를 .state/sessions에 저장합니다.
[detoks] cross-project store에는 generalize 단계를 거친 익명 패턴만 들어갑니다.
[detoks] 비활성화: detoks memory disable / 일괄 삭제: detoks memory purge --all
```

## 테스트 방법

1. 빌드

```bash
npm run build
```

2. 타입 체크

```bash
npx tsc --noEmit
```

3. Budget Gate 동작 확인 — task당 허용 토큰을 1로 낮춰 차단 검증

```bash
DETOKS_RAG_PER_TASK_CAP=1 detoks run "run tests"
# ragContext가 빈 문자열로 차단되는지 확인
```

4. memory 커맨드 확인

```bash
detoks memory disable
# → ~/.detoks/disabled 파일 생성 확인

detoks memory purge --all --yes
# → .state/sessions/*.json 삭제 확인
```

5. 첫 실행 안내 확인

```bash
rm -f .state/.detoks-notice-shown
detoks run "hello"  # stderr에 안내 출력
detoks run "hello"  # 두 번째 실행에서는 출력 없음
```

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] `tsc --noEmit` 오류 없음을 확인했습니다
- [ ] 필요한 테스트를 추가/수정했습니다
- [x] RAG_ELIGIBLE_TYPES에 해당하지 않는 task는 ragContext 없이 실행됨을 확인했습니다
- [x] 벡터 DB 없는 환경에서도 Budget Gate가 예외 없이 통과됨을 확인했습니다 (non-fatal)
- [x] Track A(`cache-validator.ts`, `hash.ts`) 파일을 수정하지 않았습니다
- [x] 리뷰하기 좋은 크기로 커밋을 분리했습니다

## 스크린샷 / 로그

```text
> npx tsc --noEmit

(0 errors)
```

## 커밋 목록

| 커밋      | 내용                                                                                              |
| --------- | ------------------------------------------------------------------------------------------------- |
| `a57a352` | feat(accounting): tokenAccounting.ts 신규 — TokenAccounting/CostAccounting/LightQualityCounters   |
| `8572912` | feat(accounting): llm-models에 USD 단가 필드 추가 + tokenMetrics에 computeCostUsd 함수 추가       |
| `b2115b6` | feat(accounting): PipelineExecutionResult에 tokenAccounting/costAccounting/lightQuality 필드 추가 |
| `73dfa04` | feat(rag): RAG Stage B 이동 — DAG 확정 후 per-task semantic retrieval로 전환 (F2 pre-scan 포함)   |
| `4b57c55` | feat(accounting): Budget Gate + Token/Cost Accounting — per-task RAG 차단, 절감/추가 토큰 집계    |
| `5f45368` | feat(privacy): memory.ts 신규 — detoks memory disable / purge --all 커맨드 구현                   |
| `c0ff24d` | feat(privacy): CLI memory 커맨드 라우팅 — memory-disable / memory-purge-all                       |
| `ffa29ab` | feat(privacy): orchestrator에 첫 실행 1회 안내 추가 (maybeShowFirstRunNotice, stderr, non-fatal)  |

## 리뷰어 참고사항

- Budget Gate 상수(`PER_TASK_TOKEN_CAP=250`, `PER_SESSION_TOKEN_CAP=500`, `RAG_BREAK_EVEN_RATIO=0.5`)는 환경변수로 override 가능하다. 실 운영 데이터가 쌓이면 P1에서 조정 예정.
- `COLD_START_THRESHOLD=5` — 세션이 5개 미만인 초기 상태에서는 손익분기 조건을 적용하지 않아 RAG가 더 적극적으로 활성화된다.
- `costAccounting`의 `compressionCostUsd`는 현재 0 (로컬 임베딩 모델 사용). 외부 LLM compressor 도입 시 양수가 될 수 있다.
- Track A PR(`cache-validator.ts` / `hash v2`)을 먼저 머지한 뒤 이 PR을 올리는 순서를 권장한다.
