### PR TITLE
fix(tui): 승인 입력 라우팅과 멀티라인 붙여넣기 수정

### DIFF
--- a/src/cli/tui/approval-prompt.ts
+++ b/src/cli/tui/approval-prompt.ts
@@ -1,0 +1,25 @@
+import { colors } from "../colors.js";
+import { padDisplayWidth, wrapTextToDisplayWidth } from "./renderer.js";
+
+const APPROVAL_MESSAGES = [
+  "실행 전 확인",
+  "Enter 실행 · Esc 편집 복귀",
+] as const;
+
+export const buildExecutionApprovalLines = (width: number): string[] => {
+  if (width <= 0) {
+    return [];
+  }
+
+  const lines: string[] = [];
+  const divider = padDisplayWidth(`── Run Check ${"─".repeat(Math.max(0, width - 13))}`.slice(0, width), width);
+  lines.push(colors.warning(divider));
+
+  for (const message of APPROVAL_MESSAGES) {
+    for (const segment of wrapTextToDisplayWidth(message, width)) {
+      lines.push(colors.warning(padDisplayWidth(segment, width)));
+    }
+  }
+
+  return lines;
+};

--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -42,6 +42,7 @@ import {
   type EmbeddedNativeCliSession,
 } from "./native-cli-session.js";
 import { formatEmbeddedTerminalFocusHint } from "./embedded-terminal.js";
+import { buildExecutionApprovalLines } from "./approval-prompt.js";
 import {
   createPinnedViewportState,
   resolveViewportWindow,
@@ -83,6 +84,34 @@ interface TuiRunOptions {
   presentationMode?: CliArgs["presentationMode"];
 }
 
+type RunBlockStatus = "pending-approval" | "running" | "completed" | "failed" | "cancelled";
+
+interface TuiRunBlock {
+  id: string;
+  index: number;
+  prompt: string;
+  status: RunBlockStatus;
+  createdAt: number;
+  completedAt?: number | undefined;
+  pane: EmbeddedTerminalPane;
+  summaryLines: string[];
+}
+
+interface StickyPromptState {
+  runId: string;
+  prompt: string;
+  status: RunBlockStatus;
+}
+
+const truncateToDisplayWidth = (text: string, width: number): string => {
+  if (width <= 0) {
+    return "";
+  }
+
+  const [firstLine = ""] = wrapTextToDisplayWidth(text, width);
+  return firstLine;
+};
+
 const formatTokenSavingsBadge = (reduction?: TokenReductionSnapshot | null): string | undefined => {
   if (!reduction) {
     return undefined;
@@ -104,8 +133,8 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
   const decoder = new StringDecoder("utf8");
   let currentAdapter = options.adapter;
   let currentAdapterModel = options.adapterModel ?? getAdapterModel(currentAdapter);
-  let currentTranslationModel = options.translationModel ?? getTranslationModel();
-  let currentVerbose = options.verbose;
+    let currentTranslationModel = options.translationModel ?? getTranslationModel();
+    let currentVerbose = options.verbose;
   let currentCacheDisabled = false;
   let currentInferenceStrength =
     currentAdapter === "codex"
@@ -204,7 +233,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     const pipelinePanel = new PipelineStatusPanel();
     const transcriptPanel = new TranscriptPanel();
     const resultPanel = new ResultSummaryPanel();
-    const embeddedTerminalPane = new EmbeddedTerminalPane();
+    let embeddedTerminalPane = new EmbeddedTerminalPane();
     const embeddedTerminalFocus = createEmbeddedTerminalFocusManager();
     let hasExecuted = false;
     let lastInputSeparatorRow = -1;
@@ -220,8 +249,86 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     let executionClockTimer: NodeJS.Timeout | undefined;
     let forceFullRender = false;
     let scrollViewportState = createPinnedViewportState();
-    let lastSubmittedPrompt: string | null = null;
+    let pendingApprovalPrompt: string | null = null;
+    let skipApprovalLineFeed = false;
     let pendingMouseInputSequence = "";
+    let runBlocks: TuiRunBlock[] = [];
+    let activeRunBlock: TuiRunBlock | null = null;
+    let stickyPrompt: StickyPromptState | null = null;
+
+    const getStickyPromptText = (): string | null => stickyPrompt?.prompt ?? pendingApprovalPrompt;
+
+    const getStickyPromptStatus = (): string => {
+      if (stickyPrompt !== null) {
+        switch (stickyPrompt.status) {
+          case "pending-approval":
+            return "실행 확인 대기 · Enter 실행 · Esc 편집 복귀";
+          case "running":
+            return "실행 중";
+          case "completed":
+            return "완료";
+          case "failed":
+            return "실패";
+          case "cancelled":
+            return "취소됨";
+        }
+      }
+
+      if (pendingApprovalPrompt !== null) {
+        return "실행 확인 대기 · Enter 실행 · Esc 편집 복귀";
+      }
+
+      return hasExecuted ? "최근 실행 완료" : "첫 프롬프트를 입력하세요";
+    };
+
+    const getEmbeddedStickyRows = (): number => 4;
+    const getEmbeddedActivityRows = (): number => 1;
+    const getEmbeddedFixedRows = (): number => getEmbeddedStickyRows() + getEmbeddedActivityRows();
+
+    const setStickyPromptFromRun = (run: TuiRunBlock): void => {
+      stickyPrompt = {
+        runId: run.id,
+        prompt: run.prompt,
+        status: run.status,
+      };
+    };
+
+    const createRunBlock = (prompt: string): TuiRunBlock => {
+      const index = runBlocks.length + 1;
+      return {
+        id: `run-${Date.now()}-${index}`,
+        index,
+        prompt,
+        status: "running",
+        createdAt: Date.now(),
+        pane: new EmbeddedTerminalPane(),
+        summaryLines: [],
+      };
+    };
+
+    const registerRunBlock = (prompt: string, status: RunBlockStatus): TuiRunBlock => {
+      const block = createRunBlock(prompt);
+      block.status = status;
+      runBlocks.push(block);
+      activeRunBlock = block;
+      embeddedTerminalPane = block.pane;
+      setStickyPromptFromRun(block);
+      return block;
+    };
+
+    const updateActiveRunBlockStatus = (status: RunBlockStatus): void => {
+      if (activeRunBlock === null) {
+        return;
+      }
+
+      activeRunBlock.status = status;
+      if (status === "running") {
+        activeRunBlock.completedAt = undefined;
+      } else {
+        activeRunBlock.completedAt = Date.now();
+      }
+      setStickyPromptFromRun(activeRunBlock);
+    };
 
     const buildSectionDivider = (label: string, width: number): string => {
       if (width <= 0) {
@@ -251,32 +358,159 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       return wrapped;
     };
 
-    const buildScrollableContentLines = (width: number): string[] => {
+    const buildStickyPromptLines = (width: number): string[] => {
+      if (width <= 0) {
+        return [];
+      }
+
+      const promptText = getStickyPromptText();
+      const statusText = getStickyPromptStatus();
+      const lines: string[] = [];
+
+      if (promptText === null) {
+        lines.push(buildSectionDivider("Sticky Prompt", width));
+        lines.push(
+          ...buildWrappedBlock(
+            [hasExecuted ? "최근 실행 결과를 준비하는 중입니다." : "첫 프롬프트를 입력하세요."],
+            width,
+          ).map((line) => colors.muted(line)),
+        );
+        lines.push(colors.muted(padDisplayWidth(`상태: ${statusText}`, width)));
+        lines.push(" ".repeat(width));
+        return lines.slice(0, getEmbeddedStickyRows());
+      }
+
+      lines.push(buildSectionDivider("Sticky Prompt", width));
+      lines.push(
+        ...buildWrappedBlock(promptText.split("\n"), width, "> ").slice(0, Math.max(0, getEmbeddedStickyRows() - 2)),
+      );
+      lines.push(colors.muted(padDisplayWidth(`상태: ${statusText}`, width)));
+      lines.push(" ".repeat(width));
+      return lines.slice(0, getEmbeddedStickyRows());
+    };
+
+    const buildEmbeddedActivityLines = (width: number): string[] => {
+      if (width <= 0) {
+        return [];
+      }
+
+      const activity = activeRunBlock?.pane.getActivitySnapshot(width);
+      if (activity === null || activity === undefined) {
+        return [
+          colors.muted(padDisplayWidth("현재 활동: 대기", width)),
+        ].slice(0, getEmbeddedActivityRows());
+      }
+
+      const statusLabel =
+        activity.status === "running" ? "진행 중" : activity.status === "completed" ? "완료" : "실패";
+      const compactLine = truncateToDisplayWidth(
+        `현재 활동: ${activity.label} · ${activity.detail} · ${statusLabel}`,
+        width,
+      );
+      return [
+        activity.status === "failed"
+          ? colors.error(padDisplayWidth(compactLine, width))
+          : colors.muted(padDisplayWidth(compactLine, width)),
+      ].slice(0, getEmbeddedActivityRows());
+    };
+
+    const buildRunSummaryLines = (run: TuiRunBlock, width: number): string[] => {
+      if (run.status === "pending-approval") {
+        return buildExecutionApprovalLines(width).map((line) => line);
+      }
+
+      if (run.status === "running" && activeRunBlock?.id === run.id) {
+        const currentSummary = resultPanel.getLines();
+        if (currentSummary.length > 0) {
+          return currentSummary;
+        }
+      }
+
+      if (run.summaryLines.length > 0) {
+        return run.summaryLines;
+      }
+
+      if (run.status === "cancelled") {
+        return ["실행이 취소되었습니다."];
+      }
+
+      if (run.status === "failed") {
+        return ["실행이 실패했습니다."];
+      }
+
+      if (run.status === "running") {
+        return ["", "  Waiting for adapter CLI to finish…"];
+      }
+
+      return ["실행 결과가 아직 없습니다."];
+    };
+
+    const buildRunBlockLines = (run: TuiRunBlock, width: number): string[] => {
       if (width <= 0) {
         return [];
       }
 
       const lines: string[] = [];
+      lines.push(buildSectionDivider(`Run #${run.index}`, width));
+      lines.push(colors.muted(padDisplayWidth(`상태: ${getStickyPromptStatusForRun(run)}`, width)));
+      lines.push(buildSectionDivider(`Prompt #${run.index}`, width));
+      lines.push(...buildWrappedBlock(run.prompt.split("\n"), width, "> "));
+      lines.push(buildSectionDivider(`Original CLI #${run.index}`, width));
 
-      if (lastSubmittedPrompt !== null) {
-        lines.push(buildSectionDivider("Prompt", width));
-        lines.push(...buildWrappedBlock(lastSubmittedPrompt.split("\n"), width, "> "));
-        lines.push(colors.header("─".repeat(width)));
-        lines.push(" ".repeat(width));
+      if (run.status === "pending-approval") {
+        lines.push(
+          ...buildWrappedBlock(
+            ["실행 확인 대기 중 · Enter로 실행 · Esc로 편집 복귀"],
+            width,
+          ).map((line) => colors.muted(line)),
+        );
+      } else {
+        const cliLines = run.pane.getRenderableLines(width).map((line) => line.text);
+        lines.push(...cliLines);
       }
 
-      lines.push(...embeddedTerminalPane.getRenderableLines(width).map((line) => line.text));
-      lines.push(" ".repeat(width));
-      lines.push(buildSectionDivider("Summary", width));
-
-      const summaryLines = resultPanel.getLines();
-      if (summaryLines.length === 0 && !isExecuting) {
-        lines.push(...buildWrappedBlock([
-          "실행 결과가 아직 없습니다.",
-          "첫 실행 이후 작업 타임라인 · 다음 작업 · 사용량/압축 지표가 이 영역에 표시됩니다.",
-        ], width).map((line) => colors.muted(line)));
-      } else {
+      lines.push(buildSectionDivider(`Summary #${run.index}`, width));
+      const summaryLines = buildRunSummaryLines(run, width);
+      if (summaryLines.length > 0) {
         lines.push(...buildWrappedBlock(summaryLines, width));
+      }
+      lines.push(" ".repeat(width));
+      return lines;
+    };
+
+    const getStickyPromptStatusForRun = (run: TuiRunBlock): string => {
+      switch (run.status) {
+        case "pending-approval":
+          return "실행 확인 대기";
+        case "running":
+          return "실행 중";
+        case "completed":
+          return "완료";
+        case "failed":
+          return "실패";
+        case "cancelled":
+          return "취소됨";
+      }
+    };
+
+    const buildScrollableContentLines = (width: number): string[] => {
+      if (width <= 0) {
+        return [];
+      }
+
+      if (runBlocks.length === 0) {
+        return buildWrappedBlock(
+          [
+            "실행 히스토리가 아직 없습니다.",
+            "프롬프트를 실행하면 여기 아래에 RunBlock이 누적됩니다.",
+          ],
+          width,
+        ).map((line) => colors.muted(line));
+      }
+
+      const lines: string[] = [];
+      for (const run of runBlocks) {
+        lines.push(...buildRunBlockLines(run, width));
       }
 
       return lines;
@@ -288,7 +522,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       const bannerRows = Math.min(3, Math.max(0, inputLayout.separatorRow));
       const statusRegionStart = bannerRows;
       const statusRegionEnd = Math.min(inputLayout.separatorRow, statusRegionStart + 8);
-      const contentHeight = Math.max(0, inputLayout.separatorRow - statusRegionEnd);
+      const contentHeight = Math.max(0, inputLayout.separatorRow - statusRegionEnd - getEmbeddedFixedRows());
       const totalLines = buildScrollableContentLines(dims.columns).length;
       scrollViewportState = scrollViewportBy(totalLines, contentHeight, scrollViewportState, deltaRows);
     };
@@ -411,7 +645,9 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     const renderBanner = (): void => {
       const dims = screen.getDimensions();
       const browsingHistoryHint =
-        embeddedPaneMode && !scrollViewportState.pinnedToBottom
+        stickyPrompt?.status === "pending-approval" || pendingApprovalPrompt !== null
+          ? "실행 대기 중 · Enter 실행 · Esc 편집 복귀"
+          : embeddedPaneMode && !scrollViewportState.pinnedToBottom
           ? "기록 탐색 중 · ↑↓ PgUp/PgDn/휠 · End로 최신으로 이동"
           : "첫 프롬프트를 입력하면 아래 패널이 채워집니다 · /... 자동완성 · q 종료";
       const bannerLines = [
@@ -516,6 +752,9 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         inputLayout.separatorRow,
         contentRegionStart + transcriptRows,
       );
+      const stickyRows = embeddedPaneMode ? getEmbeddedFixedRows() : 0;
+      const stickyRegionStart = contentRegionStart;
+      const stickyRegionEnd = Math.min(inputLayout.separatorRow, stickyRegionStart + stickyRows);
 
       // Render structure (minimal - no borders)
       renderScreenBorder(ctx);
@@ -528,12 +767,36 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       };
       pipelinePanel.render(ctx, statusRegion);
 
-      const transcriptRegion = {
-        startRow: contentRegionStart,
-        endRow: embeddedPaneMode ? inputLayout.separatorRow : transcriptRegionEnd,
-        columns: dims.columns,
-      };
       if (embeddedPaneMode) {
+        const stickyRegion = {
+          startRow: stickyRegionStart,
+          endRow: stickyRegionEnd,
+          columns: dims.columns,
+        };
+        const stickyLines = [
+          ...buildStickyPromptLines(stickyRegion.columns),
+          ...buildEmbeddedActivityLines(stickyRegion.columns),
+        ];
+        let stickyRow = stickyRegion.startRow;
+        for (const line of stickyLines.slice(0, Math.max(0, stickyRegion.endRow - stickyRegion.startRow))) {
+          if (stickyRow >= stickyRegion.endRow) {
+            break;
+          }
+          screen.cursorMoveTo(stickyRow, 0);
+          screen.write(line);
+          stickyRow += 1;
+        }
+        while (stickyRow < stickyRegion.endRow) {
+          screen.cursorMoveTo(stickyRow, 0);
+          screen.write(" ".repeat(stickyRegion.columns));
+          stickyRow += 1;
+        }
+
+        const transcriptRegion = {
+          startRow: stickyRegionEnd,
+          endRow: inputLayout.separatorRow,
+          columns: dims.columns,
+        };
         const contentLines = buildScrollableContentLines(transcriptRegion.columns);
         const viewport = resolveViewportWindow(
           contentLines.length,
@@ -560,12 +823,17 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           row += 1;
         }
 
-        const transcriptRows = Math.max(1, Math.ceil(availableContentRows * 0.7));
+        const transcriptRows = Math.max(1, Math.ceil(Math.max(0, availableContentRows - stickyRows) * 0.7));
         embeddedTerminalPane.resize(transcriptRegion.columns, transcriptRows);
         if (embeddedNativeCliSession !== null) {
           embeddedNativeCliSession?.resize(transcriptRegion.columns, transcriptRows);
         }
       } else {
+        const transcriptRegion = {
+          startRow: contentRegionStart,
+          endRow: transcriptRegionEnd,
+          columns: dims.columns,
+        };
         transcriptPanel.render(ctx, transcriptRegion);
       }
 
@@ -658,6 +926,56 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       // Process text, handling both escape sequences and individual characters
       while (i < text.length) {
         let handled = false;
+
+        if (pendingApprovalPrompt !== null) {
+          const char = text.charAt(i);
+          if (skipApprovalLineFeed) {
+            if (char === "\n") {
+              skipApprovalLineFeed = false;
+              i++;
+              continue;
+            }
+
+            skipApprovalLineFeed = false;
+          }
+
+          if (char === "\x03") {
+            closeEmbeddedNativeCliSession("SIGINT");
+            running = false;
+            needsFullRender = true;
+            i++;
+            continue;
+          }
+
+          if (char === "\r" || char === "\n") {
+            const approvedPrompt = pendingApprovalPrompt;
+            pendingApprovalPrompt = null;
+            skipApprovalLineFeed = false;
+            if (approvedPrompt !== null) {
+              executePrompt(approvedPrompt, activeRunBlock ?? undefined);
+            }
+            i++;
+            continue;
+          }
+
+          if (char === "\x1b") {
+            if (activeRunBlock !== null) {
+              activeRunBlock.status = "cancelled";
+              activeRunBlock.completedAt = Date.now();
+              activeRunBlock.summaryLines = ["실행이 취소되었습니다."];
+              setStickyPromptFromRun(activeRunBlock);
+            }
+            input = pendingApprovalPrompt;
+            pendingApprovalPrompt = null;
+            skipApprovalLineFeed = false;
+            render();
+            i++;
+            continue;
+          }
+
+          i++;
+          continue;
+        }
 
         // Check for escape sequences first (multi-character sequences)
         // Must be processed as atomic units before character-by-character handling
@@ -892,7 +1210,22 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
                       slashAutocompleteSelectedIndex,
                     )?.usage ?? input
                   : input;
-              executePrompt(resolvedPrompt);
+              const normalizedPrompt = resolvedPrompt.trim();
+              const shouldRequestApproval =
+                embeddedPaneMode &&
+                options.executionMode === "real" &&
+                normalizedPrompt.length > 0 &&
+                !normalizedPrompt.startsWith("/");
+
+              if (shouldRequestApproval) {
+                hasExecuted = true;
+                registerRunBlock(resolvedPrompt, "pending-approval");
+                pendingApprovalPrompt = resolvedPrompt;
+                skipApprovalLineFeed = char === "\r";
+                render();
+              } else {
+                executePrompt(resolvedPrompt);
+              }
               input = ""; // Clear input for next prompt
               slashAutocompleteSelectedIndex = 0;
             }
@@ -962,15 +1295,14 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     };
 
     // Phase 3: Execute prompt function
-    const executePrompt = async (prompt: string): Promise<void> => {
+    const executePrompt = async (prompt: string, runBlock?: TuiRunBlock): Promise<void> => {
       isExecuting = true;
       hasExecuted = true;
-      lastSubmittedPrompt = prompt;
-      scrollViewportState = scrollViewportToBottom();
+      const normalizedPrompt = prompt.trim();
+      let currentRunBlock: TuiRunBlock | null = runBlock ?? null;
       const workspaceBefore = captureWorkspaceSnapshot(executionCwd);
       let receivedLiveAdapterEvents = false;
       try {
-        const normalizedPrompt = prompt.trim();
         if (normalizedPrompt.startsWith("/")) {
           let shouldRestoreMainScreen = false;
           const previousState = {
@@ -1027,13 +1359,18 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           return;
         }
 
-        // Clear previous results
+        currentRunBlock = runBlock ?? registerRunBlock(prompt, "running");
+        if (currentRunBlock.status !== "running") {
+          updateActiveRunBlockStatus("running");
+        } else {
+          setStickyPromptFromRun(currentRunBlock);
+        }
+
         if (embeddedPaneMode) {
           closeEmbeddedNativeCliSession();
           embeddedTerminalFocus.focusDetoks();
         }
         transcriptPanel.clear();
-        embeddedTerminalPane.clear();
         resultPanel.clear();
         if (embeddedPaneMode) {
           resultPanel.setExecuting(true);
@@ -1124,10 +1461,15 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         const actionTimeline = buildActionTimeline(result, workspaceDiff);
 
         // Phase 3.4: Display result
-        resultPanel.setResult({
+        const completedResult = {
           ...result,
           ...(actionTimeline.length > 0 ? { actionTimeline } : {}),
-        });
+        };
+        resultPanel.setResult(completedResult);
+        currentRunBlock.summaryLines = resultPanel.getLines();
+        currentRunBlock.status = completedResult.ok ? "completed" : "failed";
+        currentRunBlock.completedAt = Date.now();
+        setStickyPromptFromRun(currentRunBlock);
         if (embeddedPaneMode) {
           closeEmbeddedNativeCliSession();
         }
@@ -1155,6 +1497,16 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         // Display error
         const errorMsg = formatError(error, currentVerbose);
         resultPanel.clear();
+        if (currentRunBlock !== null) {
+          currentRunBlock.status = "failed";
+          currentRunBlock.completedAt = Date.now();
+          currentRunBlock.summaryLines = [
+            `✗ 실패  어댑터: ${currentAdapter}  세션: ${options.sessionId ?? "new"}`,
+            `요약: ${errorMsg}`,
+            "다음 작업: 입력을 수정한 뒤 다시 시도하세요.",
+          ];
+          setStickyPromptFromRun(currentRunBlock);
+        }
         if (embeddedPaneMode) {
           embeddedTerminalPane.appendFinalAnswer(`\n[ERROR] ${errorMsg}\n`);
         } else {

--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -72,6 +72,7 @@ import {
 } from "../config/config-manager.js";
 import { loadAndApplyConfig } from "../config/loader.js";
 import type { PipelineProgressEvent } from "../../core/pipeline/types.js";
+import type { PtySessionController } from "../../integrations/subprocess/types.js";
 
 interface TuiRunOptions {
   adapter: CliArgs["adapter"];
@@ -243,6 +244,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     let isInputSuspended = false;
     let isPasting = false;
     let embeddedNativeCliSession: EmbeddedNativeCliSession | null = null;
+    let activeAdapterController: PtySessionController | null = null;
     let pendingNativeEscapeReturn = false;
     let pendingNativeEscapeTimer: NodeJS.Timeout | undefined;
     let executionClockStartedAt: number | null = null;
@@ -392,6 +394,18 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     const buildEmbeddedActivityLines = (width: number): string[] => {
       if (width <= 0) {
         return [];
+      }
+
+      const interactionState =
+        activeRunBlock?.status === "running" ? activeRunBlock.pane.getInteractionState(width) : null;
+      if (interactionState?.kind === "approval") {
+        const approvalLine = truncateToDisplayWidth(
+          `현재 활동: ${interactionState.label} · ${interactionState.detail ?? "승인 대기 중"} · 진행 중`,
+          width,
+        );
+        return [
+          colors.warning(padDisplayWidth(approvalLine, width)),
+        ].slice(0, getEmbeddedActivityRows());
       }
 
       const activity = activeRunBlock?.pane.getActivitySnapshot(width);
@@ -566,6 +580,20 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         embeddedNativeCliSession?.close();
       }
       embeddedNativeCliSession = null;
+    };
+
+    const closeActiveAdapterController = (signal?: NodeJS.Signals): void => {
+      if (signal !== undefined) {
+        activeAdapterController?.kill(signal);
+      } else {
+        activeAdapterController?.close();
+      }
+      activeAdapterController = null;
+    };
+
+    const closeExecutionControllers = (signal?: NodeJS.Signals): void => {
+      closeEmbeddedNativeCliSession(signal);
+      closeActiveAdapterController(signal);
     };
 
     const clearExecutionClock = (): void => {
@@ -908,12 +936,22 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         }
 
         // Embedded pane: forward raw bytes to child while adapter-terminal is focused
-        if (
-          embeddedPaneMode &&
-          embeddedTerminalFocus.focus === "adapter-terminal" &&
-          embeddedNativeCliSession !== null
-        ) {
-          embeddedNativeCliSession.write(text);
+        if (embeddedPaneMode && embeddedTerminalFocus.focus === "adapter-terminal") {
+          if (text === "\x07") {
+            clearNativeEscapeTimer();
+            embeddedTerminalFocus.focusDetoks();
+            renderInteractiveInput();
+            return;
+          }
+
+          if (activeAdapterController !== null) {
+            activeAdapterController.write(text);
+            return;
+          }
+
+          if (embeddedNativeCliSession !== null) {
+            embeddedNativeCliSession.write(text);
+          }
         }
         return;
       }
@@ -940,7 +978,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           }
 
           if (char === "\x03") {
-            closeEmbeddedNativeCliSession("SIGINT");
+            closeExecutionControllers("SIGINT");
             running = false;
             needsFullRender = true;
             i++;
@@ -1191,7 +1229,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
             needsFullRender = true;
           } else if (char === "\x03") {
             // Ctrl+C: close any active embedded session before exiting
-            closeEmbeddedNativeCliSession("SIGINT");
+            closeExecutionControllers("SIGINT");
             running = false;
             needsFullRender = true;
           } else if (char === "\r" || char === "\n") {
@@ -1327,7 +1365,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               shouldRestoreMainScreen = true;
             },
             onAdapterChange: async (newAdapter) => {
-              closeEmbeddedNativeCliSession();
+              closeExecutionControllers();
               currentAdapter = newAdapter;
               loadAndApplyConfig(newAdapter);
               updateSelectedAdapter(newAdapter);
@@ -1367,7 +1405,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         }
 
         if (embeddedPaneMode) {
-          closeEmbeddedNativeCliSession();
+          closeExecutionControllers();
           embeddedTerminalFocus.focusDetoks();
         }
         transcriptPanel.clear();
@@ -1409,6 +1447,9 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           ...request,
           ...(options.presentationMode ? { presentationMode: options.presentationMode } : {}),
           onProgress,
+          onPtyController: (controller) => {
+            activeAdapterController = controller;
+          },
           onAdapterEvent: (event) => {
             receivedLiveAdapterEvents = true;
             if (nativePassthroughMode) {
@@ -1417,6 +1458,13 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
 
             if (embeddedPaneMode) {
               embeddedTerminalPane.addEvent(event);
+              const interactionState = embeddedTerminalPane.getInteractionState();
+              if (
+                interactionState?.kind === "approval" &&
+                embeddedTerminalFocus.focus !== "adapter-terminal"
+              ) {
+                embeddedTerminalFocus.focusNative();
+              }
             } else {
               transcriptPanel.addEvent(event);
             }
@@ -1471,9 +1519,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         currentRunBlock.completedAt = Date.now();
         setStickyPromptFromRun(currentRunBlock);
         if (embeddedPaneMode) {
-          closeEmbeddedNativeCliSession();
-        }
-        if (embeddedPaneMode) {
+          closeExecutionControllers();
           embeddedTerminalFocus.focusDetoks();
         }
         currentTokenSavingsLabel = result.cacheHit
@@ -1515,6 +1561,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         render();
       } finally {
         clearExecutionClock();
+        closeActiveAdapterController();
+        if (embeddedPaneMode) {
+          embeddedTerminalFocus.focusDetoks();
+        }
         resumeInput();
         isExecuting = false;
       }
@@ -1523,7 +1573,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     stdin.on("data", onData);
     stdin.on("end", () => {
       clearNativeEscapeTimer();
-      closeEmbeddedNativeCliSession();
+      closeExecutionControllers();
       running = false;
     });
 

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -120,6 +120,410 @@ const META_LINE_PATTERNS = [
   /^session id:/,
 ] as const;
 
+const TOOL_ACTIVITY_PATTERNS = [
+  /^web search:/i,
+  /^tool_search:/i,
+  /^mcp\b/i,
+  /^todo_list\b/i,
+] as const;
+
+const COMMAND_STATUS_PATTERNS = [
+  /^succeeded in \d+ms:?$/i,
+  /^failed in \d+ms:?$/i,
+  /^exit code \d+$/i,
+] as const;
+
+const COMMAND_LINE_PATTERNS = [
+  /^\/bin\/(zsh|bash|sh)\b/i,
+  /^rg\b/i,
+  /^grep\b/i,
+  /^find\b/i,
+  /^git\b/i,
+  /^npm\b/i,
+  /^npx\b/i,
+  /^node\b/i,
+  /^python(?:3)?\b/i,
+  /^bun\b/i,
+  /^yarn\b/i,
+  /^pnpm\b/i,
+] as const;
+
+const CONVERSATION_ROLE_PATTERNS = [
+  /^codex$/i,
+  /^user$/i,
+  /^tokens used$/i,
+] as const;
+
+interface RenderedRowInfo {
+  cells: TerminalCell[];
+  plainText: string;
+  globalRow: number;
+}
+
+export type EmbeddedActivityKind = "file" | "search" | "tool" | "test" | "git" | "command";
+
+export interface EmbeddedActivitySnapshot {
+  kind: EmbeddedActivityKind;
+  label: string;
+  detail: string;
+  status: "running" | "completed" | "failed";
+}
+
+const isMetaLine = (plainText: string): boolean =>
+  plainText.length > 0 &&
+  (plainText === "--------" || META_LINE_PATTERNS.some((pattern) => pattern.test(plainText)));
+
+const isToolActivityLine = (plainText: string): boolean =>
+  plainText.length > 0 && TOOL_ACTIVITY_PATTERNS.some((pattern) => pattern.test(plainText));
+
+const isCommandStatusLine = (plainText: string): boolean =>
+  plainText.length > 0 && COMMAND_STATUS_PATTERNS.some((pattern) => pattern.test(plainText));
+
+const looksLikeCommandLine = (plainText: string): boolean =>
+  plainText.length > 0 && COMMAND_LINE_PATTERNS.some((pattern) => pattern.test(plainText));
+
+const isConversationRoleLine = (plainText: string): boolean =>
+  plainText.length > 0 && CONVERSATION_ROLE_PATTERNS.some((pattern) => pattern.test(plainText));
+
+const extractCommandName = (commandLine: string): string => {
+  const target = extractShellPayload(commandLine);
+  const firstToken = target.split(/\s+/)[0] ?? target;
+  const basename = firstToken.split("/").pop() ?? firstToken;
+  return basename.length > 0 ? basename : "command";
+};
+
+const extractShellPayload = (commandLine: string): string => {
+  const trimmed = commandLine.trim();
+  const shellMatch = trimmed.match(/\s-lc\s+(?:"((?:\\.|[^"\\])*)"|'([^']*)'|(\S.*?))(?:\s+in\s+\/.*)?$/);
+  if (shellMatch) {
+    return (shellMatch[1] ?? shellMatch[2] ?? shellMatch[3] ?? trimmed)
+      .replace(/\\"/g, "\"")
+      .replace(/\\'/g, "'")
+      .trim();
+  }
+
+  return trimmed.replace(/\s+in\s+\/.*$/, "").trim();
+};
+
+const extractPathCandidate = (commandLine: string): string | null => {
+  const payload = extractShellPayload(commandLine);
+  const pathMatches = payload.match(/(?:~\/|\/|\.\.?\/)[^\s"'`]+/g);
+  if (pathMatches !== null && pathMatches.length > 0) {
+    return pathMatches[pathMatches.length - 1] ?? null;
+  }
+
+  const tokens = payload.split(/\s+/).filter(Boolean);
+  const likelyPath = [...tokens].reverse().find((token) =>
+    /[./]/.test(token) && /\.(?:[cm]?[jt]sx?|json|md|yml|yaml|toml|lock|txt|css|html|py|rs|go|java|swift)$/i.test(token),
+  );
+  return likelyPath?.replace(/[;:,]+$/, "") ?? null;
+};
+
+const extractSearchQuery = (commandLine: string): string | null => {
+  const payload = extractShellPayload(commandLine);
+  const quoted = payload.match(/\b(?:rg|grep)\b(?:\s+-\S+)*\s+(?:"([^"]+)"|'([^']+)')/i);
+  if (quoted) {
+    return quoted[1] ?? quoted[2] ?? null;
+  }
+
+  const tokens = payload.split(/\s+/).filter(Boolean);
+  const commandIndex = tokens.findIndex((token) => /^(rg|grep)$/i.test(token.split("/").pop() ?? token));
+  if (commandIndex >= 0) {
+    return tokens.slice(commandIndex + 1).find((token) => !token.startsWith("-"))?.replace(/[;:,]+$/, "") ?? null;
+  }
+
+  return null;
+};
+
+const describeCommandActivity = (commandLine: string): Omit<EmbeddedActivitySnapshot, "status"> => {
+  const payload = extractShellPayload(commandLine);
+  const commandName = extractCommandName(commandLine);
+  const path = extractPathCandidate(commandLine);
+
+  if (/\b(sed|cat|less|head|tail)\b/i.test(payload) && path !== null) {
+    return { kind: "file", label: "파일 읽기", detail: path };
+  }
+
+  if (/\b(rg|grep|find)\b/i.test(payload)) {
+    const query = extractSearchQuery(commandLine);
+    return { kind: "search", label: "검색", detail: query ?? payload };
+  }
+
+  if (/\b(git)\b/i.test(payload)) {
+    return { kind: "git", label: "Git", detail: payload };
+  }
+
+  if (/\b(npm|npx|pnpm|yarn|node)\b/i.test(payload) && /\b(test|vitest|tsc|build)\b/i.test(payload)) {
+    return { kind: "test", label: "검증", detail: payload };
+  }
+
+  return { kind: "command", label: "명령 실행", detail: commandName };
+};
+
+const statusFromCommandStatusLine = (statusLine: string | null): EmbeddedActivitySnapshot["status"] => {
+  if (statusLine === null) {
+    return "running";
+  }
+
+  if (/^succeeded in/i.test(statusLine)) {
+    return "completed";
+  }
+
+  return "failed";
+};
+
+const summarizeCommandActivity = (
+  commandLine: string,
+  maxWidth: number,
+  status: EmbeddedActivitySnapshot["status"],
+): string => {
+  const activity = describeCommandActivity(commandLine);
+  const statusLabel = status === "running" ? "진행 중" : status === "completed" ? "완료" : "실패";
+  return truncateForSummary(`${activity.label}: ${activity.detail} · ${statusLabel}`, maxWidth);
+};
+
+const truncateForSummary = (text: string, maxWidth: number): string => {
+  if (maxWidth <= 0) {
+    return "";
+  }
+
+  if (text.length <= maxWidth) {
+    return text;
+  }
+
+  if (maxWidth <= 3) {
+    return ".".repeat(maxWidth);
+  }
+
+  return `${text.slice(0, maxWidth - 3)}...`;
+};
+
+const findMetaValue = (rows: RenderedRowInfo[], key: string): string | null => {
+  const matched = rows.find((row) => row.plainText.startsWith(key));
+  if (!matched) {
+    return null;
+  }
+
+  const value = matched.plainText.slice(key.length).trim();
+  return value.length > 0 ? value : null;
+};
+
+const summarizeMetadataBlock = (rows: RenderedRowInfo[], maxWidth: number): string => {
+  const parts: string[] = [];
+  const header = rows.find((row) => /^OpenAI Codex\b/i.test(row.plainText));
+  if (header) {
+    parts.push("OpenAI Codex");
+  }
+
+  const model = findMetaValue(rows, "model:");
+  const provider = findMetaValue(rows, "provider:");
+  const sandbox = findMetaValue(rows, "sandbox:");
+  const approval = findMetaValue(rows, "approval:");
+
+  for (const value of [model, provider, sandbox, approval].filter((item): item is string => Boolean(item))) {
+    parts.push(value);
+  }
+
+  const summary = parts.length > 0 ? `세션 정보: ${parts.join(" · ")}` : "세션 정보";
+  return truncateForSummary(summary, maxWidth);
+};
+
+const summarizeToolActivityBlock = (rows: RenderedRowInfo[], maxWidth: number): string => {
+  const firstLine = rows[0]?.plainText ?? "";
+  const label = firstLine.startsWith("web search:")
+    ? "웹 검색"
+    : firstLine.startsWith("tool_search:")
+      ? "도구 검색"
+      : firstLine.startsWith("todo_list:")
+        ? "할일 도구"
+        : firstLine.startsWith("mcp")
+          ? "MCP 도구"
+          : "도구 활동";
+  const detail = firstLine.includes(":") ? firstLine.slice(firstLine.indexOf(":") + 1).trim() : "";
+  const summary = detail.length > 0
+    ? `${label} ${rows.length}건 · ${detail}`
+    : `${label} ${rows.length}건`;
+  return truncateForSummary(summary, maxWidth);
+};
+
+const summarizeCommandBlock = (rows: RenderedRowInfo[], maxWidth: number): string | null => {
+  if (rows.length < 2) {
+    return null;
+  }
+
+  const commandLine = rows[1]?.plainText.trim() ?? "";
+  if (!looksLikeCommandLine(commandLine)) {
+    return null;
+  }
+
+  const statusLine = rows.find((row, index) => index >= 2 && isCommandStatusLine(row.plainText))?.plainText ?? null;
+  const resultLines = rows
+    .slice(statusLine ? rows.findIndex((row, index) => index >= 2 && isCommandStatusLine(row.plainText)) + 1 : 2)
+    .map((row) => row.plainText)
+    .filter((line) => line.length > 0);
+
+  const commandName = extractCommandName(commandLine);
+  const statusLabel = statusLine === null
+    ? "실행"
+    : /^succeeded in/i.test(statusLine)
+      ? "성공"
+      : /^failed in/i.test(statusLine)
+        ? "실패"
+        : /^exit code\s+(\d+)$/i.test(statusLine)
+          ? `종료 코드 ${statusLine.match(/^exit code\s+(\d+)$/i)?.[1] ?? ""}`.trim()
+          : "실행";
+  const durationMatch = statusLine?.match(/in\s+(\d+)ms/i);
+  const duration = durationMatch?.[1] ? `${durationMatch[1]}ms` : null;
+  const parts = [`명령 실행: ${commandName}`];
+  if (statusLabel.length > 0) {
+    parts.push(statusLabel);
+  }
+  if (duration) {
+    parts.push(duration);
+  }
+  if (resultLines.length > 0) {
+    parts.push(`${resultLines.length}개 결과`);
+  }
+  return truncateForSummary(parts.join(" · "), maxWidth);
+};
+
+const findPendingCommandEnd = (rows: RenderedRowInfo[], startIndex: number): number => {
+  let cursor = startIndex;
+  while (cursor < rows.length) {
+    const text = rows[cursor]?.plainText ?? "";
+    if (
+      text === "exec" ||
+      isMetaLine(text) ||
+      isToolActivityLine(text) ||
+      isConversationRoleLine(text)
+    ) {
+      break;
+    }
+    cursor += 1;
+  }
+  return cursor;
+};
+
+const buildCompactRenderableLines = (
+  rows: RenderedRowInfo[],
+  maxWidth: number,
+  cursorColumn?: number,
+  cursorVisible?: boolean,
+  cursorGlobalRow?: number,
+): EmbeddedTerminalRenderableLine[] => {
+  const output: EmbeddedTerminalRenderableLine[] = [];
+
+  for (let index = 0; index < rows.length; ) {
+    const row = rows[index];
+    if (!row) {
+      index += 1;
+      continue;
+    }
+
+    if (isMetaLine(row.plainText)) {
+      const block: RenderedRowInfo[] = [row];
+      index += 1;
+      while (index < rows.length && rows[index] !== undefined && isMetaLine(rows[index]!.plainText)) {
+        block.push(rows[index]!);
+        index += 1;
+      }
+
+      output.push({
+        text: colors.muted(
+          padDisplayWidth(summarizeMetadataBlock(block, maxWidth), maxWidth),
+        ),
+      });
+      continue;
+    }
+
+    if (row.plainText === "exec") {
+      const commandBlock: RenderedRowInfo[] = [row];
+      if (index + 1 < rows.length && rows[index + 1] !== undefined) {
+        commandBlock.push(rows[index + 1]!);
+      }
+
+      let statusIndex = -1;
+      for (let lookahead = 2; lookahead < Math.min(rows.length - index, 8); lookahead += 1) {
+        const candidate = rows[index + lookahead];
+        if (candidate !== undefined && isCommandStatusLine(candidate.plainText)) {
+          commandBlock.push(candidate);
+          statusIndex = index + lookahead;
+          break;
+        }
+      }
+
+      if (statusIndex !== -1) {
+        let cursor = statusIndex + 1;
+        while (
+          cursor < rows.length &&
+          rows[cursor] !== undefined &&
+          rows[cursor]!.plainText.length > 0 &&
+          !isMetaLine(rows[cursor]!.plainText) &&
+          !isToolActivityLine(rows[cursor]!.plainText) &&
+          rows[cursor]!.plainText !== "exec"
+        ) {
+          commandBlock.push(rows[cursor]!);
+          cursor += 1;
+        }
+
+        const summary = summarizeCommandBlock(commandBlock, maxWidth);
+        if (summary !== null) {
+          output.push({
+            text: colors.header(padDisplayWidth(summary, maxWidth)),
+          });
+          index = cursor;
+          continue;
+        }
+      }
+
+      const commandLine = rows[index + 1]?.plainText.trim() ?? "";
+      if (looksLikeCommandLine(commandLine)) {
+        output.push({
+          text: colors.muted(
+            padDisplayWidth(summarizeCommandActivity(commandLine, maxWidth, "running"), maxWidth),
+          ),
+        });
+        index = findPendingCommandEnd(rows, index + 2);
+        continue;
+      }
+    }
+
+    if (isToolActivityLine(row.plainText)) {
+      const block: RenderedRowInfo[] = [row];
+      index += 1;
+      while (
+        index < rows.length &&
+        rows[index] !== undefined &&
+        isToolActivityLine(rows[index]!.plainText)
+      ) {
+        block.push(rows[index]!);
+        index += 1;
+      }
+
+      output.push({
+        text: colors.muted(
+          padDisplayWidth(summarizeToolActivityBlock(block, maxWidth), maxWidth),
+        ),
+      });
+      continue;
+    }
+
+    const isCursorCell = cursorVisible === true && cursorGlobalRow === row.globalRow && cursorColumn !== undefined;
+    output.push({
+      text: renderCellsToAnsi(
+        row.cells,
+        maxWidth,
+        isCursorCell ? cursorColumn : undefined,
+        cursorVisible,
+        getRowDefaultStyle(row.plainText),
+      ),
+    });
+    index += 1;
+  }
+
+  return output;
+};
+
 const getRowDefaultStyle = (plainText: string): Partial<TerminalCellStyle> | undefined => {
   if (plainText.length === 0) {
     return undefined;
@@ -188,8 +592,8 @@ export interface EmbeddedTerminalRenderableLine {
 export class EmbeddedTerminalPane {
   private readonly buffer = new TerminalEmulatorBuffer(80, 24, EMBEDDED_PANE_SCROLLBACK_LIMIT);
   private scrollOffset = 0;
-  // Cached total row count (scrollback + visible) — updated on every write to avoid
-  // rebuilding the combined array on every scrollUp() keypress.
+  // Cached total renderable line count (after compact summaries are applied) —
+  // updated on every write to avoid rebuilding the combined array on every scrollUp() keypress.
   private cachedTotalRows = 0;
   private currentColumns = 80;
   private currentRows = 24;
@@ -229,7 +633,7 @@ export class EmbeddedTerminalPane {
   }
 
   private updateCachedTotalRows(): void {
-    this.cachedTotalRows = this.buffer.getScrollbackRows().length + this.buffer.getVisibleRows().length;
+    this.cachedTotalRows = this.getRenderableLines(this.currentColumns).length;
   }
 
   addEvent(event: PtyEvent): void {
@@ -263,6 +667,90 @@ export class EmbeddedTerminalPane {
     return this.buffer.hasContent();
   }
 
+  getActivitySnapshot(maxWidth = this.currentColumns): EmbeddedActivitySnapshot | null {
+    if (!this.buffer.hasContent()) {
+      return null;
+    }
+
+    const { rows } = this.getRenderedRows(Math.max(1, maxWidth));
+    for (let index = rows.length - 1; index >= 0; index -= 1) {
+      const row = rows[index];
+      if (row === undefined) {
+        continue;
+      }
+
+      if (row.plainText === "exec") {
+        const commandLine = rows[index + 1]?.plainText.trim() ?? "";
+        if (!looksLikeCommandLine(commandLine)) {
+          continue;
+        }
+
+        let statusLine: string | null = null;
+        for (let lookahead = index + 2; lookahead < Math.min(rows.length, index + 10); lookahead += 1) {
+          const candidate = rows[lookahead]?.plainText ?? "";
+          if (isCommandStatusLine(candidate)) {
+            statusLine = candidate;
+            break;
+          }
+        }
+
+        const activity = describeCommandActivity(commandLine);
+        return {
+          ...activity,
+          status: statusFromCommandStatusLine(statusLine),
+        };
+      }
+
+      if (isToolActivityLine(row.plainText)) {
+        const detail = row.plainText.includes(":")
+          ? row.plainText.slice(row.plainText.indexOf(":") + 1).trim()
+          : row.plainText;
+        return {
+          kind: "tool",
+          label: row.plainText.startsWith("web search:") ? "웹 검색" : "도구 활동",
+          detail: detail.length > 0 ? detail : "진행 중",
+          status: "running",
+        };
+      }
+    }
+
+    return null;
+  }
+
+  private getRenderedRows(maxWidth: number): {
+    rows: RenderedRowInfo[];
+    cursorColumn: number;
+    cursorVisible: boolean;
+    cursorGlobalRow: number;
+  } {
+    const scrollbackRows = this.buffer.getScrollbackCells();
+    const visibleRows = this.buffer.getVisibleCells();
+    const rows = [...scrollbackRows, ...visibleRows];
+    const cursorState = this.buffer.getCursorState();
+    const cursorGlobalRow = scrollbackRows.length + cursorState.row;
+
+    let lastContentIndex = -1;
+    for (let i = rows.length - 1; i >= 0; i -= 1) {
+      const row = rows[i];
+      if (row !== undefined && row.some((cell) => (cell.char ?? "").trim().length > 0)) {
+        lastContentIndex = i;
+        break;
+      }
+    }
+
+    const contentRows = rows.slice(0, lastContentIndex + 1);
+    return {
+      rows: contentRows.map((row, offset) => ({
+        cells: row,
+        plainText: rowToPlainText(row, maxWidth),
+        globalRow: offset,
+      })),
+      cursorColumn: cursorState.column,
+      cursorVisible: cursorState.visible,
+      cursorGlobalRow,
+    };
+  }
+
   getRenderableLines(maxWidth: number, maxRows?: number, scrollOffset = 0): EmbeddedTerminalRenderableLine[] {
     if (maxWidth <= 0) {
       return [];
@@ -274,39 +762,25 @@ export class EmbeddedTerminalPane {
       }));
     }
 
-    const scrollbackRows = this.buffer.getScrollbackCells();
-    const visibleRows = this.buffer.getVisibleCells();
-    const rows = [...scrollbackRows, ...visibleRows];
-    const cursorState = this.buffer.getCursorState();
-    const cursorGlobalRow = scrollbackRows.length + cursorState.row;
-    let lastContentIndex = -1;
-    for (let i = rows.length - 1; i >= 0; i -= 1) {
-      const row = rows[i];
-      if (row !== undefined && row.some((cell) => (cell.char ?? "").trim().length > 0)) {
-        lastContentIndex = i;
-        break;
-      }
-    }
+    const {
+      rows: renderedRows,
+      cursorColumn,
+      cursorVisible,
+      cursorGlobalRow,
+    } = this.getRenderedRows(maxWidth);
 
-    const endIndex = Math.max(0, lastContentIndex + 1 - scrollOffset);
+    const compactLines = buildCompactRenderableLines(
+      renderedRows,
+      maxWidth,
+      cursorColumn,
+      cursorVisible,
+      cursorGlobalRow,
+    );
+
+    const endIndex = Math.max(0, compactLines.length - Math.max(0, scrollOffset));
     const startIndex = Math.max(0, maxRows === undefined ? 0 : endIndex - Math.max(0, maxRows));
-    const renderedRows = rows.slice(startIndex, endIndex);
 
-    return renderedRows.map((row, offset) => {
-      const globalRow = startIndex + offset;
-      const cursorColumn =
-        cursorState.visible && globalRow === cursorGlobalRow ? cursorState.column : undefined;
-      const plainText = rowToPlainText(row, maxWidth);
-      return {
-        text: renderCellsToAnsi(
-          row,
-          maxWidth,
-          cursorColumn,
-          cursorState.visible,
-          getRowDefaultStyle(plainText),
-        ),
-      };
-    });
+    return compactLines.slice(startIndex, endIndex);
   }
 
   render(ctx: RenderContext, region: PanelRegion): void {

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -154,6 +154,23 @@ const CONVERSATION_ROLE_PATTERNS = [
   /^tokens used$/i,
 ] as const;
 
+const APPROVAL_PROMPT_PATTERNS = [
+  /\bapproval\b/i,
+  /\bapprove\b/i,
+  /\bconfirm\b/i,
+  /\ballow\b/i,
+  /\bproceed\b/i,
+] as const;
+
+const APPROVAL_PROMPT_HINT_PATTERNS = [
+  /\by\/n\b/i,
+  /\byes\/no\b/i,
+  /\[y\/n\]/i,
+  /\[y\/N\]/i,
+  /\benter\b/i,
+  /\bcontinue\b/i,
+] as const;
+
 interface RenderedRowInfo {
   cells: TerminalCell[];
   plainText: string;
@@ -167,6 +184,12 @@ export interface EmbeddedActivitySnapshot {
   label: string;
   detail: string;
   status: "running" | "completed" | "failed";
+}
+
+export interface EmbeddedInteractionState {
+  kind: "none" | "approval";
+  label: string;
+  detail?: string;
 }
 
 const isMetaLine = (plainText: string): boolean =>
@@ -184,6 +207,16 @@ const looksLikeCommandLine = (plainText: string): boolean =>
 
 const isConversationRoleLine = (plainText: string): boolean =>
   plainText.length > 0 && CONVERSATION_ROLE_PATTERNS.some((pattern) => pattern.test(plainText));
+
+const isApprovalPromptLine = (plainText: string): boolean => {
+  if (plainText.length === 0) {
+    return false;
+  }
+
+  const hasApprovalVerb = APPROVAL_PROMPT_PATTERNS.some((pattern) => pattern.test(plainText));
+  const hasApprovalHint = APPROVAL_PROMPT_HINT_PATTERNS.some((pattern) => pattern.test(plainText));
+  return hasApprovalVerb && hasApprovalHint;
+};
 
 const extractCommandName = (commandLine: string): string => {
   const target = extractShellPayload(commandLine);
@@ -710,6 +743,34 @@ export class EmbeddedTerminalPane {
           label: row.plainText.startsWith("web search:") ? "웹 검색" : "도구 활동",
           detail: detail.length > 0 ? detail : "진행 중",
           status: "running",
+        };
+      }
+    }
+
+    return null;
+  }
+
+  getInteractionState(maxWidth = this.currentColumns): EmbeddedInteractionState | null {
+    if (!this.buffer.hasContent()) {
+      return null;
+    }
+
+    const { rows } = this.getRenderedRows(Math.max(1, maxWidth));
+    for (let index = rows.length - 1; index >= 0; index -= 1) {
+      const row = rows[index];
+      if (row === undefined || row.plainText.length === 0) {
+        continue;
+      }
+
+      if (isMetaLine(row.plainText) || isToolActivityLine(row.plainText) || isConversationRoleLine(row.plainText)) {
+        continue;
+      }
+
+      if (isApprovalPromptLine(row.plainText)) {
+        return {
+          kind: "approval",
+          label: "Codex 승인 대기",
+          detail: row.plainText,
         };
       }
     }

--- a/src/cli/tui/renderer.ts
+++ b/src/cli/tui/renderer.ts
@@ -47,28 +47,37 @@ const wrapInputLines = (
   firstLineWidth: number,
   continuationWidth: number,
 ): WrappedInputLine[] => {
-  const chars = Array.from(input);
   const lines: WrappedInputLine[] = [];
-  let currentText = "";
-  let currentWidth = 0;
+  const normalizedInput = input.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const logicalLines = normalizedInput.split("\n");
+
   let currentLimit = firstLineWidth;
 
-  for (const char of chars) {
-    const charWidth = isWideCharacter(char) ? 2 : 1;
+  for (const logicalLine of logicalLines) {
+    const chars = Array.from(logicalLine);
+    let currentText = "";
+    let currentWidth = 0;
 
-    if (currentText.length > 0 && currentWidth + charWidth > currentLimit) {
-      lines.push({ text: currentText, width: currentWidth });
-      currentText = "";
-      currentWidth = 0;
-      currentLimit = continuationWidth;
+    for (const char of chars) {
+      const charWidth = isWideCharacter(char) ? 2 : 1;
+
+      if (currentText.length > 0 && currentWidth + charWidth > currentLimit) {
+        lines.push({ text: currentText, width: currentWidth });
+        currentText = "";
+        currentWidth = 0;
+        currentLimit = continuationWidth;
+      }
+
+      currentText += char;
+      currentWidth += charWidth;
     }
 
-    currentText += char;
-    currentWidth += charWidth;
+    lines.push({ text: currentText, width: currentWidth });
+    currentLimit = continuationWidth;
   }
 
-  if (currentText.length > 0 || lines.length === 0) {
-    lines.push({ text: currentText, width: currentWidth });
+  if (lines.length === 0) {
+    lines.push({ text: "", width: 0 });
   }
 
   return lines;

--- a/src/core/executor/execute.ts
+++ b/src/core/executor/execute.ts
@@ -24,6 +24,7 @@ export const executeWithAdapter = async (request: ExecutorRequest): Promise<Exec
       ? createPtySubprocessRunner(
           {
             ...(request.onAdapterEvent ? { onEvent: request.onAdapterEvent } : {}),
+            ...(request.onPtyController ? { onController: request.onPtyController } : {}),
             ...(request.presentationMode === "passthrough" ? { passthroughUi: true } : {}),
           },
         )

--- a/src/core/executor/types.ts
+++ b/src/core/executor/types.ts
@@ -1,6 +1,6 @@
 import type { Adapter, ExecutionMode, InteractionMode } from "../pipeline/types.js";
 import type { RequestCategory } from "../../schemas/pipeline.js";
-import type { PtyEvent, PtyTranscript } from "../../integrations/subprocess/types.js";
+import type { PtyEvent, PtySessionController, PtyTranscript } from "../../integrations/subprocess/types.js";
 import type { ActionTimelineEvent, ActionTimelineSink } from "../timeline/types.js";
 import type { TokenReductionSnapshot } from "../utils/tokenMetrics.js";
 
@@ -29,6 +29,7 @@ export interface ExecutorRequest extends AdapterExecutionRequest {
   executionMode: ExecutionMode;
   presentationMode?: "passthrough" | "embedded-pane";
   onAdapterEvent?: (event: PtyEvent) => void;
+  onPtyController?: (controller: PtySessionController) => void;
   onActionTimelineEvent?: ActionTimelineSink;
 }
 

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1070,6 +1070,7 @@ export const orchestratePipeline = async (
         ...(request.userRequest.cwd ? { cwd: request.userRequest.cwd } : {}),
         sessionId,
         ...(request.onAdapterEvent ? { onAdapterEvent: request.onAdapterEvent } : {}),
+        ...(request.onPtyController ? { onPtyController: request.onPtyController } : {}),
         onActionTimelineEvent: emitActionTimelineWithLogging,
       });
       adapterTranscript = mergePtyTranscripts(adapterTranscript, execResult.transcript);

--- a/src/core/pipeline/types.ts
+++ b/src/core/pipeline/types.ts
@@ -3,8 +3,7 @@ import type { ProjectInfo } from "../state/SessionStateManager.js";
 import type { CompressTextImplementation } from "../prompt/compression.js";
 import type { TraceLog } from "../utils/PipelineTracer.js";
 import type { TokenMetricsSnapshot } from "../utils/tokenMetrics.js";
-import type { PtyTranscript } from "../../integrations/subprocess/types.js";
-import type { PtyEvent } from "../../integrations/subprocess/types.js";
+import type { PtyTranscript, PtyEvent, PtySessionController } from "../../integrations/subprocess/types.js";
 import type { ActionTimelineEvent, ActionTimelineSink } from "../timeline/types.js";
 import type { TokenReductionSnapshot } from "../utils/tokenMetrics.js";
 
@@ -43,6 +42,7 @@ export interface PipelineExecutionRequest {
   fetchImplementation?: typeof fetch;
   onProgress?: PipelineProgressHandler;
   onAdapterEvent?: (event: PtyEvent) => void;
+  onPtyController?: (controller: PtySessionController) => void;
   onActionTimelineEvent?: ActionTimelineSink;
 }
 

--- a/src/integrations/adapters/codex/adapter.ts
+++ b/src/integrations/adapters/codex/adapter.ts
@@ -28,6 +28,8 @@ export class CodexStubAdapter implements CliAdapter {
       return {
         command: "codex",
         args: [
+          "--ask-for-approval",
+          "on-request",
           "exec",
           ...(reasoningEffort ? ["-c", `model_reasoning_effort=${reasoningEffort}`] : []),
           ...(request.model ? ["--model", request.model] : []),
@@ -38,6 +40,7 @@ export class CodexStubAdapter implements CliAdapter {
         ],
         ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
         input: request.prompt,
+        interactiveAfterInput: true,
       };
     }
 

--- a/src/integrations/subprocess/runner.ts
+++ b/src/integrations/subprocess/runner.ts
@@ -5,6 +5,7 @@ import type {
   PtyResult,
   PtyEvent,
   PtyTranscript,
+  PtySessionController,
 } from "./types.js";
 import { spawn } from "node:child_process";
 import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
@@ -177,6 +178,7 @@ export const createRealSubprocessRunner = (): SubprocessRunner => ({
 
 interface PtyRunnerOptions {
   onEvent?: (event: PtyEvent) => void;
+  onController?: (controller: PtySessionController) => void;
   passthroughUi?: boolean;
 }
 
@@ -370,55 +372,82 @@ const runWithNodePty = (
     });
   }
 
-  return new Promise<PtyResult>((resolve) => {
-    let stdout = "";
-    let settled = false;
+  let resolveResult!: (value: PtyResult) => void;
+  const result = new Promise<PtyResult>((resolve) => {
+    resolveResult = resolve;
+  });
 
-    const finish = (code: number, timedOut: boolean): void => {
-      if (settled) {
-        return;
-      }
-      settled = true;
+  let stdout = "";
+  let settled = false;
 
-      const endTime = Date.now();
-      emitEvent({ type: "exit", data: String(code) });
+  const finish = (code: number, timedOut: boolean): void => {
+    if (settled) {
+      return;
+    }
+    settled = true;
 
-      resolve({
-        stdout,
-        stderr: "",
+    const endTime = Date.now();
+    emitEvent({ type: "exit", data: String(code) });
+
+    resolveResult({
+      stdout,
+      stderr: "",
+      exitCode: code,
+      timedOut,
+      transcript: {
+        events,
+        startTime,
+        endTime,
+        totalDuration: endTime - startTime,
         exitCode: code,
         timedOut,
-        transcript: {
-          events,
-          startTime,
-          endTime,
-          totalDuration: endTime - startTime,
-          exitCode: code,
-          timedOut,
-        },
-      });
-    };
-
-    ptyProcess.onData((data) => {
-      stdout += data;
-      emitEvent({ type: "chunk", stream: "stdout", data });
+      },
     });
+  };
 
-    ptyProcess.onExit(({ exitCode }) => {
-      finish(exitCode ?? 0, false);
-    });
+  const controller: PtySessionController = {
+    write: (data: string) => {
+      emitEvent({ type: "prompt", data });
+      ptyProcess.write(data);
+    },
+    resize: (columns: number, rows: number) => {
+      emitEvent({ type: "resize", columns, rows });
+      ptyProcess.resize(columns, rows);
+    },
+    close: () => {
+      ptyProcess.kill("SIGTERM");
+    },
+    kill: (signal: NodeJS.Signals = "SIGTERM") => {
+      ptyProcess.kill(signal);
+    },
+    result,
+  };
 
-    if (request.input !== undefined) {
-      emitEvent({ type: "prompt", data: request.input });
-      ptyProcess.write(request.input);
-      // One-shot PTY prompts need an explicit submit/EOF signal so terminal
-      // applications that read stdin can finish instead of waiting forever.
-      if (!request.input.endsWith("\r") && !request.input.endsWith("\n")) {
-        ptyProcess.write("\r");
-      }
+  options?.onController?.(controller);
+
+  ptyProcess.onData((data) => {
+    stdout += data;
+    emitEvent({ type: "chunk", stream: "stdout", data });
+  });
+
+  ptyProcess.onExit(({ exitCode }) => {
+    finish(exitCode ?? 0, false);
+  });
+
+  if (request.input !== undefined) {
+    emitEvent({ type: "prompt", data: request.input });
+    ptyProcess.write(request.input);
+    // One-shot PTY prompts need an explicit submit/EOF signal so terminal
+    // applications that read stdin can finish instead of waiting forever.
+    if (!request.input.endsWith("\r") && !request.input.endsWith("\n")) {
+      ptyProcess.write("\r");
+    }
+    if (request.interactiveAfterInput !== true) {
       ptyProcess.write("\x04");
     }
-  });
+  }
+
+  return result;
 };
 
 export const createPtySubprocessRunner = (

--- a/src/integrations/subprocess/types.ts
+++ b/src/integrations/subprocess/types.ts
@@ -4,6 +4,7 @@ export interface SubprocessRequest {
   cwd?: string;
   env?: Record<string, string>;
   input?: string;
+  interactiveAfterInput?: boolean;
 }
 
 export interface SubprocessResult {

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -550,7 +550,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       const replRun = runCliWithInputFromCwdEnvAndTimeout(
         tempDir,
         ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
-        "hello detoks\n\u0007/exit\n",
+        "hello detoks\n\n/exit\n",
         {
           PATH: `${tempDir}:${process.env.PATH ?? ""}`,
         },
@@ -558,11 +558,12 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       );
 
       expect(replRun.stderr).not.toContain("ReferenceError");
-      expect(replRun.stdout).toContain("원본 CLI 출력이 이 영역에 표시됩니다.");
-      expect(replRun.stdout).toContain("[fake:codex]");
       expect(replRun.stdout).toContain("hello detoks");
-      expect(replRun.stdout).toContain("실행 결과가 아직 없습니다.");
-      expect(replRun.stdout).toContain("작업 타임라인");
+      expect(replRun.stdout).toContain("Sticky Prompt");
+      expect(replRun.stdout).toContain("실행 확인 대기");
+      expect(replRun.stdout).toContain("실행 중");
+      expect(replRun.stdout).toContain("완료");
+      expect(replRun.stdout).toContain("Summary #1");
       expect(replRun.stdout).toContain("detoks 압축 지표");
     } finally {
       rmSync(tempDir, { force: true, recursive: true });
@@ -577,7 +578,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       const replRun = runCliWithInputFromCwdEnvAndTimeout(
         tempDir,
         ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
-        "hello detoks\n\u0007hello again\n\u0007/exit\n",
+        "hello detoks\n\nhello again\n\n/exit\n",
         {
           PATH: `${tempDir}:${process.env.PATH ?? ""}`,
           DETOKS_CACHE_DISABLED: "1",
@@ -586,13 +587,39 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       );
 
       expect(replRun.stderr).not.toContain("ReferenceError");
-      expect(replRun.stdout).toContain("[fake:codex]");
       expect(replRun.stdout).toContain("hello detoks");
       expect(replRun.stdout).toContain("hello again");
+      expect(replRun.stdout).toContain("Sticky Prompt");
+      expect(replRun.stdout).toContain("실행 중");
+      expect(replRun.stdout).toContain("완료");
     } finally {
       rmSync(tempDir, { force: true, recursive: true });
     }
   }, 30_000);
+
+  it("does not auto-execute the approval prompt when the initial Enter arrives as CRLF", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "detoks-cli-embedded-repl-"));
+
+    try {
+      createFakeBinary(tempDir, "codex");
+      const replRun = runCliWithInputFromCwdEnvAndTimeout(
+        tempDir,
+        ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
+        "hello detoks\r\n",
+        {
+          PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+          DETOKS_CACHE_DISABLED: "1",
+        },
+        4_000,
+      );
+
+      expect(replRun.stdout).toContain("실행 확인 대기");
+      expect(replRun.stdout).not.toContain("[fake:codex]");
+      expect(replRun.stdout).not.toContain("실행 중");
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  }, 10_000);
 
   it("keeps default stderr concise and verbose stderr stacked on errors", () => {
     const defaultRun = runCli(["--unknown"]);

--- a/tests/ts/unit/cli/tui/approval-prompt.test.ts
+++ b/tests/ts/unit/cli/tui/approval-prompt.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { buildExecutionApprovalLines } from "../../../../../src/cli/tui/approval-prompt.js";
+
+describe("execution approval prompt", () => {
+  it("renders confirm and cancel guidance", () => {
+    const lines = buildExecutionApprovalLines(40).join("\n");
+
+    expect(lines).toContain("실행 전 확인");
+    expect(lines).toContain("Enter 실행 · Esc 편집 복귀");
+  });
+
+  it("returns empty lines for non-positive width", () => {
+    expect(buildExecutionApprovalLines(0)).toEqual([]);
+  });
+});

--- a/tests/ts/unit/cli/tui/korean-input.test.ts
+++ b/tests/ts/unit/cli/tui/korean-input.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { measureInputLayout } from "../../../../../src/cli/tui/renderer.js";
+import { measureInputLayout, renderInputArea } from "../../../../../src/cli/tui/renderer.js";
 
 describe("Korean Input Handling", () => {
   describe("Display width calculation", () => {
@@ -244,6 +244,28 @@ describe("Korean Input Handling", () => {
       expect(layout.cursorCol).toBe(2);
     });
 
+    it("treats pasted newlines as separate prompt lines instead of literal control characters", () => {
+      const dims = { rows: 24, columns: 80 };
+      const multilineInput = [
+        "프로젝트 루트는 그대로 두고,",
+        "/var/tmp/detoks-approval-check.txt 파일을 새로 만든 뒤",
+        "현재 브랜치명과 현재 시각을 한 줄로 기록해줘.",
+      ].join("\n");
+
+      const layout = measureInputLayout(dims, multilineInput);
+
+      expect(layout.visibleLines.map((line) => line.text)).toEqual([
+        "프로젝트 루트는 그대로 두고,",
+        "/var/tmp/detoks-approval-check.txt 파일을 새로 만든 뒤",
+        "현재 브랜치명과 현재 시각을 한 줄로 기록해줘.",
+      ]);
+      expect(layout.separatorRow).toBe(18);
+      expect(layout.inputStartRow).toBe(19);
+      expect(layout.bottomSeparatorRow).toBe(22);
+      expect(layout.cursorRow).toBe(21);
+      expect(layout.cursorCol).toBeGreaterThan(0);
+    });
+
     it("keeps the separator low when input stays on one line", () => {
       const dims = { rows: 24, columns: 20 };
       const layout = measureInputLayout(dims, "한글");
@@ -254,6 +276,31 @@ describe("Korean Input Handling", () => {
       expect(layout.bottomSeparatorRow).toBe(22);
       expect(layout.cursorRow).toBe(21);
       expect(layout.cursorCol).toBe(6);
+    });
+
+    it("renders pasted multiline input without writing raw newline characters into the prompt rows", () => {
+      const dims = { rows: 24, columns: 80 };
+      const mockScreen = {
+        cursorMoveTo: vi.fn(),
+        write: vi.fn(),
+      };
+      const ctx = { screen: mockScreen, dims } as unknown as Parameters<typeof renderInputArea>[0];
+      const multilineInput = [
+        "프로젝트 루트는 그대로 두고,",
+        "/var/tmp/detoks-approval-check.txt 파일을 새로 만든 뒤",
+        "현재 브랜치명과 현재 시각을 한 줄로 기록해줘.",
+      ].join("\n");
+
+      const layout = renderInputArea(ctx, multilineInput);
+
+      expect(layout.visibleLines.map((line) => line.text)).toEqual([
+        "프로젝트 루트는 그대로 두고,",
+        "/var/tmp/detoks-approval-check.txt 파일을 새로 만든 뒤",
+        "현재 브랜치명과 현재 시각을 한 줄로 기록해줘.",
+      ]);
+      expect(
+        mockScreen.write.mock.calls.some(([value]) => String(value).includes("\n")),
+      ).toBe(false);
     });
   });
 });

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -71,7 +71,7 @@ describe("EmbeddedTerminalPane", () => {
     expect(output).toContain("world");
   });
 
-  it("renders codex metadata lines with a muted gray tone for readability", () => {
+  it("compresses codex metadata lines into a short summary", () => {
     pane.addEvent({
       type: "chunk",
       timestamp: Date.now(),
@@ -82,10 +82,90 @@ describe("EmbeddedTerminalPane", () => {
     pane.render(mockContext, mockRegion);
 
     const output = mockScreen.write.mock.calls.map((call: any) => call[0]).join("\n");
-    expect(output).toContain("\x1b[38;5;250m");
-    expect(output).toContain("\x1b[2;38;5;244m");
+    expect(output).toContain("세션 정보");
     expect(output).toContain("OpenAI Codex");
-    expect(output).toContain("workdir:");
+    expect(output).not.toContain("workdir:");
+    expect(output).not.toContain("--------");
+  });
+
+  it("compresses exec command blocks into a short summary", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: [
+        "exec",
+        `/bin/zsh -lc "rg -n \"new ProjectMemory\" src tests"`,
+        "succeeded in 0ms:",
+        "src/core/pipeline/orchestrator.ts:34:import { ProjectMemory } from \"../rag/project-memory.js\";",
+        "src/core/rag/project-memory.ts:5:import { TaskSequenceMiner } from \"./task-sequence-miner.js\";",
+        "",
+      ].join("\n"),
+    });
+
+    pane.render(mockContext, mockRegion);
+
+    const output = mockScreen.write.mock.calls.map((call: any) => call[0]).join("\n");
+    expect(output).toContain("명령 실행");
+    expect(output).toContain("rg");
+    expect(output).not.toContain("succeeded in 0ms");
+    expect(output).not.toContain("TaskSequenceMiner");
+  });
+
+  it("keeps an in-progress file read compact and exposes it as current activity", () => {
+    mockRegion.columns = 140;
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: [
+        "exec",
+        `/bin/zsh -lc "sed -n '1,220p' /Users/choi/.codex/RTK.md" in /Users/choi/Desktop/workspace/detoks`,
+        "# verbose file contents",
+        "line that should not fill the pane",
+      ].join("\n"),
+    });
+
+    pane.render(mockContext, mockRegion);
+
+    const output = mockScreen.write.mock.calls.map((call: any) => call[0]).join("\n");
+    expect(output).toContain("파일 읽기");
+    expect(output).toContain("/Users/choi/.codex/RTK.md");
+    expect(output).not.toContain("line that should not fill the pane");
+    expect(pane.getActivitySnapshot(120)).toMatchObject({
+      kind: "file",
+      label: "파일 읽기",
+      detail: "/Users/choi/.codex/RTK.md",
+      status: "running",
+    });
+  });
+
+  it("summarizes an in-progress search without streaming every match line", () => {
+    mockRegion.columns = 140;
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: [
+        "exec",
+        `/bin/zsh -lc "rg -n \\"ProjectMemory\\" src tests"`,
+        "src/core/pipeline/orchestrator.ts:34:import { ProjectMemory } from \"../rag/project-memory.js\";",
+        "tests/ts/unit/core/rag/project-memory.test.ts:1:import { ProjectMemory } from \"x\";",
+      ].join("\n"),
+    });
+
+    pane.render(mockContext, mockRegion);
+
+    const output = mockScreen.write.mock.calls.map((call: any) => call[0]).join("\n");
+    expect(output).toContain("검색");
+    expect(output).toContain("ProjectMemory");
+    expect(output).not.toContain("orchestrator.ts:34");
+    expect(pane.getActivitySnapshot(120)).toMatchObject({
+      kind: "search",
+      label: "검색",
+      detail: "ProjectMemory",
+      status: "running",
+    });
   });
 
   it("renders the live cursor cell with inverse video when the buffer reports a visible cursor", () => {

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -168,6 +168,23 @@ describe("EmbeddedTerminalPane", () => {
     });
   });
 
+  it("detects approval prompts as a focused interaction state", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "approval required (y/n)\n",
+    });
+
+    pane.render(mockContext, mockRegion);
+
+    expect(pane.getInteractionState(120)).toMatchObject({
+      kind: "approval",
+      label: "Codex 승인 대기",
+      detail: "approval required (y/n)",
+    });
+  });
+
   it("renders the live cursor cell with inverse video when the buffer reports a visible cursor", () => {
     pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "hello" });
 

--- a/tests/ts/unit/core/executor/execute.test.ts
+++ b/tests/ts/unit/core/executor/execute.test.ts
@@ -134,6 +134,25 @@ describe("executeWithAdapter", () => {
     );
   });
 
+  it("threads PTY controller hooks into the real subprocess runner", async () => {
+    const onPtyController = vi.fn();
+
+    await executeWithAdapter({
+      adapter: "codex",
+      mode: "run",
+      executionMode: "real",
+      prompt: "hello controller",
+      verbose: false,
+      onPtyController,
+    });
+
+    expect(subprocessMocks.createPtyRunner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onController: onPtyController,
+      }),
+    );
+  });
+
   it("preserves transcript data when the real path exposes it", async () => {
     const result = await executeWithAdapter({
       adapter: "codex",

--- a/tests/ts/unit/integrations/adapters/adapter-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/adapter-path.test.ts
@@ -167,7 +167,7 @@ describe("adapter subprocess path", () => {
     });
   });
 
-  it("builds codex embedded-pane subprocess requests as one-shot stdin prompts", () => {
+  it("builds codex embedded-pane subprocess requests for interactive approval", () => {
     const adapter = new CodexStubAdapter();
     expect(
       adapter.buildSubprocessRequest({
@@ -181,6 +181,8 @@ describe("adapter subprocess path", () => {
     ).toEqual({
       command: "codex",
       args: [
+        "--ask-for-approval",
+        "on-request",
         "exec",
         "--model",
         "gpt-5",
@@ -191,6 +193,7 @@ describe("adapter subprocess path", () => {
       ],
       cwd: "/tmp",
       input: "",
+      interactiveAfterInput: true,
     });
   });
 

--- a/tests/ts/unit/integrations/subprocess/runner.test.ts
+++ b/tests/ts/unit/integrations/subprocess/runner.test.ts
@@ -113,6 +113,55 @@ describe("createRealSubprocessRunner", () => {
     10_000,
   );
 
+  it("keeps the PTY open after prompt submission when interactiveAfterInput is enabled", async () => {
+    const dir = tempDirs.at(-1)!;
+    const codexScript = join(dir, "codex");
+    writeFileSync(
+      codexScript,
+      [
+        "#!/usr/bin/env node",
+        'let input = "";',
+        'process.stdin.setEncoding("utf8");',
+        'process.stdin.on("data", (chunk) => {',
+        "  input += chunk;",
+        "  process.stdout.write('approval required\\n');",
+        "});",
+        'process.stdin.on("end", () => {',
+        "  process.stdout.write('stdin-ended\\n');",
+        "});",
+        "setTimeout(() => {",
+        "  process.stdout.write(input);",
+        "  process.exit(0);",
+        "}, 60);",
+        "process.stdin.resume();",
+      ].join("\n"),
+      "utf8",
+    );
+    chmodSync(codexScript, 0o755);
+
+    let capturedController: { write: (data: string) => void } | null = null;
+    const runner = createPtySubprocessRunner({
+      onController: (controller) => {
+        capturedController = controller;
+      },
+    });
+    const result = await runner.runWithTranscript({
+      command: "codex",
+      args: ["exec", "-", "--sandbox", "workspace-write"],
+      input: "hello\n",
+      interactiveAfterInput: true,
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(capturedController).not.toBeNull();
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("approval required");
+    expect(result.stdout).not.toContain("stdin-ended");
+  }, 10_000);
+
   it("streams Codex JSON output without waiting for a PTY wrapper", async () => {
     const dir = tempDirs.at(-1)!;
     const codexScript = join(dir, "codex");


### PR DESCRIPTION
## 요약
- embedded Codex 승인 프롬프트를 active PTY controller로 전달할 수 있도록 TUI 입력 라우팅을 연결했습니다.
- `Ctrl+G`로 detoks 입력으로 복귀할 수 있게 하고, 승인 대기 상태를 고정 활동 표시줄에 보여주도록 정리했습니다.
- 붙여넣은 멀티라인 프롬프트의 줄바꿈을 실제 입력 레이아웃으로 계산하도록 수정해, 입력 텍스트가 footer 영역으로 새는 문제를 해결했습니다.
- 승인 프롬프트 감지, PTY 컨트롤러 연결, 멀티라인 입력 렌더링에 대한 회귀 테스트를 추가했습니다.

## 검증
- `npm run build`
- `npx vitest run tests/ts/unit/cli/tui/korean-input.test.ts tests/ts/unit/integrations/subprocess/runner.test.ts tests/ts/unit/core/executor/execute.test.ts tests/ts/unit/integrations/adapters/adapter-path.test.ts tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts --reporter=dot`
- `npx vitest run tests/ts/integration/cli-smoke.test.ts -t "returns to detoks input after an embedded run so another prompt can be entered|does not auto-execute the approval prompt when the initial Enter arrives as CRLF" --reporter=dot`

## 참고
- 로컬에 남아 있는 `src/cli/cache/cache-manager.ts` 변경은 이번 PR 범위에 포함하지 않았습니다.