### PR TITLE
fix(tui): 라이브 활동 정보 압축 및 승인 Enter 오작동 방지

### DIFF
--- a/src/cli/tui/approval-prompt.ts
+++ b/src/cli/tui/approval-prompt.ts
@@ -1,0 +1,25 @@
+import { colors } from "../colors.js";
+import { padDisplayWidth, wrapTextToDisplayWidth } from "./renderer.js";
+
+const APPROVAL_MESSAGES = [
+  "실행 전 확인",
+  "Enter 실행 · Esc 편집 복귀",
+] as const;
+
+export const buildExecutionApprovalLines = (width: number): string[] => {
+  if (width <= 0) {
+    return [];
+  }
+
+  const lines: string[] = [];
+  const divider = padDisplayWidth(`── Run Check ${"─".repeat(Math.max(0, width - 13))}`.slice(0, width), width);
+  lines.push(colors.warning(divider));
+
+  for (const message of APPROVAL_MESSAGES) {
+    for (const segment of wrapTextToDisplayWidth(message, width)) {
+      lines.push(colors.warning(padDisplayWidth(segment, width)));
+    }
+  }
+
+  return lines;
+};

--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -42,6 +42,7 @@ import {
   type EmbeddedNativeCliSession,
 } from "./native-cli-session.js";
 import { formatEmbeddedTerminalFocusHint } from "./embedded-terminal.js";
+import { buildExecutionApprovalLines } from "./approval-prompt.js";
 import {
   createPinnedViewportState,
   resolveViewportWindow,
@@ -83,6 +84,34 @@ interface TuiRunOptions {
   presentationMode?: CliArgs["presentationMode"];
 }
 
+type RunBlockStatus = "pending-approval" | "running" | "completed" | "failed" | "cancelled";
+
+interface TuiRunBlock {
+  id: string;
+  index: number;
+  prompt: string;
+  status: RunBlockStatus;
+  createdAt: number;
+  completedAt?: number | undefined;
+  pane: EmbeddedTerminalPane;
+  summaryLines: string[];
+}
+
+interface StickyPromptState {
+  runId: string;
+  prompt: string;
+  status: RunBlockStatus;
+}
+
+const truncateToDisplayWidth = (text: string, width: number): string => {
+  if (width <= 0) {
+    return "";
+  }
+
+  const [firstLine = ""] = wrapTextToDisplayWidth(text, width);
+  return firstLine;
+};
+
 const formatTokenSavingsBadge = (reduction?: TokenReductionSnapshot | null): string | undefined => {
   if (!reduction) {
     return undefined;
@@ -104,8 +133,8 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
   const decoder = new StringDecoder("utf8");
   let currentAdapter = options.adapter;
   let currentAdapterModel = options.adapterModel ?? getAdapterModel(currentAdapter);
-  let currentTranslationModel = options.translationModel ?? getTranslationModel();
-  let currentVerbose = options.verbose;
+    let currentTranslationModel = options.translationModel ?? getTranslationModel();
+    let currentVerbose = options.verbose;
   let currentCacheDisabled = false;
   let currentInferenceStrength =
     currentAdapter === "codex"
@@ -204,7 +233,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     const pipelinePanel = new PipelineStatusPanel();
     const transcriptPanel = new TranscriptPanel();
     const resultPanel = new ResultSummaryPanel();
-    const embeddedTerminalPane = new EmbeddedTerminalPane();
+    let embeddedTerminalPane = new EmbeddedTerminalPane();
     const embeddedTerminalFocus = createEmbeddedTerminalFocusManager();
     let hasExecuted = false;
     let lastInputSeparatorRow = -1;
@@ -220,8 +249,86 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     let executionClockTimer: NodeJS.Timeout | undefined;
     let forceFullRender = false;
     let scrollViewportState = createPinnedViewportState();
-    let lastSubmittedPrompt: string | null = null;
+    let pendingApprovalPrompt: string | null = null;
+    let skipApprovalLineFeed = false;
     let pendingMouseInputSequence = "";
+    let runBlocks: TuiRunBlock[] = [];
+    let activeRunBlock: TuiRunBlock | null = null;
+    let stickyPrompt: StickyPromptState | null = null;
+
+    const getStickyPromptText = (): string | null => stickyPrompt?.prompt ?? pendingApprovalPrompt;
+
+    const getStickyPromptStatus = (): string => {
+      if (stickyPrompt !== null) {
+        switch (stickyPrompt.status) {
+          case "pending-approval":
+            return "실행 확인 대기 · Enter 실행 · Esc 편집 복귀";
+          case "running":
+            return "실행 중";
+          case "completed":
+            return "완료";
+          case "failed":
+            return "실패";
+          case "cancelled":
+            return "취소됨";
+        }
+      }
+
+      if (pendingApprovalPrompt !== null) {
+        return "실행 확인 대기 · Enter 실행 · Esc 편집 복귀";
+      }
+
+      return hasExecuted ? "최근 실행 완료" : "첫 프롬프트를 입력하세요";
+    };
+
+    const getEmbeddedStickyRows = (): number => 4;
+    const getEmbeddedActivityRows = (): number => 1;
+    const getEmbeddedFixedRows = (): number => getEmbeddedStickyRows() + getEmbeddedActivityRows();
+
+    const setStickyPromptFromRun = (run: TuiRunBlock): void => {
+      stickyPrompt = {
+        runId: run.id,
+        prompt: run.prompt,
+        status: run.status,
+      };
+    };
+
+    const createRunBlock = (prompt: string): TuiRunBlock => {
+      const index = runBlocks.length + 1;
+      return {
+        id: `run-${Date.now()}-${index}`,
+        index,
+        prompt,
+        status: "running",
+        createdAt: Date.now(),
+        pane: new EmbeddedTerminalPane(),
+        summaryLines: [],
+      };
+    };
+
+    const registerRunBlock = (prompt: string, status: RunBlockStatus): TuiRunBlock => {
+      const block = createRunBlock(prompt);
+      block.status = status;
+      runBlocks.push(block);
+      activeRunBlock = block;
+      embeddedTerminalPane = block.pane;
+      setStickyPromptFromRun(block);
+      return block;
+    };
+
+    const updateActiveRunBlockStatus = (status: RunBlockStatus): void => {
+      if (activeRunBlock === null) {
+        return;
+      }
+
+      activeRunBlock.status = status;
+      if (status === "running") {
+        activeRunBlock.completedAt = undefined;
+      } else {
+        activeRunBlock.completedAt = Date.now();
+      }
+      setStickyPromptFromRun(activeRunBlock);
+    };
 
     const buildSectionDivider = (label: string, width: number): string => {
       if (width <= 0) {
@@ -251,32 +358,159 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       return wrapped;
     };
 
-    const buildScrollableContentLines = (width: number): string[] => {
+    const buildStickyPromptLines = (width: number): string[] => {
+      if (width <= 0) {
+        return [];
+      }
+
+      const promptText = getStickyPromptText();
+      const statusText = getStickyPromptStatus();
+      const lines: string[] = [];
+
+      if (promptText === null) {
+        lines.push(buildSectionDivider("Sticky Prompt", width));
+        lines.push(
+          ...buildWrappedBlock(
+            [hasExecuted ? "최근 실행 결과를 준비하는 중입니다." : "첫 프롬프트를 입력하세요."],
+            width,
+          ).map((line) => colors.muted(line)),
+        );
+        lines.push(colors.muted(padDisplayWidth(`상태: ${statusText}`, width)));
+        lines.push(" ".repeat(width));
+        return lines.slice(0, getEmbeddedStickyRows());
+      }
+
+      lines.push(buildSectionDivider("Sticky Prompt", width));
+      lines.push(
+        ...buildWrappedBlock(promptText.split("\n"), width, "> ").slice(0, Math.max(0, getEmbeddedStickyRows() - 2)),
+      );
+      lines.push(colors.muted(padDisplayWidth(`상태: ${statusText}`, width)));
+      lines.push(" ".repeat(width));
+      return lines.slice(0, getEmbeddedStickyRows());
+    };
+
+    const buildEmbeddedActivityLines = (width: number): string[] => {
+      if (width <= 0) {
+        return [];
+      }
+
+      const activity = activeRunBlock?.pane.getActivitySnapshot(width);
+      if (activity === null || activity === undefined) {
+        return [
+          colors.muted(padDisplayWidth("현재 활동: 대기", width)),
+        ].slice(0, getEmbeddedActivityRows());
+      }
+
+      const statusLabel =
+        activity.status === "running" ? "진행 중" : activity.status === "completed" ? "완료" : "실패";
+      const compactLine = truncateToDisplayWidth(
+        `현재 활동: ${activity.label} · ${activity.detail} · ${statusLabel}`,
+        width,
+      );
+      return [
+        activity.status === "failed"
+          ? colors.error(padDisplayWidth(compactLine, width))
+          : colors.muted(padDisplayWidth(compactLine, width)),
+      ].slice(0, getEmbeddedActivityRows());
+    };
+
+    const buildRunSummaryLines = (run: TuiRunBlock, width: number): string[] => {
+      if (run.status === "pending-approval") {
+        return buildExecutionApprovalLines(width).map((line) => line);
+      }
+
+      if (run.status === "running" && activeRunBlock?.id === run.id) {
+        const currentSummary = resultPanel.getLines();
+        if (currentSummary.length > 0) {
+          return currentSummary;
+        }
+      }
+
+      if (run.summaryLines.length > 0) {
+        return run.summaryLines;
+      }
+
+      if (run.status === "cancelled") {
+        return ["실행이 취소되었습니다."];
+      }
+
+      if (run.status === "failed") {
+        return ["실행이 실패했습니다."];
+      }
+
+      if (run.status === "running") {
+        return ["", "  Waiting for adapter CLI to finish…"];
+      }
+
+      return ["실행 결과가 아직 없습니다."];
+    };
+
+    const buildRunBlockLines = (run: TuiRunBlock, width: number): string[] => {
       if (width <= 0) {
         return [];
       }
 
       const lines: string[] = [];
+      lines.push(buildSectionDivider(`Run #${run.index}`, width));
+      lines.push(colors.muted(padDisplayWidth(`상태: ${getStickyPromptStatusForRun(run)}`, width)));
+      lines.push(buildSectionDivider(`Prompt #${run.index}`, width));
+      lines.push(...buildWrappedBlock(run.prompt.split("\n"), width, "> "));
+      lines.push(buildSectionDivider(`Original CLI #${run.index}`, width));
 
-      if (lastSubmittedPrompt !== null) {
-        lines.push(buildSectionDivider("Prompt", width));
-        lines.push(...buildWrappedBlock(lastSubmittedPrompt.split("\n"), width, "> "));
-        lines.push(colors.header("─".repeat(width)));
-        lines.push(" ".repeat(width));
+      if (run.status === "pending-approval") {
+        lines.push(
+          ...buildWrappedBlock(
+            ["실행 확인 대기 중 · Enter로 실행 · Esc로 편집 복귀"],
+            width,
+          ).map((line) => colors.muted(line)),
+        );
+      } else {
+        const cliLines = run.pane.getRenderableLines(width).map((line) => line.text);
+        lines.push(...cliLines);
       }
 
-      lines.push(...embeddedTerminalPane.getRenderableLines(width).map((line) => line.text));
-      lines.push(" ".repeat(width));
-      lines.push(buildSectionDivider("Summary", width));
-
-      const summaryLines = resultPanel.getLines();
-      if (summaryLines.length === 0 && !isExecuting) {
-        lines.push(...buildWrappedBlock([
-          "실행 결과가 아직 없습니다.",
-          "첫 실행 이후 작업 타임라인 · 다음 작업 · 사용량/압축 지표가 이 영역에 표시됩니다.",
-        ], width).map((line) => colors.muted(line)));
-      } else {
+      lines.push(buildSectionDivider(`Summary #${run.index}`, width));
+      const summaryLines = buildRunSummaryLines(run, width);
+      if (summaryLines.length > 0) {
         lines.push(...buildWrappedBlock(summaryLines, width));
+      }
+      lines.push(" ".repeat(width));
+      return lines;
+    };
+
+    const getStickyPromptStatusForRun = (run: TuiRunBlock): string => {
+      switch (run.status) {
+        case "pending-approval":
+          return "실행 확인 대기";
+        case "running":
+          return "실행 중";
+        case "completed":
+          return "완료";
+        case "failed":
+          return "실패";
+        case "cancelled":
+          return "취소됨";
+      }
+    };
+
+    const buildScrollableContentLines = (width: number): string[] => {
+      if (width <= 0) {
+        return [];
+      }
+
+      if (runBlocks.length === 0) {
+        return buildWrappedBlock(
+          [
+            "실행 히스토리가 아직 없습니다.",
+            "프롬프트를 실행하면 여기 아래에 RunBlock이 누적됩니다.",
+          ],
+          width,
+        ).map((line) => colors.muted(line));
+      }
+
+      const lines: string[] = [];
+      for (const run of runBlocks) {
+        lines.push(...buildRunBlockLines(run, width));
       }
 
       return lines;
@@ -288,7 +522,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       const bannerRows = Math.min(3, Math.max(0, inputLayout.separatorRow));
       const statusRegionStart = bannerRows;
       const statusRegionEnd = Math.min(inputLayout.separatorRow, statusRegionStart + 8);
-      const contentHeight = Math.max(0, inputLayout.separatorRow - statusRegionEnd);
+      const contentHeight = Math.max(0, inputLayout.separatorRow - statusRegionEnd - getEmbeddedFixedRows());
       const totalLines = buildScrollableContentLines(dims.columns).length;
       scrollViewportState = scrollViewportBy(totalLines, contentHeight, scrollViewportState, deltaRows);
     };
@@ -411,7 +645,9 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     const renderBanner = (): void => {
       const dims = screen.getDimensions();
       const browsingHistoryHint =
-        embeddedPaneMode && !scrollViewportState.pinnedToBottom
+        stickyPrompt?.status === "pending-approval" || pendingApprovalPrompt !== null
+          ? "실행 대기 중 · Enter 실행 · Esc 편집 복귀"
+          : embeddedPaneMode && !scrollViewportState.pinnedToBottom
           ? "기록 탐색 중 · ↑↓ PgUp/PgDn/휠 · End로 최신으로 이동"
           : "첫 프롬프트를 입력하면 아래 패널이 채워집니다 · /... 자동완성 · q 종료";
       const bannerLines = [
@@ -516,6 +752,9 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         inputLayout.separatorRow,
         contentRegionStart + transcriptRows,
       );
+      const stickyRows = embeddedPaneMode ? getEmbeddedFixedRows() : 0;
+      const stickyRegionStart = contentRegionStart;
+      const stickyRegionEnd = Math.min(inputLayout.separatorRow, stickyRegionStart + stickyRows);
 
       // Render structure (minimal - no borders)
       renderScreenBorder(ctx);
@@ -528,12 +767,36 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       };
       pipelinePanel.render(ctx, statusRegion);
 
-      const transcriptRegion = {
-        startRow: contentRegionStart,
-        endRow: embeddedPaneMode ? inputLayout.separatorRow : transcriptRegionEnd,
-        columns: dims.columns,
-      };
       if (embeddedPaneMode) {
+        const stickyRegion = {
+          startRow: stickyRegionStart,
+          endRow: stickyRegionEnd,
+          columns: dims.columns,
+        };
+        const stickyLines = [
+          ...buildStickyPromptLines(stickyRegion.columns),
+          ...buildEmbeddedActivityLines(stickyRegion.columns),
+        ];
+        let stickyRow = stickyRegion.startRow;
+        for (const line of stickyLines.slice(0, Math.max(0, stickyRegion.endRow - stickyRegion.startRow))) {
+          if (stickyRow >= stickyRegion.endRow) {
+            break;
+          }
+          screen.cursorMoveTo(stickyRow, 0);
+          screen.write(line);
+          stickyRow += 1;
+        }
+        while (stickyRow < stickyRegion.endRow) {
+          screen.cursorMoveTo(stickyRow, 0);
+          screen.write(" ".repeat(stickyRegion.columns));
+          stickyRow += 1;
+        }
+
+        const transcriptRegion = {
+          startRow: stickyRegionEnd,
+          endRow: inputLayout.separatorRow,
+          columns: dims.columns,
+        };
         const contentLines = buildScrollableContentLines(transcriptRegion.columns);
         const viewport = resolveViewportWindow(
           contentLines.length,
@@ -560,12 +823,17 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           row += 1;
         }
 
-        const transcriptRows = Math.max(1, Math.ceil(availableContentRows * 0.7));
+        const transcriptRows = Math.max(1, Math.ceil(Math.max(0, availableContentRows - stickyRows) * 0.7));
         embeddedTerminalPane.resize(transcriptRegion.columns, transcriptRows);
         if (embeddedNativeCliSession !== null) {
           embeddedNativeCliSession?.resize(transcriptRegion.columns, transcriptRows);
         }
       } else {
+        const transcriptRegion = {
+          startRow: contentRegionStart,
+          endRow: transcriptRegionEnd,
+          columns: dims.columns,
+        };
         transcriptPanel.render(ctx, transcriptRegion);
       }
 
@@ -658,6 +926,56 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       // Process text, handling both escape sequences and individual characters
       while (i < text.length) {
         let handled = false;
+
+        if (pendingApprovalPrompt !== null) {
+          const char = text.charAt(i);
+          if (skipApprovalLineFeed) {
+            if (char === "\n") {
+              skipApprovalLineFeed = false;
+              i++;
+              continue;
+            }
+
+            skipApprovalLineFeed = false;
+          }
+
+          if (char === "\x03") {
+            closeEmbeddedNativeCliSession("SIGINT");
+            running = false;
+            needsFullRender = true;
+            i++;
+            continue;
+          }
+
+          if (char === "\r" || char === "\n") {
+            const approvedPrompt = pendingApprovalPrompt;
+            pendingApprovalPrompt = null;
+            skipApprovalLineFeed = false;
+            if (approvedPrompt !== null) {
+              executePrompt(approvedPrompt, activeRunBlock ?? undefined);
+            }
+            i++;
+            continue;
+          }
+
+          if (char === "\x1b") {
+            if (activeRunBlock !== null) {
+              activeRunBlock.status = "cancelled";
+              activeRunBlock.completedAt = Date.now();
+              activeRunBlock.summaryLines = ["실행이 취소되었습니다."];
+              setStickyPromptFromRun(activeRunBlock);
+            }
+            input = pendingApprovalPrompt;
+            pendingApprovalPrompt = null;
+            skipApprovalLineFeed = false;
+            render();
+            i++;
+            continue;
+          }
+
+          i++;
+          continue;
+        }
 
         // Check for escape sequences first (multi-character sequences)
         // Must be processed as atomic units before character-by-character handling
@@ -892,7 +1210,22 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
                       slashAutocompleteSelectedIndex,
                     )?.usage ?? input
                   : input;
-              executePrompt(resolvedPrompt);
+              const normalizedPrompt = resolvedPrompt.trim();
+              const shouldRequestApproval =
+                embeddedPaneMode &&
+                options.executionMode === "real" &&
+                normalizedPrompt.length > 0 &&
+                !normalizedPrompt.startsWith("/");
+
+              if (shouldRequestApproval) {
+                hasExecuted = true;
+                registerRunBlock(resolvedPrompt, "pending-approval");
+                pendingApprovalPrompt = resolvedPrompt;
+                skipApprovalLineFeed = char === "\r";
+                render();
+              } else {
+                executePrompt(resolvedPrompt);
+              }
               input = ""; // Clear input for next prompt
               slashAutocompleteSelectedIndex = 0;
             }
@@ -962,15 +1295,14 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     };
 
     // Phase 3: Execute prompt function
-    const executePrompt = async (prompt: string): Promise<void> => {
+    const executePrompt = async (prompt: string, runBlock?: TuiRunBlock): Promise<void> => {
       isExecuting = true;
       hasExecuted = true;
-      lastSubmittedPrompt = prompt;
-      scrollViewportState = scrollViewportToBottom();
+      const normalizedPrompt = prompt.trim();
+      let currentRunBlock: TuiRunBlock | null = runBlock ?? null;
       const workspaceBefore = captureWorkspaceSnapshot(executionCwd);
       let receivedLiveAdapterEvents = false;
       try {
-        const normalizedPrompt = prompt.trim();
         if (normalizedPrompt.startsWith("/")) {
           let shouldRestoreMainScreen = false;
           const previousState = {
@@ -1027,13 +1359,18 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           return;
         }
 
-        // Clear previous results
+        currentRunBlock = runBlock ?? registerRunBlock(prompt, "running");
+        if (currentRunBlock.status !== "running") {
+          updateActiveRunBlockStatus("running");
+        } else {
+          setStickyPromptFromRun(currentRunBlock);
+        }
+
         if (embeddedPaneMode) {
           closeEmbeddedNativeCliSession();
           embeddedTerminalFocus.focusDetoks();
         }
         transcriptPanel.clear();
-        embeddedTerminalPane.clear();
         resultPanel.clear();
         if (embeddedPaneMode) {
           resultPanel.setExecuting(true);
@@ -1124,10 +1461,15 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         const actionTimeline = buildActionTimeline(result, workspaceDiff);
 
         // Phase 3.4: Display result
-        resultPanel.setResult({
+        const completedResult = {
           ...result,
           ...(actionTimeline.length > 0 ? { actionTimeline } : {}),
-        });
+        };
+        resultPanel.setResult(completedResult);
+        currentRunBlock.summaryLines = resultPanel.getLines();
+        currentRunBlock.status = completedResult.ok ? "completed" : "failed";
+        currentRunBlock.completedAt = Date.now();
+        setStickyPromptFromRun(currentRunBlock);
         if (embeddedPaneMode) {
           closeEmbeddedNativeCliSession();
         }
@@ -1155,6 +1497,16 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         // Display error
         const errorMsg = formatError(error, currentVerbose);
         resultPanel.clear();
+        if (currentRunBlock !== null) {
+          currentRunBlock.status = "failed";
+          currentRunBlock.completedAt = Date.now();
+          currentRunBlock.summaryLines = [
+            `✗ 실패  어댑터: ${currentAdapter}  세션: ${options.sessionId ?? "new"}`,
+            `요약: ${errorMsg}`,
+            "다음 작업: 입력을 수정한 뒤 다시 시도하세요.",
+          ];
+          setStickyPromptFromRun(currentRunBlock);
+        }
         if (embeddedPaneMode) {
           embeddedTerminalPane.appendFinalAnswer(`\n[ERROR] ${errorMsg}\n`);
         } else {

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -120,6 +120,410 @@ const META_LINE_PATTERNS = [
   /^session id:/,
 ] as const;
 
+const TOOL_ACTIVITY_PATTERNS = [
+  /^web search:/i,
+  /^tool_search:/i,
+  /^mcp\b/i,
+  /^todo_list\b/i,
+] as const;
+
+const COMMAND_STATUS_PATTERNS = [
+  /^succeeded in \d+ms:?$/i,
+  /^failed in \d+ms:?$/i,
+  /^exit code \d+$/i,
+] as const;
+
+const COMMAND_LINE_PATTERNS = [
+  /^\/bin\/(zsh|bash|sh)\b/i,
+  /^rg\b/i,
+  /^grep\b/i,
+  /^find\b/i,
+  /^git\b/i,
+  /^npm\b/i,
+  /^npx\b/i,
+  /^node\b/i,
+  /^python(?:3)?\b/i,
+  /^bun\b/i,
+  /^yarn\b/i,
+  /^pnpm\b/i,
+] as const;
+
+const CONVERSATION_ROLE_PATTERNS = [
+  /^codex$/i,
+  /^user$/i,
+  /^tokens used$/i,
+] as const;
+
+interface RenderedRowInfo {
+  cells: TerminalCell[];
+  plainText: string;
+  globalRow: number;
+}
+
+export type EmbeddedActivityKind = "file" | "search" | "tool" | "test" | "git" | "command";
+
+export interface EmbeddedActivitySnapshot {
+  kind: EmbeddedActivityKind;
+  label: string;
+  detail: string;
+  status: "running" | "completed" | "failed";
+}
+
+const isMetaLine = (plainText: string): boolean =>
+  plainText.length > 0 &&
+  (plainText === "--------" || META_LINE_PATTERNS.some((pattern) => pattern.test(plainText)));
+
+const isToolActivityLine = (plainText: string): boolean =>
+  plainText.length > 0 && TOOL_ACTIVITY_PATTERNS.some((pattern) => pattern.test(plainText));
+
+const isCommandStatusLine = (plainText: string): boolean =>
+  plainText.length > 0 && COMMAND_STATUS_PATTERNS.some((pattern) => pattern.test(plainText));
+
+const looksLikeCommandLine = (plainText: string): boolean =>
+  plainText.length > 0 && COMMAND_LINE_PATTERNS.some((pattern) => pattern.test(plainText));
+
+const isConversationRoleLine = (plainText: string): boolean =>
+  plainText.length > 0 && CONVERSATION_ROLE_PATTERNS.some((pattern) => pattern.test(plainText));
+
+const extractCommandName = (commandLine: string): string => {
+  const target = extractShellPayload(commandLine);
+  const firstToken = target.split(/\s+/)[0] ?? target;
+  const basename = firstToken.split("/").pop() ?? firstToken;
+  return basename.length > 0 ? basename : "command";
+};
+
+const extractShellPayload = (commandLine: string): string => {
+  const trimmed = commandLine.trim();
+  const shellMatch = trimmed.match(/\s-lc\s+(?:"((?:\\.|[^"\\])*)"|'([^']*)'|(\S.*?))(?:\s+in\s+\/.*)?$/);
+  if (shellMatch) {
+    return (shellMatch[1] ?? shellMatch[2] ?? shellMatch[3] ?? trimmed)
+      .replace(/\\"/g, "\"")
+      .replace(/\\'/g, "'")
+      .trim();
+  }
+
+  return trimmed.replace(/\s+in\s+\/.*$/, "").trim();
+};
+
+const extractPathCandidate = (commandLine: string): string | null => {
+  const payload = extractShellPayload(commandLine);
+  const pathMatches = payload.match(/(?:~\/|\/|\.\.?\/)[^\s"'`]+/g);
+  if (pathMatches !== null && pathMatches.length > 0) {
+    return pathMatches[pathMatches.length - 1] ?? null;
+  }
+
+  const tokens = payload.split(/\s+/).filter(Boolean);
+  const likelyPath = [...tokens].reverse().find((token) =>
+    /[./]/.test(token) && /\.(?:[cm]?[jt]sx?|json|md|yml|yaml|toml|lock|txt|css|html|py|rs|go|java|swift)$/i.test(token),
+  );
+  return likelyPath?.replace(/[;:,]+$/, "") ?? null;
+};
+
+const extractSearchQuery = (commandLine: string): string | null => {
+  const payload = extractShellPayload(commandLine);
+  const quoted = payload.match(/\b(?:rg|grep)\b(?:\s+-\S+)*\s+(?:"([^"]+)"|'([^']+)')/i);
+  if (quoted) {
+    return quoted[1] ?? quoted[2] ?? null;
+  }
+
+  const tokens = payload.split(/\s+/).filter(Boolean);
+  const commandIndex = tokens.findIndex((token) => /^(rg|grep)$/i.test(token.split("/").pop() ?? token));
+  if (commandIndex >= 0) {
+    return tokens.slice(commandIndex + 1).find((token) => !token.startsWith("-"))?.replace(/[;:,]+$/, "") ?? null;
+  }
+
+  return null;
+};
+
+const describeCommandActivity = (commandLine: string): Omit<EmbeddedActivitySnapshot, "status"> => {
+  const payload = extractShellPayload(commandLine);
+  const commandName = extractCommandName(commandLine);
+  const path = extractPathCandidate(commandLine);
+
+  if (/\b(sed|cat|less|head|tail)\b/i.test(payload) && path !== null) {
+    return { kind: "file", label: "파일 읽기", detail: path };
+  }
+
+  if (/\b(rg|grep|find)\b/i.test(payload)) {
+    const query = extractSearchQuery(commandLine);
+    return { kind: "search", label: "검색", detail: query ?? payload };
+  }
+
+  if (/\b(git)\b/i.test(payload)) {
+    return { kind: "git", label: "Git", detail: payload };
+  }
+
+  if (/\b(npm|npx|pnpm|yarn|node)\b/i.test(payload) && /\b(test|vitest|tsc|build)\b/i.test(payload)) {
+    return { kind: "test", label: "검증", detail: payload };
+  }
+
+  return { kind: "command", label: "명령 실행", detail: commandName };
+};
+
+const statusFromCommandStatusLine = (statusLine: string | null): EmbeddedActivitySnapshot["status"] => {
+  if (statusLine === null) {
+    return "running";
+  }
+
+  if (/^succeeded in/i.test(statusLine)) {
+    return "completed";
+  }
+
+  return "failed";
+};
+
+const summarizeCommandActivity = (
+  commandLine: string,
+  maxWidth: number,
+  status: EmbeddedActivitySnapshot["status"],
+): string => {
+  const activity = describeCommandActivity(commandLine);
+  const statusLabel = status === "running" ? "진행 중" : status === "completed" ? "완료" : "실패";
+  return truncateForSummary(`${activity.label}: ${activity.detail} · ${statusLabel}`, maxWidth);
+};
+
+const truncateForSummary = (text: string, maxWidth: number): string => {
+  if (maxWidth <= 0) {
+    return "";
+  }
+
+  if (text.length <= maxWidth) {
+    return text;
+  }
+
+  if (maxWidth <= 3) {
+    return ".".repeat(maxWidth);
+  }
+
+  return `${text.slice(0, maxWidth - 3)}...`;
+};
+
+const findMetaValue = (rows: RenderedRowInfo[], key: string): string | null => {
+  const matched = rows.find((row) => row.plainText.startsWith(key));
+  if (!matched) {
+    return null;
+  }
+
+  const value = matched.plainText.slice(key.length).trim();
+  return value.length > 0 ? value : null;
+};
+
+const summarizeMetadataBlock = (rows: RenderedRowInfo[], maxWidth: number): string => {
+  const parts: string[] = [];
+  const header = rows.find((row) => /^OpenAI Codex\b/i.test(row.plainText));
+  if (header) {
+    parts.push("OpenAI Codex");
+  }
+
+  const model = findMetaValue(rows, "model:");
+  const provider = findMetaValue(rows, "provider:");
+  const sandbox = findMetaValue(rows, "sandbox:");
+  const approval = findMetaValue(rows, "approval:");
+
+  for (const value of [model, provider, sandbox, approval].filter((item): item is string => Boolean(item))) {
+    parts.push(value);
+  }
+
+  const summary = parts.length > 0 ? `세션 정보: ${parts.join(" · ")}` : "세션 정보";
+  return truncateForSummary(summary, maxWidth);
+};
+
+const summarizeToolActivityBlock = (rows: RenderedRowInfo[], maxWidth: number): string => {
+  const firstLine = rows[0]?.plainText ?? "";
+  const label = firstLine.startsWith("web search:")
+    ? "웹 검색"
+    : firstLine.startsWith("tool_search:")
+      ? "도구 검색"
+      : firstLine.startsWith("todo_list:")
+        ? "할일 도구"
+        : firstLine.startsWith("mcp")
+          ? "MCP 도구"
+          : "도구 활동";
+  const detail = firstLine.includes(":") ? firstLine.slice(firstLine.indexOf(":") + 1).trim() : "";
+  const summary = detail.length > 0
+    ? `${label} ${rows.length}건 · ${detail}`
+    : `${label} ${rows.length}건`;
+  return truncateForSummary(summary, maxWidth);
+};
+
+const summarizeCommandBlock = (rows: RenderedRowInfo[], maxWidth: number): string | null => {
+  if (rows.length < 2) {
+    return null;
+  }
+
+  const commandLine = rows[1]?.plainText.trim() ?? "";
+  if (!looksLikeCommandLine(commandLine)) {
+    return null;
+  }
+
+  const statusLine = rows.find((row, index) => index >= 2 && isCommandStatusLine(row.plainText))?.plainText ?? null;
+  const resultLines = rows
+    .slice(statusLine ? rows.findIndex((row, index) => index >= 2 && isCommandStatusLine(row.plainText)) + 1 : 2)
+    .map((row) => row.plainText)
+    .filter((line) => line.length > 0);
+
+  const commandName = extractCommandName(commandLine);
+  const statusLabel = statusLine === null
+    ? "실행"
+    : /^succeeded in/i.test(statusLine)
+      ? "성공"
+      : /^failed in/i.test(statusLine)
+        ? "실패"
+        : /^exit code\s+(\d+)$/i.test(statusLine)
+          ? `종료 코드 ${statusLine.match(/^exit code\s+(\d+)$/i)?.[1] ?? ""}`.trim()
+          : "실행";
+  const durationMatch = statusLine?.match(/in\s+(\d+)ms/i);
+  const duration = durationMatch?.[1] ? `${durationMatch[1]}ms` : null;
+  const parts = [`명령 실행: ${commandName}`];
+  if (statusLabel.length > 0) {
+    parts.push(statusLabel);
+  }
+  if (duration) {
+    parts.push(duration);
+  }
+  if (resultLines.length > 0) {
+    parts.push(`${resultLines.length}개 결과`);
+  }
+  return truncateForSummary(parts.join(" · "), maxWidth);
+};
+
+const findPendingCommandEnd = (rows: RenderedRowInfo[], startIndex: number): number => {
+  let cursor = startIndex;
+  while (cursor < rows.length) {
+    const text = rows[cursor]?.plainText ?? "";
+    if (
+      text === "exec" ||
+      isMetaLine(text) ||
+      isToolActivityLine(text) ||
+      isConversationRoleLine(text)
+    ) {
+      break;
+    }
+    cursor += 1;
+  }
+  return cursor;
+};
+
+const buildCompactRenderableLines = (
+  rows: RenderedRowInfo[],
+  maxWidth: number,
+  cursorColumn?: number,
+  cursorVisible?: boolean,
+  cursorGlobalRow?: number,
+): EmbeddedTerminalRenderableLine[] => {
+  const output: EmbeddedTerminalRenderableLine[] = [];
+
+  for (let index = 0; index < rows.length; ) {
+    const row = rows[index];
+    if (!row) {
+      index += 1;
+      continue;
+    }
+
+    if (isMetaLine(row.plainText)) {
+      const block: RenderedRowInfo[] = [row];
+      index += 1;
+      while (index < rows.length && rows[index] !== undefined && isMetaLine(rows[index]!.plainText)) {
+        block.push(rows[index]!);
+        index += 1;
+      }
+
+      output.push({
+        text: colors.muted(
+          padDisplayWidth(summarizeMetadataBlock(block, maxWidth), maxWidth),
+        ),
+      });
+      continue;
+    }
+
+    if (row.plainText === "exec") {
+      const commandBlock: RenderedRowInfo[] = [row];
+      if (index + 1 < rows.length && rows[index + 1] !== undefined) {
+        commandBlock.push(rows[index + 1]!);
+      }
+
+      let statusIndex = -1;
+      for (let lookahead = 2; lookahead < Math.min(rows.length - index, 8); lookahead += 1) {
+        const candidate = rows[index + lookahead];
+        if (candidate !== undefined && isCommandStatusLine(candidate.plainText)) {
+          commandBlock.push(candidate);
+          statusIndex = index + lookahead;
+          break;
+        }
+      }
+
+      if (statusIndex !== -1) {
+        let cursor = statusIndex + 1;
+        while (
+          cursor < rows.length &&
+          rows[cursor] !== undefined &&
+          rows[cursor]!.plainText.length > 0 &&
+          !isMetaLine(rows[cursor]!.plainText) &&
+          !isToolActivityLine(rows[cursor]!.plainText) &&
+          rows[cursor]!.plainText !== "exec"
+        ) {
+          commandBlock.push(rows[cursor]!);
+          cursor += 1;
+        }
+
+        const summary = summarizeCommandBlock(commandBlock, maxWidth);
+        if (summary !== null) {
+          output.push({
+            text: colors.header(padDisplayWidth(summary, maxWidth)),
+          });
+          index = cursor;
+          continue;
+        }
+      }
+
+      const commandLine = rows[index + 1]?.plainText.trim() ?? "";
+      if (looksLikeCommandLine(commandLine)) {
+        output.push({
+          text: colors.muted(
+            padDisplayWidth(summarizeCommandActivity(commandLine, maxWidth, "running"), maxWidth),
+          ),
+        });
+        index = findPendingCommandEnd(rows, index + 2);
+        continue;
+      }
+    }
+
+    if (isToolActivityLine(row.plainText)) {
+      const block: RenderedRowInfo[] = [row];
+      index += 1;
+      while (
+        index < rows.length &&
+        rows[index] !== undefined &&
+        isToolActivityLine(rows[index]!.plainText)
+      ) {
+        block.push(rows[index]!);
+        index += 1;
+      }
+
+      output.push({
+        text: colors.muted(
+          padDisplayWidth(summarizeToolActivityBlock(block, maxWidth), maxWidth),
+        ),
+      });
+      continue;
+    }
+
+    const isCursorCell = cursorVisible === true && cursorGlobalRow === row.globalRow && cursorColumn !== undefined;
+    output.push({
+      text: renderCellsToAnsi(
+        row.cells,
+        maxWidth,
+        isCursorCell ? cursorColumn : undefined,
+        cursorVisible,
+        getRowDefaultStyle(row.plainText),
+      ),
+    });
+    index += 1;
+  }
+
+  return output;
+};
+
 const getRowDefaultStyle = (plainText: string): Partial<TerminalCellStyle> | undefined => {
   if (plainText.length === 0) {
     return undefined;
@@ -188,8 +592,8 @@ export interface EmbeddedTerminalRenderableLine {
 export class EmbeddedTerminalPane {
   private readonly buffer = new TerminalEmulatorBuffer(80, 24, EMBEDDED_PANE_SCROLLBACK_LIMIT);
   private scrollOffset = 0;
-  // Cached total row count (scrollback + visible) — updated on every write to avoid
-  // rebuilding the combined array on every scrollUp() keypress.
+  // Cached total renderable line count (after compact summaries are applied) —
+  // updated on every write to avoid rebuilding the combined array on every scrollUp() keypress.
   private cachedTotalRows = 0;
   private currentColumns = 80;
   private currentRows = 24;
@@ -229,7 +633,7 @@ export class EmbeddedTerminalPane {
   }
 
   private updateCachedTotalRows(): void {
-    this.cachedTotalRows = this.buffer.getScrollbackRows().length + this.buffer.getVisibleRows().length;
+    this.cachedTotalRows = this.getRenderableLines(this.currentColumns).length;
   }
 
   addEvent(event: PtyEvent): void {
@@ -263,6 +667,90 @@ export class EmbeddedTerminalPane {
     return this.buffer.hasContent();
   }
 
+  getActivitySnapshot(maxWidth = this.currentColumns): EmbeddedActivitySnapshot | null {
+    if (!this.buffer.hasContent()) {
+      return null;
+    }
+
+    const { rows } = this.getRenderedRows(Math.max(1, maxWidth));
+    for (let index = rows.length - 1; index >= 0; index -= 1) {
+      const row = rows[index];
+      if (row === undefined) {
+        continue;
+      }
+
+      if (row.plainText === "exec") {
+        const commandLine = rows[index + 1]?.plainText.trim() ?? "";
+        if (!looksLikeCommandLine(commandLine)) {
+          continue;
+        }
+
+        let statusLine: string | null = null;
+        for (let lookahead = index + 2; lookahead < Math.min(rows.length, index + 10); lookahead += 1) {
+          const candidate = rows[lookahead]?.plainText ?? "";
+          if (isCommandStatusLine(candidate)) {
+            statusLine = candidate;
+            break;
+          }
+        }
+
+        const activity = describeCommandActivity(commandLine);
+        return {
+          ...activity,
+          status: statusFromCommandStatusLine(statusLine),
+        };
+      }
+
+      if (isToolActivityLine(row.plainText)) {
+        const detail = row.plainText.includes(":")
+          ? row.plainText.slice(row.plainText.indexOf(":") + 1).trim()
+          : row.plainText;
+        return {
+          kind: "tool",
+          label: row.plainText.startsWith("web search:") ? "웹 검색" : "도구 활동",
+          detail: detail.length > 0 ? detail : "진행 중",
+          status: "running",
+        };
+      }
+    }
+
+    return null;
+  }
+
+  private getRenderedRows(maxWidth: number): {
+    rows: RenderedRowInfo[];
+    cursorColumn: number;
+    cursorVisible: boolean;
+    cursorGlobalRow: number;
+  } {
+    const scrollbackRows = this.buffer.getScrollbackCells();
+    const visibleRows = this.buffer.getVisibleCells();
+    const rows = [...scrollbackRows, ...visibleRows];
+    const cursorState = this.buffer.getCursorState();
+    const cursorGlobalRow = scrollbackRows.length + cursorState.row;
+
+    let lastContentIndex = -1;
+    for (let i = rows.length - 1; i >= 0; i -= 1) {
+      const row = rows[i];
+      if (row !== undefined && row.some((cell) => (cell.char ?? "").trim().length > 0)) {
+        lastContentIndex = i;
+        break;
+      }
+    }
+
+    const contentRows = rows.slice(0, lastContentIndex + 1);
+    return {
+      rows: contentRows.map((row, offset) => ({
+        cells: row,
+        plainText: rowToPlainText(row, maxWidth),
+        globalRow: offset,
+      })),
+      cursorColumn: cursorState.column,
+      cursorVisible: cursorState.visible,
+      cursorGlobalRow,
+    };
+  }
+
   getRenderableLines(maxWidth: number, maxRows?: number, scrollOffset = 0): EmbeddedTerminalRenderableLine[] {
     if (maxWidth <= 0) {
       return [];
@@ -274,39 +762,25 @@ export class EmbeddedTerminalPane {
       }));
     }
 
-    const scrollbackRows = this.buffer.getScrollbackCells();
-    const visibleRows = this.buffer.getVisibleCells();
-    const rows = [...scrollbackRows, ...visibleRows];
-    const cursorState = this.buffer.getCursorState();
-    const cursorGlobalRow = scrollbackRows.length + cursorState.row;
-    let lastContentIndex = -1;
-    for (let i = rows.length - 1; i >= 0; i -= 1) {
-      const row = rows[i];
-      if (row !== undefined && row.some((cell) => (cell.char ?? "").trim().length > 0)) {
-        lastContentIndex = i;
-        break;
-      }
-    }
+    const {
+      rows: renderedRows,
+      cursorColumn,
+      cursorVisible,
+      cursorGlobalRow,
+    } = this.getRenderedRows(maxWidth);
 
-    const endIndex = Math.max(0, lastContentIndex + 1 - scrollOffset);
+    const compactLines = buildCompactRenderableLines(
+      renderedRows,
+      maxWidth,
+      cursorColumn,
+      cursorVisible,
+      cursorGlobalRow,
+    );
+
+    const endIndex = Math.max(0, compactLines.length - Math.max(0, scrollOffset));
     const startIndex = Math.max(0, maxRows === undefined ? 0 : endIndex - Math.max(0, maxRows));
-    const renderedRows = rows.slice(startIndex, endIndex);
 
-    return renderedRows.map((row, offset) => {
-      const globalRow = startIndex + offset;
-      const cursorColumn =
-        cursorState.visible && globalRow === cursorGlobalRow ? cursorState.column : undefined;
-      const plainText = rowToPlainText(row, maxWidth);
-      return {
-        text: renderCellsToAnsi(
-          row,
-          maxWidth,
-          cursorColumn,
-          cursorState.visible,
-          getRowDefaultStyle(plainText),
-        ),
-      };
-    });
+    return compactLines.slice(startIndex, endIndex);
   }
 
   render(ctx: RenderContext, region: PanelRegion): void {

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -550,7 +550,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       const replRun = runCliWithInputFromCwdEnvAndTimeout(
         tempDir,
         ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
-        "hello detoks\n\u0007/exit\n",
+        "hello detoks\n\n/exit\n",
         {
           PATH: `${tempDir}:${process.env.PATH ?? ""}`,
         },
@@ -558,11 +558,12 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       );
 
       expect(replRun.stderr).not.toContain("ReferenceError");
-      expect(replRun.stdout).toContain("원본 CLI 출력이 이 영역에 표시됩니다.");
-      expect(replRun.stdout).toContain("[fake:codex]");
       expect(replRun.stdout).toContain("hello detoks");
-      expect(replRun.stdout).toContain("실행 결과가 아직 없습니다.");
-      expect(replRun.stdout).toContain("작업 타임라인");
+      expect(replRun.stdout).toContain("Sticky Prompt");
+      expect(replRun.stdout).toContain("실행 확인 대기");
+      expect(replRun.stdout).toContain("실행 중");
+      expect(replRun.stdout).toContain("완료");
+      expect(replRun.stdout).toContain("Summary #1");
       expect(replRun.stdout).toContain("detoks 압축 지표");
     } finally {
       rmSync(tempDir, { force: true, recursive: true });
@@ -577,7 +578,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       const replRun = runCliWithInputFromCwdEnvAndTimeout(
         tempDir,
         ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
-        "hello detoks\n\u0007hello again\n\u0007/exit\n",
+        "hello detoks\n\nhello again\n\n/exit\n",
         {
           PATH: `${tempDir}:${process.env.PATH ?? ""}`,
           DETOKS_CACHE_DISABLED: "1",
@@ -586,13 +587,39 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       );
 
       expect(replRun.stderr).not.toContain("ReferenceError");
-      expect(replRun.stdout).toContain("[fake:codex]");
       expect(replRun.stdout).toContain("hello detoks");
       expect(replRun.stdout).toContain("hello again");
+      expect(replRun.stdout).toContain("Sticky Prompt");
+      expect(replRun.stdout).toContain("실행 중");
+      expect(replRun.stdout).toContain("완료");
     } finally {
       rmSync(tempDir, { force: true, recursive: true });
     }
   }, 30_000);
+
+  it("does not auto-execute the approval prompt when the initial Enter arrives as CRLF", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "detoks-cli-embedded-repl-"));
+
+    try {
+      createFakeBinary(tempDir, "codex");
+      const replRun = runCliWithInputFromCwdEnvAndTimeout(
+        tempDir,
+        ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
+        "hello detoks\r\n",
+        {
+          PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+          DETOKS_CACHE_DISABLED: "1",
+        },
+        4_000,
+      );
+
+      expect(replRun.stdout).toContain("실행 확인 대기");
+      expect(replRun.stdout).not.toContain("[fake:codex]");
+      expect(replRun.stdout).not.toContain("실행 중");
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  }, 10_000);
 
   it("keeps default stderr concise and verbose stderr stacked on errors", () => {
     const defaultRun = runCli(["--unknown"]);

--- a/tests/ts/unit/cli/tui/approval-prompt.test.ts
+++ b/tests/ts/unit/cli/tui/approval-prompt.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { buildExecutionApprovalLines } from "../../../../../src/cli/tui/approval-prompt.js";
+
+describe("execution approval prompt", () => {
+  it("renders confirm and cancel guidance", () => {
+    const lines = buildExecutionApprovalLines(40).join("\n");
+
+    expect(lines).toContain("실행 전 확인");
+    expect(lines).toContain("Enter 실행 · Esc 편집 복귀");
+  });
+
+  it("returns empty lines for non-positive width", () => {
+    expect(buildExecutionApprovalLines(0)).toEqual([]);
+  });
+});

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -71,7 +71,7 @@ describe("EmbeddedTerminalPane", () => {
     expect(output).toContain("world");
   });
 
-  it("renders codex metadata lines with a muted gray tone for readability", () => {
+  it("compresses codex metadata lines into a short summary", () => {
     pane.addEvent({
       type: "chunk",
       timestamp: Date.now(),
@@ -82,10 +82,90 @@ describe("EmbeddedTerminalPane", () => {
     pane.render(mockContext, mockRegion);
 
     const output = mockScreen.write.mock.calls.map((call: any) => call[0]).join("\n");
-    expect(output).toContain("\x1b[38;5;250m");
-    expect(output).toContain("\x1b[2;38;5;244m");
+    expect(output).toContain("세션 정보");
     expect(output).toContain("OpenAI Codex");
-    expect(output).toContain("workdir:");
+    expect(output).not.toContain("workdir:");
+    expect(output).not.toContain("--------");
+  });
+
+  it("compresses exec command blocks into a short summary", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: [
+        "exec",
+        `/bin/zsh -lc "rg -n \"new ProjectMemory\" src tests"`,
+        "succeeded in 0ms:",
+        "src/core/pipeline/orchestrator.ts:34:import { ProjectMemory } from \"../rag/project-memory.js\";",
+        "src/core/rag/project-memory.ts:5:import { TaskSequenceMiner } from \"./task-sequence-miner.js\";",
+        "",
+      ].join("\n"),
+    });
+
+    pane.render(mockContext, mockRegion);
+
+    const output = mockScreen.write.mock.calls.map((call: any) => call[0]).join("\n");
+    expect(output).toContain("명령 실행");
+    expect(output).toContain("rg");
+    expect(output).not.toContain("succeeded in 0ms");
+    expect(output).not.toContain("TaskSequenceMiner");
+  });
+
+  it("keeps an in-progress file read compact and exposes it as current activity", () => {
+    mockRegion.columns = 140;
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: [
+        "exec",
+        `/bin/zsh -lc "sed -n '1,220p' /Users/choi/.codex/RTK.md" in /Users/choi/Desktop/workspace/detoks`,
+        "# verbose file contents",
+        "line that should not fill the pane",
+      ].join("\n"),
+    });
+
+    pane.render(mockContext, mockRegion);
+
+    const output = mockScreen.write.mock.calls.map((call: any) => call[0]).join("\n");
+    expect(output).toContain("파일 읽기");
+    expect(output).toContain("/Users/choi/.codex/RTK.md");
+    expect(output).not.toContain("line that should not fill the pane");
+    expect(pane.getActivitySnapshot(120)).toMatchObject({
+      kind: "file",
+      label: "파일 읽기",
+      detail: "/Users/choi/.codex/RTK.md",
+      status: "running",
+    });
+  });
+
+  it("summarizes an in-progress search without streaming every match line", () => {
+    mockRegion.columns = 140;
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: [
+        "exec",
+        `/bin/zsh -lc "rg -n \\"ProjectMemory\\" src tests"`,
+        "src/core/pipeline/orchestrator.ts:34:import { ProjectMemory } from \"../rag/project-memory.js\";",
+        "tests/ts/unit/core/rag/project-memory.test.ts:1:import { ProjectMemory } from \"x\";",
+      ].join("\n"),
+    });
+
+    pane.render(mockContext, mockRegion);
+
+    const output = mockScreen.write.mock.calls.map((call: any) => call[0]).join("\n");
+    expect(output).toContain("검색");
+    expect(output).toContain("ProjectMemory");
+    expect(output).not.toContain("orchestrator.ts:34");
+    expect(pane.getActivitySnapshot(120)).toMatchObject({
+      kind: "search",
+      label: "검색",
+      detail: "ProjectMemory",
+      status: "running",
+    });
   });
 
   it("renders the live cursor cell with inverse video when the buffer reports a visible cursor", () => {


### PR DESCRIPTION
## 요약
  - Enter가 CRLF로 들어올 때 승인 프롬프트가 자동 실행되는 문제를 수정했습니다.
  - 원본 CLI 영역의 실시간 출력에서 파일 읽기/검색/명령 실행 상태를 고정된 활동 표시줄로
  압축해 정보량을 줄였습니다.
  - 승인 흐름과 임베디드 활동 렌더링에 대한 회귀 테스트를 추가했습니다.

 ## 검증
  - npm run build
  - npx vitest run tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts --reporter=dot
  - npx vitest run tests/ts/integration/cli-smoke.test.ts -t "does not auto-execute the
  approval prompt when the initial Enter arrives as CRLF|returns to detoks input after an
  embedded run so another prompt can be entered" --reporter=dot

 ## 참고
  - 이번 브랜치 범위와 무관한 로컬 변경은 제외했습니다.

