### PR TITLE
Implement memory disable features and improve RAG handling

### DIFF
--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -937,7 +937,7 @@ export const orchestratePipeline = async (
   // DAG가 확정된 뒤 실행 필요 task를 먼저 파악하고, 그 task에만 RAG 검색을 수행한다.
   const f2PreScanHits = new Map<string, Record<string, unknown>>();
   const tasksNeedingExecution: typeof graph.tasks = [];
-  if (!request.noCache && !CACHE_DISABLED && request.executionMode !== "stub") {
+  if (!request.noCache && !CACHE_DISABLED && !memoryDisabled && request.executionMode !== "stub") {
     const prescanProjectId = state.shared_context.project_id as string | undefined;
     for (const task of graph.tasks) {
       if (!task.input_hash) { tasksNeedingExecution.push(task); continue; }

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -975,18 +975,19 @@ export const orchestratePipeline = async (
       const sessionsDir = resolveSessionsDir(cwd);
       const loader = new RagContextLoader(sessionsDir);
 
+      if (!semanticContext) semanticContext = [];
       for (const task of tasksNeedingExecution) {
         if (!RAG_ELIGIBLE_TYPES.has(task.type)) continue;
         const queryText = `${task.type} ${task.title}`;
         const hits = await retriever.hybridSearch(queryText, 5);
         if (hits.length > 0) {
-          semanticContext = hits.map((h) => ({
+          semanticContext.push(...hits.map((h) => ({
             id: h.id,
             distance: h.distance,
             kind: h.meta.kind as SemanticContextResult["kind"],
             session_id: h.meta.session_id as string,
             ...(h.meta.task_id ? { task_id: h.meta.task_id as string } : {}),
-          }));
+          })));
           const snippets = await loader.load(hits.slice(0, 1));
           if (snippets.length > 0) perTaskSnippets.set(task.id, snippets);
         }

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1008,7 +1008,7 @@ export const orchestratePipeline = async (
   }
 
   // ── F8~F14: 프로젝트별 패턴 학습 (non-fatal) ─────────────────────────────
-  if (request.executionMode !== "stub") {
+  if (request.executionMode !== "stub" && !memoryDisabled) {
     const cwd = request.userRequest.cwd ?? process.cwd();
     const sessionsDir = resolveSessionsDir(cwd);
     const projectId = state.shared_context.project_id as string | undefined;

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -25,6 +25,7 @@ import {
   type TokenReductionSnapshot,
 } from "../utils/tokenMetrics.js";
 import { computeNetTokens, countRagContextTokens } from "../utils/tokenAccounting.js";
+import { countTokens } from "../utils/tokenMetrics.js";
 import { getLLMModelConfig } from "../llm-client/llm-models.js";
 import { computeProjectId, hashRawInput, hashTaskInputV2 } from "../rag/hash.js";
 import { CACHE_DISABLED, CACHE_TTL_DAYS } from "../cache/cache-config.js";
@@ -222,6 +223,7 @@ function markTaskCompleted(
   taskType?: string,
   task?: { title?: string; input_hash?: string; depends_on?: string[] },
   stamp: { adapter?: string; adapterModel?: string; gitHead?: string } = {},
+  tokenEstimateTotal?: number,
 ): SessionState {
   const now = new Date().toISOString();
   return {
@@ -241,6 +243,7 @@ function markTaskCompleted(
         ...(stamp.adapter ? { adapter: stamp.adapter } : {}),
         ...(stamp.adapterModel ? { adapter_model: stamp.adapterModel } : {}),
         ...(stamp.gitHead ? { git_head: stamp.gitHead } : {}),
+        ...(tokenEstimateTotal !== undefined ? { token_estimate_total: tokenEstimateTotal } : {}),
       },
     },
     updated_at: now,
@@ -1321,11 +1324,12 @@ export const orchestratePipeline = async (
           message: `Executor(${task.id}) 완료`,
         });
         failedTaskIds.delete(task.id);
+        const taskTokenEstimate = countTokens(prompt) + countTokens(execResult.rawOutput);
         state = markTaskCompleted(state, task.id, execResult.rawOutput, task.type, task, {
           adapter: request.adapter,
           ...(adapterModel ? { adapterModel } : {}),
           ...(gitHead ? { gitHead } : {}),
-        });
+        }, taskTokenEstimate);
         state = applySessionTokenMetrics(
           state,
           request.userRequest.raw_input,

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -564,14 +564,16 @@ export const orchestratePipeline = async (
     }
   };
 
-  // 첫 실행 1회 안내 (non-fatal, stderr)
-  await maybeShowFirstRunNotice(request.userRequest.cwd ?? process.cwd());
-
   // ~/.detoks/disabled 또는 DETOKS_MEMORY=off 시 저장/조회/인덱싱 전체 비활성화
   const memoryDisabled = await isMemoryDisabled();
   const saveSessionIfEnabled = async (s: SessionState) => {
     if (!memoryDisabled) await SessionStateManager.saveSession(s);
   };
+
+  // 첫 실행 1회 안내 (non-fatal, stderr) — 메모리 비활성화 상태면 표시하지 않음
+  if (!memoryDisabled) {
+    await maybeShowFirstRunNotice(request.userRequest.cwd ?? process.cwd());
+  }
 
   // projectId / gitHead — F1·F3 cache lookup과 hash v2 re-map에서 공통으로 사용
   const projectId =

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { execSync } from "node:child_process";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
+import { homedir } from "node:os";
 import { DAGValidator } from "../task-graph/DAGValidator.js";
 import { DependencyResolver } from "../task-graph/DependencyResolver.js";
 import { ParallelClassifier } from "../task-graph/ParallelClassifier.js";
@@ -111,6 +112,17 @@ async function countPriorSessions(projectId: string | undefined): Promise<number
     }).length;
   } catch {
     return 0;
+  }
+}
+
+// ~/.detoks/disabled 파일 또는 DETOKS_MEMORY=off 환경변수가 있으면 저장/조회/인덱싱 전체 비활성화.
+async function isMemoryDisabled(): Promise<boolean> {
+  if (process.env.DETOKS_MEMORY === "off" || process.env.DETOKS_MEMORY === "0") return true;
+  try {
+    await fs.access(join(homedir(), ".detoks", "disabled"));
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -555,6 +567,12 @@ export const orchestratePipeline = async (
   // 첫 실행 1회 안내 (non-fatal, stderr)
   await maybeShowFirstRunNotice(request.userRequest.cwd ?? process.cwd());
 
+  // ~/.detoks/disabled 또는 DETOKS_MEMORY=off 시 저장/조회/인덱싱 전체 비활성화
+  const memoryDisabled = await isMemoryDisabled();
+  const saveSessionIfEnabled = async (s: SessionState) => {
+    if (!memoryDisabled) await SessionStateManager.saveSession(s);
+  };
+
   // projectId / gitHead — F1·F3 cache lookup과 hash v2 re-map에서 공통으로 사용
   const projectId =
     request.projectInfo?.projectId ??
@@ -563,7 +581,7 @@ export const orchestratePipeline = async (
 
   // ── F1: Cross-session input_hash cache bypass ────────────────────────────
   // stub 모드는 테스트/개발용이므로 캐시 우회 대상에서 제외
-  if (!request.noCache && !CACHE_DISABLED && request.executionMode !== "stub") {
+  if (!request.noCache && !CACHE_DISABLED && !memoryDisabled && request.executionMode !== "stub") {
     const inputHash = hashRawInput(request.userRequest.raw_input);
     const cachedSession = await SessionStateManager.findSuccessfulSessionByInputHash(
       inputHash,
@@ -629,7 +647,7 @@ export const orchestratePipeline = async (
 
   // ── F3: 미완성 세션 resume 힌트 ──────────────────────────────────────────
   let resumeHint: ResumeHintInfo | undefined;
-  if (!request.noCache && !CACHE_DISABLED && request.executionMode !== "stub") {
+  if (!request.noCache && !CACHE_DISABLED && !memoryDisabled && request.executionMode !== "stub") {
     const inputHash = hashRawInput(request.userRequest.raw_input);
     const incompleteSession = await SessionStateManager.findIncompleteSessionByInputHash(
       inputHash,
@@ -1091,7 +1109,7 @@ export const orchestratePipeline = async (
           request.userRequest.raw_input,
           compiledPrompt.compressed_prompt,
         ).state;
-        await SessionStateManager.saveSession(state);
+        await saveSessionIfEnabled(state);
         taskRecords.push({ taskId: task.id, status: "skipped", rawOutput: "", blockedBy });
         await PipelineTracer.trace({
           sessionId, stage: `Executor:${task.id}`, role: "role3", phase: "output",
@@ -1113,7 +1131,7 @@ export const orchestratePipeline = async (
       }
 
       // F2: Task-level input_hash cache bypass (stub 모드 제외)
-      if (!request.noCache && !CACHE_DISABLED && request.executionMode !== "stub" && task.input_hash) {
+      if (!request.noCache && !CACHE_DISABLED && !memoryDisabled && request.executionMode !== "stub" && task.input_hash) {
         const f2ProjectId = state.shared_context.project_id as string | undefined;
         const cachedTask = await SessionStateManager.findSuccessfulTaskByHash(
           task.input_hash,
@@ -1146,7 +1164,7 @@ export const orchestratePipeline = async (
             request.userRequest.raw_input,
             compiledPrompt.compressed_prompt,
           ).state;
-          await SessionStateManager.saveSession(state);
+          await saveSessionIfEnabled(state);
           taskRecords.push({ taskId: task.id, status: "completed", rawOutput: cachedOutput });
           await emitActionTimelineWithLogging(
             createActionTimelineEvent({
@@ -1296,7 +1314,7 @@ export const orchestratePipeline = async (
           request.userRequest.raw_input,
           compiledPrompt.compressed_prompt,
         ).state;
-        await SessionStateManager.saveSession(state);
+        await saveSessionIfEnabled(state);
         taskRecords.push({ taskId: task.id, status: "failed", rawOutput: execResult.rawOutput });
         await PipelineTracer.trace({
           sessionId, stage: `Executor:${task.id}`, role: "role3", phase: "output",
@@ -1341,7 +1359,7 @@ export const orchestratePipeline = async (
           taskId: task.id,
           message: `State Manager(${task.id}) 저장 중`,
         });
-        await SessionStateManager.saveSession(state);
+        await saveSessionIfEnabled(state);
         await emitProgressWithLogging( {
           stage: "State Manager",
           status: "end",
@@ -1389,7 +1407,7 @@ export const orchestratePipeline = async (
     status: "start",
     message: "State Manager: 최종 세션 저장 중",
   });
-  await SessionStateManager.saveSession(state);
+  await saveSessionIfEnabled(state);
   await emitProgressWithLogging( {
     stage: "State Manager",
     status: "end",
@@ -1397,7 +1415,7 @@ export const orchestratePipeline = async (
   });
 
   // ── RAG indexing: 완료된 세션을 벡터 DB에 인덱싱 ─────────────────────────
-  if (ragEmbedder && ragStore) {
+  if (ragEmbedder && ragStore && !memoryDisabled) {
     try {
       const indexer = new EmbeddingIndexer(ragStore, ragEmbedder);
       await indexer.indexSession(state as any);

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -960,7 +960,7 @@ export const orchestratePipeline = async (
     tasksNeedingExecution.push(...graph.tasks);
   }
 
-  if (isRagEnabled() && request.executionMode !== "stub" && tasksNeedingExecution.length > 0) {
+  if (isRagEnabled() && !memoryDisabled && request.executionMode !== "stub" && tasksNeedingExecution.length > 0) {
     try {
       const modelPath = getRagModelPath()!;
       const cwd = request.userRequest.cwd ?? process.cwd();


### PR DESCRIPTION
## 요약

- `markTaskCompleted`에 `token_estimate_total` 저장 추가 — F2 cache hit 시 `tokensSavedByCache`가 항상 0이던 회계 버그 수정
- `detoks memory disable`의 실제 적용 완성 — F1/F3/F2-loop cache lookup, `saveSession` 5곳, `indexSession` 전부에 `!memoryDisabled` 게이트 연결
- F2 pre-scan에 `!memoryDisabled` 추가 — 비활성화 시 pre-scan이 잘못 `tasksNeedingExecution`을 제외해 cache도 안 되고 RAG도 없는 최악 상태를 만들던 버그 수정
- RAG 검색에 `!memoryDisabled` 추가 — 비활성화 상태에서도 구 세션 벡터 DB를 조회하던 정책 위반 수정
- F8~F14 패턴 마이닝에 `!memoryDisabled` 추가 — 비활성화 상태에서도 구 세션 파일 읽어 emit하던 정책 위반 수정
- `maybeShowFirstRunNotice`를 `isMemoryDisabled()` 이후로 이동 — 비활성화 상태에서 "메모리를 저장합니다" 안내가 뜨던 문제 해소
- `semanticContext` 덮어쓰기 → `push` 누적으로 변경 — 여러 task에 RAG 적용 시 마지막 task 결과만 남던 버그 수정

## 관련 이슈

- Closes #250 

## 변경 유형

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [ ] 테스트 추가/수정

## 영향 범위

- 영향받는 모듈:
  - `src/core/pipeline/orchestrator.ts` (7곳 수정)
- 영향받지 않는 모듈:
  - `src/core/utils/tokenAccounting.ts`
  - `src/core/utils/tokenMetrics.ts`
  - `src/core/llm-client/llm-models.ts`
  - `src/core/pipeline/types.ts`
  - `src/cli/commands/memory.ts`
  - `src/cli/types.ts` / `parse.ts` / `index.ts`

## 수정 내역 상세

### Gap 1 — `token_estimate_total` 저장

```ts
// 이전: markTaskCompleted에 token_estimate_total 저장 없음
// → F2 hit 시 cachedTask.taskResult.token_estimate_total = undefined → 0
// → tokensSavedByCache 항상 0

// 이후: 실행 완료 직후 prompt + output 토큰 합산 후 저장
const taskTokenEstimate = countTokens(prompt) + countTokens(execResult.rawOutput);
state = markTaskCompleted(state, task.id, execResult.rawOutput, task.type, task, stamp, taskTokenEstimate);
// task_results[task.id].token_estimate_total = taskTokenEstimate
```

### Gap 2 — `detoks memory disable` 실제 적용

```ts
// 이전: isMemoryDisabled() / saveSessionIfEnabled 선언만 있고 실제 호출부는 그대로
await SessionStateManager.saveSession(state); // ×5곳

// 이후: F1/F3/F2-loop 조건 + saveSession 5곳 + indexSession 게이팅
if (!request.noCache && !CACHE_DISABLED && !memoryDisabled && ...) { /* F1 */ }
if (!request.noCache && !CACHE_DISABLED && !memoryDisabled && ...) { /* F3 */ }
if (!request.noCache && !CACHE_DISABLED && !memoryDisabled && ... && task.input_hash) { /* F2 loop */ }
await saveSessionIfEnabled(state); // ×5곳
if (ragEmbedder && ragStore && !memoryDisabled) { /* indexSession */ }
```

### Bug 1 — F2 pre-scan `!memoryDisabled`

```ts
// 이전
if (!request.noCache && !CACHE_DISABLED && request.executionMode !== "stub") {

// 이후
if (!request.noCache && !CACHE_DISABLED && !memoryDisabled && request.executionMode !== "stub") {
```

비활성화 시 모든 task가 `tasksNeedingExecution`에 포함되어 RAG 검색 대상이 된다. `f2PreScanHits`가 Budget Gate에 잘못 사용되는 문제도 해소된다.

### Bug 2 — RAG 검색 `!memoryDisabled`

```ts
// 이전
if (isRagEnabled() && request.executionMode !== "stub" && tasksNeedingExecution.length > 0) {

// 이후
if (isRagEnabled() && !memoryDisabled && request.executionMode !== "stub" && tasksNeedingExecution.length > 0) {
```

### Bug 3 — F8~F14 패턴 마이닝 `!memoryDisabled`

```ts
// 이전
if (request.executionMode !== "stub") {

// 이후
if (request.executionMode !== "stub" && !memoryDisabled) {
```

### 이슈 4 — `maybeShowFirstRunNotice` 순서 조정

```ts
// 이전: isMemoryDisabled() 계산 전에 안내 출력
await maybeShowFirstRunNotice(...);
const memoryDisabled = await isMemoryDisabled();

// 이후: 비활성화 상태에서는 안내 생략
const memoryDisabled = await isMemoryDisabled();
if (!memoryDisabled) {
  await maybeShowFirstRunNotice(...);
}
```

### 이슈 5 — `semanticContext` 누적

```ts
// 이전: 루프마다 재할당 → 마지막 task 결과만 남음
semanticContext = hits.map((h) => ({ ... }));

// 이후: push로 누적
if (!semanticContext) semanticContext = [];
semanticContext.push(...hits.map((h) => ({ ... })));
```

## 테스트 방법

1. 타입 체크

```bash
npx tsc --noEmit
```

2. `token_estimate_total` 저장 확인 — 같은 input을 두 번 실행해 F2 hit 발생 후 `tokenAccounting.tokensSavedByCache > 0` 확인

```bash
detoks run "run unit tests"
detoks run "run unit tests"   # F2 hit — tokensSavedByCache가 0이 아님
```

3. memory disable 완전 동작 확인

```bash
detoks memory disable

detoks run "hello"
# .state/sessions/ 에 새 파일이 생기지 않음
# [detoks] DeToks는 실행 메모리를... 안내가 stderr에 없음
# RAG retrieval log 없음
# F8~F14 패턴 힌트 없음

rm ~/.detoks/disabled   # 재활성화
```

4. `semanticContext` 누적 확인 — tasks가 여러 개이고 RAG가 활성화된 환경에서 결과의 `semanticContext` 배열 길이 확인

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] `tsc --noEmit` 오류 없음을 확인했습니다
- [ ] 필요한 테스트를 추가/수정했습니다
- [x] Track B 신규 파일(`tokenAccounting.ts`, `memory.ts` 등)을 수정하지 않았습니다
- [x] 리뷰하기 좋은 크기로 커밋을 분리했습니다

## 스크린샷 / 로그

```text
> npx tsc --noEmit

(0 errors)
```

## 커밋 목록

| 커밋      | 내용                                                                                      |
| --------- | ----------------------------------------------------------------------------------------- |
| `388f37d` | fix(accounting): markTaskCompleted에 token_estimate_total 저장 — tokensSavedByCache 실제값 집계 |
| `239ac9c` | fix(privacy): detoks memory disable 실제 적용 — 저장/조회/인덱싱 전체 비활성화           |
| `3f84cc2` | fix(privacy): F2 pre-scan에 memoryDisabled 게이트 추가                                    |
| `3321356` | fix(privacy): RAG 검색에 memoryDisabled 게이트 추가                                       |
| `5472a12` | fix(privacy): F8~F14 패턴 마이닝에 memoryDisabled 게이트 추가                             |
| `bd170eb` | fix(privacy): 첫 실행 안내를 memoryDisabled 확인 이후로 이동                              |
| `4a20705` | fix(rag): semanticContext를 덮어쓰기 대신 누적으로 수정                                   |

## 리뷰어 참고사항

- Bug 1 수정이 없으면 `memoryDisabled=true` 상태에서 일부 task는 cache도 RAG도 없이 실행되는 최악의 케이스가 발생한다. Bug 1→2→3은 모두 같은 `memoryDisabled` 게이트 누락이지만, 각각 다른 경로(pre-scan / RAG 검색 / 패턴 마이닝)에서 독립적으로 문제를 일으킨다.
- Gap 1(token_estimate_total)은 Fix 2(saveSessionIfEnabled)보다 먼저 커밋되어야 의미가 있다. 새 세션에 `token_estimate_total`이 저장되어야 다음 실행의 F2 hit에서 합산이 가능하다.
- `semanticContext` 누적 수정은 `PipelineExecutionResult.semanticContext` 타입(`SemanticContextResult[] | undefined`)을 바꾸지 않는다. 길이만 늘어난다.
