### PR TITLE
Add cache_advise event for user guidance in advise mode

### DIFF
--- a/src/core/cache/cache-validator.ts
+++ b/src/core/cache/cache-validator.ts
@@ -2,8 +2,7 @@ import type { SessionState } from "../../schemas/pipeline.js";
 import { CACHE_TTL_DAYS } from "./cache-config.js";
 
 // "auto"   → 모든 조건 통과, 즉시 캐시 반환
-// "advise" → recency 경계 근처 / adapter·git HEAD 불일치 등
-//             결과 반환 X, 구 세션 기록으로만 취급 (P1에서 사용자 안내 추가 예정)
+// "advise" → adapter·git HEAD 불일치 등 — 결과 반환 X, 구 세션 기록으로만 취급
 // "skip"   → 검증 실패, miss 처리
 export type CacheValidity = "auto" | "advise" | "skip";
 
@@ -39,6 +38,22 @@ export function isSessionCacheValid(
   if (expected_git_head && ctx.git_head && ctx.git_head !== expected_git_head) return "advise";
 
   return "auto";
+}
+
+export function deriveAdviseReasons(
+  ctx: Record<string, unknown>,
+  opts: Pick<CacheValidationOpts, "expected_adapter" | "expected_git_head">,
+): string[] {
+  const reasons: string[] = [];
+  if (opts.expected_adapter && ctx.adapter && ctx.adapter !== opts.expected_adapter) {
+    reasons.push(`adapter 불일치: 저장 ${String(ctx.adapter)} → 현재 ${opts.expected_adapter}`);
+  }
+  if (opts.expected_git_head && ctx.git_head && ctx.git_head !== opts.expected_git_head) {
+    const stored = String(ctx.git_head).slice(0, 7);
+    const current = opts.expected_git_head.slice(0, 7);
+    reasons.push(`git HEAD 변경: ${stored} → ${current}`);
+  }
+  return reasons;
 }
 
 export function isTaskCacheValid(

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -30,7 +30,7 @@ import { countTokens } from "../utils/tokenMetrics.js";
 import { getLLMModelConfig } from "../llm-client/llm-models.js";
 import { computeProjectId, hashRawInput, hashTaskInputV2 } from "../rag/hash.js";
 import { CACHE_DISABLED, CACHE_TTL_DAYS } from "../cache/cache-config.js";
-import { isSessionCacheValid, isTaskCacheValid } from "../cache/cache-validator.js";
+import { isSessionCacheValid, isTaskCacheValid, deriveAdviseReasons } from "../cache/cache-validator.js";
 import { isRagEnabled, getRagModelPath, getRagVectorDbPath, RAG_EMBEDDING_DIMS } from "../rag/rag-config.js";
 import { EmbeddingService } from "../rag/embedding-service.js";
 import { VectorStore } from "../rag/vector-store.js";
@@ -667,16 +667,29 @@ export const orchestratePipeline = async (
       };
     }
 
-    // "advise": adapter·git HEAD 불일치 — P0에서는 miss로 처리 (P1에서 사용자 안내 추가 예정)
-    await emitActionTimelineWithLogging(
-      createActionTimelineEvent({
-        kind: "cache_miss",
-        source: "pipeline",
-        summary: f1Validity === "advise"
-          ? `F1 캐시 advise — adapter 또는 git HEAD 불일치 (hash ${inputHash})`
-          : `F1 캐시 miss — hash ${inputHash}`,
-      }),
-    );
+    if (f1Validity === "advise") {
+      const adviseCtx = cachedSession!.shared_context as Record<string, unknown>;
+      const adviseReasons = deriveAdviseReasons(adviseCtx, {
+        expected_adapter: request.adapter,
+        ...(gitHead ? { expected_git_head: gitHead } : {}),
+      });
+      await emitActionTimelineWithLogging(
+        createActionTimelineEvent({
+          kind: "cache_advise",
+          source: "pipeline",
+          summary: `F1 캐시 advise — 유사 세션 ${adviseCtx.session_id} 발견 (자동 적용 불가)`,
+          details: [...adviseReasons, "현재 상태로 새로 실행합니다."],
+        }),
+      );
+    } else {
+      await emitActionTimelineWithLogging(
+        createActionTimelineEvent({
+          kind: "cache_miss",
+          source: "pipeline",
+          summary: `F1 캐시 miss — hash ${inputHash}`,
+        }),
+      );
+    }
   }
 
   // ── F3: 미완성 세션 resume 힌트 ──────────────────────────────────────────
@@ -1227,15 +1240,28 @@ export const orchestratePipeline = async (
             };
           }
 
-          await emitActionTimelineWithLogging(
-            createActionTimelineEvent({
-              kind: "cache_miss", source: "pipeline",
-              summary: f2Validity === "advise"
-                ? `F2 캐시 advise — adapter 또는 git HEAD 불일치 (task ${task.id})`
-                : `F2 캐시 miss — task ${task.id} hash ${task.input_hash}`,
-              taskId: task.id,
-            }),
-          );
+          if (f2Validity === "advise") {
+            const f2AdviseReasons = deriveAdviseReasons(cachedTask!.taskResult, {
+              expected_adapter: request.adapter,
+              ...(gitHead ? { expected_git_head: gitHead } : {}),
+            });
+            await emitActionTimelineWithLogging(
+              createActionTimelineEvent({
+                kind: "cache_advise", source: "pipeline",
+                summary: `F2 캐시 advise — task ${task.id} 유사 결과 발견 (자동 적용 불가)`,
+                taskId: task.id,
+                details: [...f2AdviseReasons, "현재 상태로 새로 실행합니다."],
+              }),
+            );
+          } else {
+            await emitActionTimelineWithLogging(
+              createActionTimelineEvent({
+                kind: "cache_miss", source: "pipeline",
+                summary: `F2 캐시 miss — task ${task.id} hash ${task.input_hash}`,
+                taskId: task.id,
+              }),
+            );
+          }
         }
 
         // (4) ExecutionContext 생성

--- a/src/core/timeline/types.ts
+++ b/src/core/timeline/types.ts
@@ -10,6 +10,7 @@ export const ActionTimelineKinds = [
   "stage_update",
   "cache_hit",
   "cache_miss",
+  "cache_advise",
 ] as const;
 
 export type ActionTimelineKind = (typeof ActionTimelineKinds)[number];


### PR DESCRIPTION
## 요약

- `cache_advise` ActionTimelineKind를 추가해 advise 케이스를 단순 miss와 구분했습니다.
- `deriveAdviseReasons()` 헬퍼를 `cache-validator.ts`에 추가해 adapter 불일치·git HEAD 변경을 각각 구체적인 문자열로 반환합니다.
- F1·F2 모두 `advise` 케이스에서 `cache_advise` 이벤트를 emit하도록 orchestrator를 수정했습니다. `details` 배열에 불일치 이유와 어떤 세션/태스크가 발견됐는지 포함됩니다.
- 기존 `skip` 케이스는 `cache_miss` 이벤트를 그대로 유지합니다.

## 관련 이슈

- Closes #257 

## 변경 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [ ] 테스트 추가/수정

## 영향 범위

영향받는 모듈:

- `src/core/timeline/types.ts` — `cache_advise` kind 추가
- `src/core/cache/cache-validator.ts` — `deriveAdviseReasons()` 헬퍼 추가, 주석 정리
- `src/core/pipeline/orchestrator.ts` — F1·F2 advise/skip 분기 분리

영향받지 않는 모듈:

- `src/cli/tui/index.ts` — `formatCacheHitBadge`는 `cacheHit.kind`만 사용하므로 무영향
- `src/core/state/SessionStateManager.ts`
- RAG vector store 구현
- adapter 실행 경로
- 기존 `cache_miss`·`cache_hit` 이벤트 처리

## 수정 내역 상세

### 1. `cache_advise` Kind 추가

기존 `ActionTimelineKinds`에 `"cache_advise"`를 추가했다.

```ts
// 이전
export const ActionTimelineKinds = [
  "cache_hit",
  "cache_miss",
] as const;

// 이후
export const ActionTimelineKinds = [
  "cache_hit",
  "cache_miss",
  "cache_advise",
] as const;
```

TUI 팀은 이 kind를 기준으로 advise 케이스를 별도 스타일로 렌더링할 수 있다.

### 2. `deriveAdviseReasons()` 헬퍼

캐시된 컨텍스트(세션의 `shared_context` 또는 태스크의 `taskResult`)와 현재 요청값을 비교해 이유 문자열 배열을 반환한다.

```ts
export function deriveAdviseReasons(
  ctx: Record<string, unknown>,
  opts: Pick<CacheValidationOpts, "expected_adapter" | "expected_git_head">,
): string[] {
  const reasons: string[] = [];
  if (opts.expected_adapter && ctx.adapter && ctx.adapter !== opts.expected_adapter) {
    reasons.push(`adapter 불일치: 저장 ${String(ctx.adapter)} → 현재 ${opts.expected_adapter}`);
  }
  if (opts.expected_git_head && ctx.git_head && ctx.git_head !== opts.expected_git_head) {
    const stored = String(ctx.git_head).slice(0, 7);
    const current = opts.expected_git_head.slice(0, 7);
    reasons.push(`git HEAD 변경: ${stored} → ${current}`);
  }
  return reasons;
}
```

두 조건이 동시에 해당하면 두 이유가 모두 반환된다.

### 3. F1 advise 분기 분리

이전에는 advise와 skip이 같은 `cache_miss` 이벤트로 처리됐다.

```ts
// 이전
await emitActionTimelineWithLogging(
  createActionTimelineEvent({
    kind: "cache_miss",
    source: "pipeline",
    summary: f1Validity === "advise"
      ? `F1 캐시 advise — adapter 또는 git HEAD 불일치 (hash ${inputHash})`
      : `F1 캐시 miss — hash ${inputHash}`,
  }),
);
```

변경 후에는 advise 케이스만 `cache_advise` 이벤트로 emit하고, skip은 그대로 `cache_miss`다.

```ts
// 이후
if (f1Validity === "advise") {
  const adviseCtx = cachedSession!.shared_context as Record<string, unknown>;
  const adviseReasons = deriveAdviseReasons(adviseCtx, { ... });
  await emitActionTimelineWithLogging(
    createActionTimelineEvent({
      kind: "cache_advise",
      source: "pipeline",
      summary: `F1 캐시 advise — 유사 세션 ${adviseCtx.session_id} 발견 (자동 적용 불가)`,
      details: [...adviseReasons, "현재 상태로 새로 실행합니다."],
    }),
  );
} else {
  await emitActionTimelineWithLogging(
    createActionTimelineEvent({
      kind: "cache_miss",
      source: "pipeline",
      summary: `F1 캐시 miss — hash ${inputHash}`,
    }),
  );
}
```

`details`에는 이유 문자열들과 함께 "현재 상태로 새로 실행합니다."가 포함돼 사용자에게 다음 동작을 안내한다.

### 4. F2 advise 분기 분리

F2(태스크 단위)도 동일한 패턴으로 수정했다. `taskId` 필드도 함께 포함된다.

```ts
if (f2Validity === "advise") {
  const f2AdviseReasons = deriveAdviseReasons(cachedTask!.taskResult, { ... });
  await emitActionTimelineWithLogging(
    createActionTimelineEvent({
      kind: "cache_advise", source: "pipeline",
      summary: `F2 캐시 advise — task ${task.id} 유사 결과 발견 (자동 적용 불가)`,
      taskId: task.id,
      details: [...f2AdviseReasons, "현재 상태로 새로 실행합니다."],
    }),
  );
} else {
  await emitActionTimelineWithLogging(
    createActionTimelineEvent({
      kind: "cache_miss", source: "pipeline",
      summary: `F2 캐시 miss — task ${task.id} hash ${task.input_hash}`,
      taskId: task.id,
    }),
  );
}
```

## 테스트 방법

### 타입 체크

```bash
npx tsc --noEmit
```

결과:

```text
(오류 없음)
```

### 캐시 검증 단위 테스트

```bash
npx --no-install vitest run tests/ts/unit/core/cache/cache-validator.test.ts
```

결과:

```text
Test Files  1 passed (1)
Tests       19 passed (19)
```

### 오케스트레이터 단위 테스트

```bash
npx --no-install vitest run tests/ts/unit/core/pipeline/orchestrator.test.ts
```

결과:

```text
Test Files  1 passed (1)
Tests       15 passed | 1 skipped (16)
```

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] `npx tsc --noEmit` 통과를 확인했습니다
- [x] 기존 캐시·오케스트레이터 테스트 전체 통과를 확인했습니다
- [x] `deriveAdviseReasons()`가 두 조건(adapter/git HEAD) 모두 감지함을 확인했습니다
- [x] 기존 `cache_miss` 이벤트 동작을 변경하지 않았습니다

## 커밋 목록

| 커밋 | 내용 |
|---|---|
| `643b4ab` | `feat(cache): advise 모드 사용자 안내 이벤트 추가` |

## 리뷰어 참고사항

- `cache_advise`는 "캐시를 찾긴 했는데 못 썼다"는 케이스다. skip(캐시 자체가 없거나 TTL 초과)과 구분해서 봐야 한다.
- `details` 배열 구조를 유지하면 팀장이 TUI에서 이유를 리스트로 표시하기 쉽다.
- `deriveAdviseReasons()`는 validator와 같은 파일에 있어서 판단 기준이 한 곳에 모여 있다.
- `action-timeline.ts`의 `deriveActionWorkState()`는 `cache_advise` kind에 대해 `null`을 반환한다 — 의도적이며 work state 표시에 영향 없다.
