### PR TITLE
test: edge case 회귀 테스트 추가 (sessionId, lock, passthrough, NaN env)

### DIFF
--- a/tests/ts/unit/core/pipeline/orchestrator-nan-env.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator-nan-env.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * orchestrator.ts 모듈 상단에서 Budget Gate 상수를 초기화하는 패턴:
+ *
+ *   const COLD_START_THRESHOLD = Math.max(0, parseInt(env ?? "5", 10) || 5);
+ *   const RAG_BREAK_EVEN_RATIO = parseFloat(env ?? "0.5") || 0.5;
+ *   const PER_TASK_TOKEN_CAP   = Math.max(0, parseInt(env ?? "250", 10) || 250);
+ *   const PER_SESSION_TOKEN_CAP= Math.max(0, parseInt(env ?? "500", 10) || 500);
+ *   const MAX_PARALLEL_TASKS   = Math.max(1, parseInt(env ?? "5",   10) || 5);
+ *
+ * 이 테스트는 각 패턴이 NaN·빈 문자열·음수 등 잘못된 입력에서
+ * 항상 안전한 기본값을 반환함을 명시적으로 고정한다.
+ * 모듈 로드 타임에 평가되므로, 공식 자체를 단위 테스트로 커버한다.
+ */
+
+function parseIntWithFallback(raw: string | undefined, defaultVal: number): number {
+  return parseInt(raw ?? String(defaultVal), 10) || defaultVal;
+}
+
+function parseFloatWithFallback(raw: string | undefined, defaultVal: number): number {
+  return parseFloat(raw ?? String(defaultVal)) || defaultVal;
+}
+
+describe("Budget Gate env var NaN 방어 공식", () => {
+  describe("parseInt || fallback 패턴 (COLD_START_THRESHOLD, PER_TASK_TOKEN_CAP, etc.)", () => {
+    it.each([
+      ["abc",   5],
+      ["NaN",   5],
+      ["",      5],
+      [" ",     5],
+      ["1.5",   1],  // parseInt truncates float → 1 (valid, truthy)
+    ])("parseIntWithFallback(%j, 5) === %d", (input, expected) => {
+      expect(parseIntWithFallback(input, 5)).toBe(expected);
+    });
+
+    it("유효한 정수는 그대로 사용", () => {
+      expect(parseIntWithFallback("10", 5)).toBe(10);
+      expect(parseIntWithFallback("250", 5)).toBe(250);
+    });
+  });
+
+  describe("Math.max(0, ...) — 음수 방지 (PER_TASK_TOKEN_CAP, COLD_START_THRESHOLD)", () => {
+    it("음수 env var는 Math.max(0, ...) 로 0으로 클램프", () => {
+      // parseInt("-5") = -5, -5은 truthy이므로 || 250 적용 안 됨
+      // Math.max(0, -5) = 0
+      expect(Math.max(0, parseIntWithFallback("-5", 250))).toBe(0);
+    });
+
+    it("0은 falsy이므로 || fallback이 적용됨", () => {
+      // parseInt("0") = 0 → falsy → || 250 적용 → 250
+      expect(Math.max(0, parseIntWithFallback("0", 250))).toBe(250);
+    });
+
+    it("양수 유효값은 그대로 사용", () => {
+      expect(Math.max(0, parseIntWithFallback("100", 250))).toBe(100);
+    });
+  });
+
+  describe("Math.max(1, ...) — 최소 1 보장 (MAX_PARALLEL_TASKS)", () => {
+    it("NaN 입력은 fallback 5, Math.max(1, 5) = 5", () => {
+      expect(Math.max(1, parseIntWithFallback("abc", 5))).toBe(5);
+    });
+
+    it("0 입력은 || fallback 후 Math.max(1, 5) = 5", () => {
+      expect(Math.max(1, parseIntWithFallback("0", 5))).toBe(5);
+    });
+
+    it("음수 입력은 Math.max(1, -3) = 1", () => {
+      // parseInt("-3") = -3, truthy → || 5 미적용, Math.max(1, -3) = 1
+      expect(Math.max(1, parseIntWithFallback("-3", 5))).toBe(1);
+    });
+
+    it("유효한 정수 3은 Math.max(1, 3) = 3", () => {
+      expect(Math.max(1, parseIntWithFallback("3", 5))).toBe(3);
+    });
+  });
+
+  describe("parseFloat || fallback 패턴 (RAG_BREAK_EVEN_RATIO)", () => {
+    it.each([
+      ["abc",  0.5],
+      ["NaN",  0.5],
+      ["",     0.5],
+      ["0",    0.5],  // 0.0 is falsy → fallback
+    ])("parseFloatWithFallback(%j, 0.5) === %d", (input, expected) => {
+      expect(parseFloatWithFallback(input, 0.5)).toBe(expected);
+    });
+
+    it("유효한 소수는 그대로 사용", () => {
+      expect(parseFloatWithFallback("0.3", 0.5)).toBe(0.3);
+      expect(parseFloatWithFallback("1.0", 0.5)).toBe(1.0);
+    });
+  });
+});

--- a/tests/ts/unit/core/state/session-state-manager-lock.test.ts
+++ b/tests/ts/unit/core/state/session-state-manager-lock.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { SessionStateManager } from "../../../../../src/core/state/SessionStateManager.js";
+import { StateLockError } from "../../../../../src/core/errors/StateErrors.js";
+
+const SESSIONS_SUBDIR = ".state/sessions";
+const LOCK_STALE_MS = 5_000;
+
+function makeMinimalSession(sessionId: string) {
+  return {
+    shared_context: { session_id: sessionId, failed_task_ids: [] },
+    task_results: {
+      t1: {
+        task_id: "t1",
+        success: true,
+        raw_output: "ok",
+        summary: "ok",
+        completed_at: new Date().toISOString(),
+      },
+    },
+    current_task_id: null,
+    completed_task_ids: ["t1"],
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function sessionsDir(tmpDir: string) {
+  return join(tmpDir, SESSIONS_SUBDIR);
+}
+
+function writeLock(tmpDir: string, sessionId: string, content: string, mtimeOffset = 0) {
+  const dir = sessionsDir(tmpDir);
+  mkdirSync(dir, { recursive: true });
+  const lockPath = join(dir, `${sessionId}.lock`);
+  writeFileSync(lockPath, content);
+  if (mtimeOffset !== 0) {
+    const { utimesSync } = require("node:fs");
+    const t = (Date.now() + mtimeOffset) / 1000;
+    utimesSync(lockPath, t, t);
+  }
+  return lockPath;
+}
+
+describe("lock PID 스테일 감지", () => {
+  let tmpDir: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "detoks-lock-test-"));
+    origCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("잠금 없는 경우 saveSession이 정상 완료", async () => {
+    const state = makeMinimalSession("sess-no-lock") as any;
+    await expect(SessionStateManager.saveSession(state)).resolves.toBeUndefined();
+  });
+
+  it("죽은 PID가 잠금 파일에 있으면 스테일로 처리 — saveSession 성공", async () => {
+    // process.kill(pid, 0)이 ESRCH를 던지면 isProcessAlive = false → 스테일
+    const deadPid = 99999999;
+    writeLock(tmpDir, "sess-stale", String(deadPid));
+
+    // process.kill이 존재하지 않는 PID에 대해 throw하도록 spy
+    vi.spyOn(process, "kill").mockImplementation((pid: number, signal?: string | number) => {
+      if (signal === 0 && pid === deadPid) {
+        const err = Object.assign(new Error("No such process"), { code: "ESRCH" });
+        throw err;
+      }
+      return true;
+    });
+
+    const state = makeMinimalSession("sess-stale") as any;
+    await expect(SessionStateManager.saveSession(state)).resolves.toBeUndefined();
+  });
+
+  it("현재 프로세스 PID가 잠금 파일에 있으면 StateLockError", async () => {
+    const alivePid = process.pid;
+    writeLock(tmpDir, "sess-live", String(alivePid));
+
+    // process.kill spy: 현재 프로세스에 signal 0은 정상 반환(alive)
+    vi.spyOn(process, "kill").mockImplementation((pid: number, signal?: string | number) => {
+      if (signal === 0 && pid === alivePid) {
+        return true; // alive — does not throw
+      }
+      return true;
+    });
+
+    const state = makeMinimalSession("sess-live") as any;
+    await expect(SessionStateManager.saveSession(state)).rejects.toBeInstanceOf(StateLockError);
+  });
+
+  it("PID를 읽을 수 없는 잠금 + mtime이 오래된 경우 스테일로 처리 — saveSession 성공", async () => {
+    // PID 필드 없음(isNaN = true) + mtime이 LOCK_STALE_TIMEOUT_MS 초과
+    const staleOffset = -(LOCK_STALE_MS + 1000); // 현재보다 6초 이전
+    writeLock(tmpDir, "sess-no-pid", "not-a-number", staleOffset);
+
+    const state = makeMinimalSession("sess-no-pid") as any;
+    await expect(SessionStateManager.saveSession(state)).resolves.toBeUndefined();
+  });
+
+  it("PID를 읽을 수 없는 잠금 + mtime이 최근이면 StateLockError", async () => {
+    // PID 필드 없음(isNaN = true) + mtime이 LOCK_STALE_TIMEOUT_MS 이내
+    writeLock(tmpDir, "sess-fresh-no-pid", "not-a-number"); // 현재 시간 → 최신
+
+    const state = makeMinimalSession("sess-fresh-no-pid") as any;
+    await expect(SessionStateManager.saveSession(state)).rejects.toBeInstanceOf(StateLockError);
+  });
+});

--- a/tests/ts/unit/core/state/session-state-manager-security.test.ts
+++ b/tests/ts/unit/core/state/session-state-manager-security.test.ts
@@ -1,0 +1,149 @@
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { SessionStateManager } from "../../../../../src/core/state/SessionStateManager.js";
+import { StateIOError } from "../../../../../src/core/errors/StateErrors.js";
+
+const SESSIONS_SUBDIR = ".state/sessions";
+
+function makeMinimalSession(sessionId: string) {
+  return {
+    shared_context: { session_id: sessionId, failed_task_ids: [] },
+    task_results: {
+      t1: {
+        task_id: "t1",
+        success: true,
+        raw_output: "ok",
+        summary: "ok",
+        completed_at: new Date().toISOString(),
+      },
+    },
+    current_task_id: null,
+    completed_task_ids: ["t1"],
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function writeSession(dir: string, id: string) {
+  const sessDir = join(dir, SESSIONS_SUBDIR);
+  mkdirSync(sessDir, { recursive: true });
+  writeFileSync(join(sessDir, `${id}.json`), JSON.stringify(makeMinimalSession(id)));
+}
+
+describe("sessionId 패턴 검증 (assertSafeSessionId)", () => {
+  let tmpDir: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "detoks-sid-sec-"));
+    origCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── saveSession ────────────────────────────────────────────────────────────
+
+  it("saveSession — path traversal sessionId는 StateIOError", async () => {
+    const state = makeMinimalSession("../../etc/passwd") as any;
+    await expect(SessionStateManager.saveSession(state)).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  it("saveSession — 슬래시 포함 sessionId는 StateIOError", async () => {
+    const state = makeMinimalSession("sessions/evil") as any;
+    await expect(SessionStateManager.saveSession(state)).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  it("saveSession — 공백 포함 sessionId는 StateIOError", async () => {
+    const state = makeMinimalSession("session id") as any;
+    await expect(SessionStateManager.saveSession(state)).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  it("saveSession — 65자 초과 sessionId는 StateIOError", async () => {
+    const longId = "a".repeat(65);
+    const state = makeMinimalSession(longId) as any;
+    await expect(SessionStateManager.saveSession(state)).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  // saveSession은 빈 문자열을 'default'로 fallback하므로 loadSession으로 검증
+  it("loadSession — 빈 문자열 sessionId는 StateIOError", async () => {
+    await expect(SessionStateManager.loadSession("")).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  it("saveSession — 특수문자(@, !, #) sessionId는 StateIOError", async () => {
+    const state = makeMinimalSession("sess!on@#") as any;
+    await expect(SessionStateManager.saveSession(state)).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  // ── loadSession ────────────────────────────────────────────────────────────
+
+  it("loadSession — path traversal sessionId는 StateIOError", async () => {
+    await expect(SessionStateManager.loadSession("../../etc/passwd")).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  it("loadSession — 특수문자 sessionId는 StateIOError", async () => {
+    await expect(SessionStateManager.loadSession("sess!on")).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  // ── deleteSession ──────────────────────────────────────────────────────────
+
+  it("deleteSession — path traversal sessionId는 StateIOError", async () => {
+    await expect(SessionStateManager.deleteSession("../evil")).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  it("deleteSession — 슬래시 포함 sessionId는 StateIOError", async () => {
+    await expect(SessionStateManager.deleteSession("a/b")).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  // ── forkSession ────────────────────────────────────────────────────────────
+
+  it("forkSession — source sessionId가 invalid이면 StateIOError", async () => {
+    await expect(
+      SessionStateManager.forkSession("../evil-source", "valid-target"),
+    ).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  it("forkSession — new sessionId가 invalid이면 StateIOError", async () => {
+    writeSession(tmpDir, "valid-source");
+    await expect(
+      SessionStateManager.forkSession("valid-source", "../evil-target"),
+    ).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  // ── sessionExists ──────────────────────────────────────────────────────────
+
+  it("sessionExists — path traversal sessionId는 StateIOError", async () => {
+    await expect(SessionStateManager.sessionExists("../../etc/passwd")).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  it("sessionExists — 특수문자 sessionId는 StateIOError", async () => {
+    await expect(SessionStateManager.sessionExists("sess!on")).rejects.toBeInstanceOf(StateIOError);
+  });
+
+  // ── 유효한 ID는 허용 ────────────────────────────────────────────────────────
+
+  it("saveSession — 소문자+숫자 sessionId는 통과", async () => {
+    const state = makeMinimalSession("sess123") as any;
+    await expect(SessionStateManager.saveSession(state)).resolves.toBeUndefined();
+  });
+
+  it("saveSession — 하이픈·언더스코어 포함 sessionId는 통과", async () => {
+    const state = makeMinimalSession("sess-abc_def") as any;
+    await expect(SessionStateManager.saveSession(state)).resolves.toBeUndefined();
+  });
+
+  it("saveSession — 정확히 64자 sessionId는 통과", async () => {
+    const id = "a".repeat(64);
+    const state = makeMinimalSession(id) as any;
+    await expect(SessionStateManager.saveSession(state)).resolves.toBeUndefined();
+  });
+
+  it("loadSession — 유효한 sessionId로 로드 가능", async () => {
+    writeSession(tmpDir, "valid-sess");
+    await expect(SessionStateManager.loadSession("valid-sess")).resolves.toBeDefined();
+  });
+});

--- a/tests/ts/unit/integrations/adapters/adapter-passthrough-limit.test.ts
+++ b/tests/ts/unit/integrations/adapters/adapter-passthrough-limit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { AdapterExecutionRequest } from "../../../../../src/core/executor/types.js";
 import { ClaudeStubAdapter } from "../../../../../src/integrations/adapters/claude/adapter.js";
 import { CodexStubAdapter } from "../../../../../src/integrations/adapters/codex/adapter.js";
 import { GeminiStubAdapter } from "../../../../../src/integrations/adapters/gemini/adapter.js";
@@ -76,13 +77,15 @@ describe("passthrough 모드 prompt 크기 제한 (200,000 bytes)", () => {
       });
 
       it("prompt가 undefined이면 passthrough에서도 오류 없음", () => {
+        const requestWithMissingPrompt = {
+          mode: "run",
+          prompt: undefined,
+          presentationMode: "passthrough",
+          verbose: false,
+        } as unknown as AdapterExecutionRequest;
+
         expect(() =>
-          adapter.buildSubprocessRequest({
-            mode: "run",
-            prompt: undefined,
-            presentationMode: "passthrough",
-            verbose: false,
-          }),
+          adapter.buildSubprocessRequest(requestWithMissingPrompt),
         ).not.toThrow();
       });
     });

--- a/tests/ts/unit/integrations/adapters/adapter-passthrough-limit.test.ts
+++ b/tests/ts/unit/integrations/adapters/adapter-passthrough-limit.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { ClaudeStubAdapter } from "../../../../../src/integrations/adapters/claude/adapter.js";
+import { CodexStubAdapter } from "../../../../../src/integrations/adapters/codex/adapter.js";
+import { GeminiStubAdapter } from "../../../../../src/integrations/adapters/gemini/adapter.js";
+
+const LIMIT = 200_000; // bytes
+
+// 정확히 LIMIT 바이트인 ASCII 문자열 (1문자 = 1바이트)
+const promptAtLimit = "a".repeat(LIMIT);
+// LIMIT + 1 바이트 — 거부 경계
+const promptOverLimit = "a".repeat(LIMIT + 1);
+// 멀티바이트 문자(한글 1자 = 3바이트)로 LIMIT 초과
+const promptMultibyte = "가".repeat(Math.ceil((LIMIT + 1) / 3));
+
+describe("passthrough 모드 prompt 크기 제한 (200,000 bytes)", () => {
+  const adapters = [
+    { name: "claude", adapter: new ClaudeStubAdapter() },
+    { name: "codex", adapter: new CodexStubAdapter() },
+    { name: "gemini", adapter: new GeminiStubAdapter() },
+  ] as const;
+
+  for (const { name, adapter } of adapters) {
+    describe(`${name} adapter`, () => {
+      it("정확히 200,000 bytes는 통과", () => {
+        expect(() =>
+          adapter.buildSubprocessRequest({
+            mode: "run",
+            prompt: promptAtLimit,
+            presentationMode: "passthrough",
+            verbose: false,
+          }),
+        ).not.toThrow();
+      });
+
+      it("200,001 bytes에서 Error를 던진다", () => {
+        expect(() =>
+          adapter.buildSubprocessRequest({
+            mode: "run",
+            prompt: promptOverLimit,
+            presentationMode: "passthrough",
+            verbose: false,
+          }),
+        ).toThrow(/200,000 bytes/);
+      });
+
+      it("멀티바이트 문자로 200,000 bytes 초과 시 Error를 던진다", () => {
+        expect(() =>
+          adapter.buildSubprocessRequest({
+            mode: "run",
+            prompt: promptMultibyte,
+            presentationMode: "passthrough",
+            verbose: false,
+          }),
+        ).toThrow(/200,000 bytes/);
+      });
+
+      it("embedded-pane 모드에서는 크기 제한 없음", () => {
+        expect(() =>
+          adapter.buildSubprocessRequest({
+            mode: "run",
+            prompt: promptOverLimit,
+            presentationMode: "embedded-pane",
+            verbose: false,
+          }),
+        ).not.toThrow();
+      });
+
+      it("presentationMode 미지정(기본값)에서는 크기 제한 없음", () => {
+        expect(() =>
+          adapter.buildSubprocessRequest({
+            mode: "run",
+            prompt: promptOverLimit,
+            verbose: false,
+          }),
+        ).not.toThrow();
+      });
+
+      it("prompt가 undefined이면 passthrough에서도 오류 없음", () => {
+        expect(() =>
+          adapter.buildSubprocessRequest({
+            mode: "run",
+            prompt: undefined,
+            presentationMode: "passthrough",
+            verbose: false,
+          }),
+        ).not.toThrow();
+      });
+    });
+  }
+});


### PR DESCRIPTION
## 요약

- `fix-edge-cases-nan-saveSession-lock`에서 추가된 edge case 수정 로직 4종에 대한 회귀 테스트를 추가했습니다.
- 프로덕션 코드 변경 없음. 테스트 파일 4개 신규 추가, 총 59개 테스트 케이스.

## 변경 유형

- [x] 테스트 추가/수정

## 영향 범위

영향받는 모듈:

- `tests/ts/unit/core/state/session-state-manager-security.test.ts` (신규)
- `tests/ts/unit/core/state/session-state-manager-lock.test.ts` (신규)
- `tests/ts/unit/integrations/adapters/adapter-passthrough-limit.test.ts` (신규)
- `tests/ts/unit/core/pipeline/orchestrator-nan-env.test.ts` (신규)

영향받지 않는 모듈:

- 프로덕션 소스 전체 (`src/`) — 변경 없음

## 수정 내역 상세

### 1. sessionId 패턴 검증 (`session-state-manager-security.test.ts` — 18 케이스)

`assertSafeSessionId()`가 실제로 path traversal과 특수문자를 막는지 검증한다. `saveSession`, `loadSession`, `deleteSession`, `forkSession`, `sessionExists` 각 경로를 모두 포함한다.

거부되어야 하는 케이스:

```
../../etc/passwd   — path traversal
sessions/evil      — 슬래시
sess!on@#          — 특수문자
a × 65             — 64자 초과
""                 — 빈 문자열 (loadSession 경로)
```

통과해야 하는 케이스:

```
sess123            — 알파벳+숫자
sess-abc_def       — 하이픈·언더스코어 허용
a × 64             — 정확히 64자
```

### 2. lock PID 스테일 감지 (`session-state-manager-lock.test.ts` — 5 케이스)

`process.kill`을 `vi.spyOn`으로 모킹해 PID 생존 여부를 결정론적으로 제어한다.

| 시나리오 | 기대 결과 |
|---|---|
| 잠금 파일 없음 | `saveSession` 성공 |
| 죽은 PID (`ESRCH` 발생) | 스테일 → 자동 해제 → 성공 |
| 살아있는 PID (throw 없음) | `StateLockError` |
| PID 불명 + 오래된 mtime | 스테일 → 자동 해제 → 성공 |
| PID 불명 + 최신 mtime | `StateLockError` |

### 3. passthrough 200KB 제한 (`adapter-passthrough-limit.test.ts` — 18 케이스)

Claude, Codex, Gemini 세 어댑터를 동일한 테스트 매트릭스로 검증한다.

| 케이스 | presentationMode | 결과 |
|---|---|---|
| 200,000 bytes ASCII | passthrough | 통과 |
| 200,001 bytes ASCII | passthrough | Error |
| 멀티바이트(한글) > 200,000 bytes | passthrough | Error |
| 200,001 bytes | embedded-pane | 통과 |

### 4. Budget Gate NaN 방어 공식 (`orchestrator-nan-env.test.ts` — 18 케이스)

모듈 로드 타임 상수 테스트를 위해 공식 자체를 추출해 단위 검증한다.

## 테스트 방법

```bash
npx --no-install vitest run \
  tests/ts/unit/core/state/session-state-manager-security.test.ts \
  tests/ts/unit/core/state/session-state-manager-lock.test.ts \
  tests/ts/unit/integrations/adapters/adapter-passthrough-limit.test.ts \
  tests/ts/unit/core/pipeline/orchestrator-nan-env.test.ts
```

결과: `Test Files 4 passed (4) | Tests 59 passed (59)`

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] 신규 테스트 59개 전부 통과를 확인했습니다
- [x] 기존 테스트를 깨지 않음을 확인했습니다
- [x] 프로덕션 코드를 변경하지 않았습니다
- [x] 각 edge case를 의미 단위로 커밋 분리했습니다

## 리뷰어 참고사항

- lock 테스트에서 `process.kill` spy는 `vi.restoreAllMocks()`로 afterEach에서 항상 복구된다.
- passthrough 테스트는 subprocess를 실제로 실행하지 않는다. `buildSubprocessRequest()`만 호출한다.
- NaN 방어 공식 테스트는 모듈 상수를 직접 노출하지 않고, 동일한 공식을 helper 함수로 추출해 검증한다.
- `saveSession` 빈 문자열 케이스는 `|| 'default'` fallback 때문에 `loadSession`으로 대체 검증한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)