### PR TITLE
Fix cache token savings and improve CLI memory handling

### DIFF
--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -294,6 +294,8 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
   let verbose = false;
   let trace = false;
   let noCache = false;
+  let memoryPurgeAll = false;
+  let skipConfirm = false;
   let tui: CliArgs["tui"] = undefined;
   let presentationMode: CliArgs["presentationMode"] = undefined;
 
@@ -320,6 +322,16 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
 
     if (current === "--human") {
       human = true;
+      continue;
+    }
+
+    if (current === "--all" && positionals[0] === "memory") {
+      memoryPurgeAll = true;
+      continue;
+    }
+
+    if (current === "--yes" && positionals[0] === "memory") {
+      skipConfirm = true;
       continue;
     }
 
@@ -659,27 +671,35 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
   if (first === "memory") {
     const sub = positionals[1];
     if (sub === "disable") {
+      if (memoryPurgeAll || skipConfirm) {
+        throw new Error("memory disable은 --all 또는 --yes를 지원하지 않습니다. detoks memory disable [--human]");
+      }
       return {
         mode: "run",
         adapter,
         executionMode,
         verbose,
         trace,
+        ...(human ? { human } : {}),
         showHelp: false,
         command: "memory-disable",
       };
     }
     if (sub === "purge") {
+      if (!memoryPurgeAll) {
+        throw new Error("memory purge에는 --all 플래그가 필요합니다. detoks memory purge --all");
+      }
       return {
         mode: "run",
         adapter,
         executionMode,
         verbose,
         trace,
+        ...(human ? { human } : {}),
         showHelp: false,
         command: "memory-purge-all",
-        memoryPurgeAll: argv.includes("--all"),
-        skipConfirm: argv.includes("--yes"),
+        memoryPurgeAll,
+        skipConfirm,
       };
     }
     throw new Error(`알 수 없는 memory 하위 명령: ${sub ?? "(없음)"}. detoks memory disable | purge --all`);

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -659,7 +659,9 @@ export const orchestratePipeline = async (
           kind: "session" as const,
           sourceSessionId: cachedSessionId,
           cacheAge,
-          tokensSaved: 0,
+          tokensSaved: sumCachedTaskTokens(
+            new Map(Object.entries(cachedSession!.task_results as Record<string, Record<string, unknown>>)),
+          ),
         },
         ...(actionTimeline.length ? { actionTimeline } : {}),
       };

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -458,6 +459,57 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
     expect(withCache.status).toBe(0);
     expect(withoutCache.status).toBe(0);
     expect(withCache.stdout).toBe(withoutCache.stdout);
+  });
+
+  it("prints human output for memory disable without touching the real home directory", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "detoks-cli-memory-disable-"));
+    const tempHome = mkdtempSync(join(tmpdir(), "detoks-cli-memory-home-"));
+
+    try {
+      const run = runCliFromCwdWithEnv(tempDir, ["memory", "disable", "--human"], {
+        HOME: tempHome,
+      });
+
+      expect(run.error).toBeUndefined();
+      expect(run.status).toBe(0);
+      expect(run.stderr).toBe("");
+      expect(run.stdout).toContain("DeToks 메모리 기능이 비활성화되었습니다.");
+      expect(run.stdout).toContain(join(tempHome, ".detoks", "disabled"));
+      expect(run.stdout.trimStart()).not.toMatch(/^\{/);
+      expect(existsSync(join(tempHome, ".detoks", "disabled"))).toBe(true);
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true });
+      rmSync(tempHome, { force: true, recursive: true });
+    }
+  });
+
+  it("purges session files and vector db with memory purge --all --yes", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "detoks-cli-memory-purge-"));
+    const sessionDir = join(tempDir, ".state", "sessions");
+    const ragDir = join(tempDir, ".state", "rag");
+    const sessionPath = join(sessionDir, "test-session.json");
+    const vectorDbPath = join(ragDir, "vectors.db");
+
+    try {
+      mkdirSync(sessionDir, { recursive: true });
+      mkdirSync(ragDir, { recursive: true });
+      writeFileSync(sessionPath, "{}", "utf8");
+      writeFileSync(vectorDbPath, "x", "utf8");
+
+      const run = runCliFromCwd(tempDir, ["memory", "purge", "--all", "--yes"]);
+
+      expect(run.error).toBeUndefined();
+      expect(run.status).toBe(0);
+      expect(run.stderr).toBe("");
+      expect(parseCliJson(run.stdout)).toMatchObject({
+        ok: true,
+        action: "purge-all",
+      });
+      expect(existsSync(sessionPath)).toBe(false);
+      expect(existsSync(vectorDbPath)).toBe(false);
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
   });
 
   it("enters repl when detoks runs without arguments", () => {

--- a/tests/ts/unit/cli/parse.test.ts
+++ b/tests/ts/unit/cli/parse.test.ts
@@ -538,6 +538,74 @@ describe("parseCliArgs", () => {
     });
   });
 
+  it("parses memory disable command", () => {
+    expect(parseCliArgs(["memory", "disable"])).toEqual({
+      mode: "run",
+      command: "memory-disable",
+      adapter: "codex",
+      executionMode: "real",
+      verbose: false,
+      trace: false,
+      showHelp: false,
+    });
+  });
+
+  it("preserves human output flag for memory disable", () => {
+    expect(parseCliArgs(["memory", "disable", "--human"])).toEqual({
+      mode: "run",
+      command: "memory-disable",
+      human: true,
+      adapter: "codex",
+      executionMode: "real",
+      verbose: false,
+      trace: false,
+      showHelp: false,
+    });
+  });
+
+  it("parses memory purge --all command", () => {
+    expect(parseCliArgs(["memory", "purge", "--all"])).toEqual({
+      mode: "run",
+      command: "memory-purge-all",
+      memoryPurgeAll: true,
+      skipConfirm: false,
+      adapter: "codex",
+      executionMode: "real",
+      verbose: false,
+      trace: false,
+      showHelp: false,
+    });
+  });
+
+  it("parses memory purge --all --yes command", () => {
+    expect(parseCliArgs(["memory", "purge", "--all", "--yes"])).toEqual({
+      mode: "run",
+      command: "memory-purge-all",
+      memoryPurgeAll: true,
+      skipConfirm: true,
+      adapter: "codex",
+      executionMode: "real",
+      verbose: false,
+      trace: false,
+      showHelp: false,
+    });
+  });
+
+  it("requires --all for memory purge", () => {
+    expect(() => parseCliArgs(["memory", "purge"])).toThrow(
+      /memory purge에는 --all 플래그가 필요합니다/,
+    );
+  });
+
+  it("rejects purge-only flags for memory disable", () => {
+    expect(() => parseCliArgs(["memory", "disable", "--all"])).toThrow(
+      /memory disable은 --all 또는 --yes를 지원하지 않습니다/,
+    );
+    expect(() => parseCliArgs(["memory", "disable", "--yes"])).toThrow(
+      /memory disable은 --all 또는 --yes를 지원하지 않습니다/,
+    );
+  });
+
   it("parses repl with explicit --no-tui flag to disable TUI mode", () => {
     const parsed = parseCliArgs(["repl", "--no-tui"]);
     expect(parsed).toEqual({

--- a/tests/ts/unit/cli/repl-adapter-auth.test.ts
+++ b/tests/ts/unit/cli/repl-adapter-auth.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
@@ -84,6 +87,9 @@ vi.mock("../../../../src/cli/config/config-manager.js", () => ({
 import { handleAdapterSwitch } from "../../../../src/cli/repl-commands/index.js";
 import { handleSlashCommand } from "../../../../src/cli/repl-commands/index.js";
 
+const originalHome = process.env.HOME;
+let tempHome: string | undefined;
+
 const restoreTTY = () => {
   Object.defineProperty(process.stdin, "isTTY", {
     configurable: true,
@@ -102,6 +108,8 @@ const restoreTTY = () => {
 
 describe("adapter auth flow", () => {
   beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "detoks-repl-auth-home-"));
+    process.env.HOME = tempHome;
     vi.clearAllMocks();
     mocks.resetAuthStarted();
     Object.defineProperty(process.stdin, "isTTY", {
@@ -122,6 +130,15 @@ describe("adapter auth flow", () => {
 
   afterEach(() => {
     restoreTTY();
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    if (tempHome) {
+      rmSync(tempHome, { recursive: true, force: true });
+      tempHome = undefined;
+    }
   });
 
   it("authenticates immediately after selecting claude", async () => {


### PR DESCRIPTION
## 요약

- F1 session cache hit의 `cacheHit.tokensSaved`가 항상 `0`이던 문제를 수정했습니다.
- `detoks memory purge --all --yes`가 unknown flag로 실패하던 CLI parser 버그를 수정했습니다.
- `memory purge`는 `--all` 없이 실행되지 않도록 명확히 막았습니다.
- `memory disable --human`의 `human` flag가 실제 command route까지 전달되도록 보존했습니다.
- `repl-adapter-auth.test.ts`가 실제 `~/.detoks`를 건드리지 않도록 테스트 HOME을 임시 디렉터리로 격리했습니다.
- `memory disable --human`, `memory purge --all --yes`의 실제 CLI smoke 테스트를 추가했습니다.

## 관련 이슈

- Closes #255 

## 변경 유형

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [x] 테스트 추가/수정

## 영향 범위

영향받는 모듈:

- `src/core/pipeline/orchestrator.ts`
- `src/cli/parse.ts`
- `tests/ts/unit/cli/parse.test.ts`
- `tests/ts/unit/cli/repl-adapter-auth.test.ts`
- `tests/ts/integration/cli-smoke.test.ts`

영향받지 않는 모듈:

- `src/cli/commands/memory.ts`
- `src/cli/index.ts`
- `src/core/state/SessionStateManager.ts`
- RAG vector store 구현
- adapter 실행 경로

## 수정 내역 상세

### 1. F1 session cache hit의 `tokensSaved` 집계

이전에는 F1 cache hit 반환값이 항상 `tokensSaved: 0`이었다.

```ts
cacheHit: {
  kind: "session",
  sourceSessionId: cachedSessionId,
  cacheAge,
  tokensSaved: 0,
}
```

변경 후에는 캐시된 세션의 `task_results`에서 `token_estimate_total`을 합산한다.

```ts
tokensSaved: sumCachedTaskTokens(
  new Map(Object.entries(cachedSession!.task_results as Record<string, Record<string, unknown>>)),
)
```

이제 F1 hit에서도 실제로 생략한 task들의 추정 토큰 절감량을 사용자에게 반환할 수 있다.

### 2. memory 전용 flag 파싱

`parseCliArgs()` 전역 flag 루프에서 memory command일 때만 `--all`, `--yes`를 허용한다.

```ts
if (current === "--all" && positionals[0] === "memory") {
  memoryPurgeAll = true;
  continue;
}

if (current === "--yes" && positionals[0] === "memory") {
  skipConfirm = true;
  continue;
}
```

이로써 `detoks memory purge --all --yes`가 unknown flag에서 막히지 않는다.

### 3. destructive command guard

`memory purge`는 `--all`이 없으면 실패한다.

```ts
if (!memoryPurgeAll) {
  throw new Error("memory purge에는 --all 플래그가 필요합니다. detoks memory purge --all");
}
```

반대로 `memory disable`은 purge 전용 flag를 받으면 실패한다.

```ts
if (memoryPurgeAll || skipConfirm) {
  throw new Error("memory disable은 --all 또는 --yes를 지원하지 않습니다. detoks memory disable [--human]");
}
```

### 4. memory command의 human output 보존

`memory disable --human`과 `memory purge --all --human`에서 `args.human`이 route까지 전달되도록 반환 객체에 `human`을 포함했다.

```ts
...(human ? { human } : {}),
```

### 5. adapter auth 테스트 HOME 격리

`repl-adapter-auth.test.ts`가 실제 `~/.detoks/cache`를 지우지 않도록 각 테스트마다 임시 HOME을 만든다.

```ts
tempHome = mkdtempSync(join(tmpdir(), "detoks-repl-auth-home-"));
process.env.HOME = tempHome;
```

afterEach에서 원래 HOME을 복구하고 임시 디렉터리를 삭제한다.

### 6. memory command smoke 테스트

`cli-smoke.test.ts`에 실제 CLI entry를 통한 smoke 테스트를 추가했다.

- `memory disable --human`
  - 임시 HOME에 `.detoks/disabled` 생성 확인
  - stdout이 JSON이 아닌 human text인지 확인
- `memory purge --all --yes`
  - 임시 cwd의 `.state/sessions/test-session.json` 삭제 확인
  - 임시 cwd의 `.state/rag/vectors.db` 삭제 확인

## 테스트 방법

### 타입 체크

```bash
npm run typecheck
```

결과:

```text
tsc --noEmit -p tsconfig.json
```

### parser 단위 테스트

```bash
npx --no-install vitest run tests/ts/unit/cli/parse.test.ts
```

결과:

```text
Test Files  1 passed (1)
Tests       51 passed (51)
```

### adapter auth 격리 테스트

```bash
npx --no-install vitest run tests/ts/unit/cli/repl-adapter-auth.test.ts
```

결과:

```text
Test Files  1 passed (1)
Tests       5 passed (5)
```

### CLI smoke

```bash
npx --no-install vitest run tests/ts/integration/cli-smoke.test.ts
```

결과:

```text
Test Files  1 passed (1)
Tests       26 passed | 2 skipped (28)
```

### 전체 테스트

```bash
npm test
```

결과:

```text
Test Files  93 passed | 1 skipped (94)
Tests       832 passed | 3 skipped (835)
```

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] `npm run typecheck` 통과를 확인했습니다
- [x] `npm test` 전체 통과를 확인했습니다
- [x] memory purge CLI 동작을 smoke 테스트로 고정했습니다
- [x] 실제 `~/.detoks`를 건드리던 테스트를 임시 HOME으로 격리했습니다
- [x] 커밋을 의미 단위로 분리했습니다

## 커밋 목록

| 커밋 | 내용 |
|---|---|
| `d6b372b` | `fix(cache): F1 세션 캐시 hit 시 tokensSaved 0 고정 문제 해결` |
| `05432df` | `fix(cli): parse memory purge flags` |
| `1d79881` | `test(cli): isolate adapter auth cache home` |
| `66d50cf` | `test(cli): cover memory commands in smoke` |

## 리뷰어 참고사항

- 이번 PR에는 기존에 push되지 않았던 `d6b372b` 커밋도 포함되어 있다.
- `memory purge --all --yes`는 parser와 smoke 양쪽에서 고정했다.
- `repl-adapter-auth.test.ts`는 이제 sandbox 권한 없이도 통과한다.
- `src/cli/commands/memory.ts`의 삭제 로직은 변경하지 않았다. 이번 수정은 parser와 테스트 보강에 집중했다.
