### PR TITLE
feat(model): HuggingFace 레포를 통한 사용자 지정 GGUF 모델 다운로드 지원

### DIFF
--- a/src/cli/interactive/prompt-line.ts
+++ b/src/cli/interactive/prompt-line.ts
@@ -1,0 +1,62 @@
+import { stdin as defaultInput, stdout as defaultOutput } from "node:process";
+import { createInterface } from "node:readline";
+import { colors } from "../colors.js";
+
+export interface PromptLineOptions {
+  placeholder?: string;
+  validate?: (value: string) => string | null;
+}
+
+export interface PromptLineStreams {
+  input?: typeof defaultInput;
+  output?: typeof defaultOutput;
+}
+
+export const promptLine = async (
+  message: string,
+  options: PromptLineOptions = {},
+  streams: PromptLineStreams = {},
+): Promise<string | null> => {
+  const input = streams.input ?? defaultInput;
+  const output = streams.output ?? defaultOutput;
+
+  if (!input.isTTY || !output.isTTY) {
+    return null;
+  }
+
+  const { placeholder, validate } = options;
+
+  const hint = placeholder ? colors.muted(` (예: ${placeholder})`) : "";
+  output.write(`${colors.title(message)}${hint}\n`);
+
+  while (true) {
+    const value = await new Promise<string | null>((resolve) => {
+      const rl = createInterface({ input, output, terminal: true });
+
+      rl.on("SIGINT", () => {
+        rl.close();
+        output.write("\n");
+        process.exit(130);
+      });
+
+      rl.question(colors.muted("> "), (answer) => {
+        rl.close();
+        resolve(answer.trim() || null);
+      });
+    });
+
+    if (value === null) {
+      return null;
+    }
+
+    if (validate) {
+      const error = validate(value);
+      if (error) {
+        output.write(`${colors.error(`✗ ${error}`)}\n`);
+        continue;
+      }
+    }
+
+    return value;
+  }
+};

--- a/src/cli/model-setup/custom-store.ts
+++ b/src/cli/model-setup/custom-store.ts
@@ -1,0 +1,37 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+interface StoredCustomModel {
+  hfRepo: string;
+  hfFile: string;
+  quantization: string;
+  sizeMb: number;
+  savedAt: string;
+}
+
+const getStorePath = (): string =>
+  join(homedir(), ".detoks", "custom-models.json");
+
+export const loadLastCustomModel = (): StoredCustomModel | null => {
+  const path = getStorePath();
+  if (!existsSync(path)) return null;
+
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const list = JSON.parse(raw) as StoredCustomModel[];
+    return Array.isArray(list) && list.length > 0 ? (list[0] ?? null) : null;
+  } catch {
+    return null;
+  }
+};
+
+export const saveCustomModel = (model: StoredCustomModel): void => {
+  const path = getStorePath();
+  mkdirSync(join(homedir(), ".detoks"), { recursive: true });
+
+  const list: StoredCustomModel[] = [
+    { ...model, savedAt: new Date().toISOString() },
+  ];
+  writeFileSync(path, JSON.stringify(list, null, 2), "utf-8");
+};

--- a/src/cli/model-setup/hf-repo.ts
+++ b/src/cli/model-setup/hf-repo.ts
@@ -1,0 +1,128 @@
+export interface GgufFileInfo {
+  filename: string;
+  quantization: string;
+  sizeMb: number;
+}
+
+export interface HfRepoRef {
+  owner: string;
+  repo: string;
+  fullRepo: string;
+}
+
+const HF_URL_RE =
+  /^https?:\/\/(?:www\.)?huggingface\.co\/([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)(?:\/.*)?$/;
+const REPO_RE = /^([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)$/;
+const QUANT_RE = /-(Q\d[A-Z0-9_]*|IQ\d[A-Z0-9_]*|F16|BF16|F32)\.gguf$/i;
+
+export const parseHfRepoInput = (raw: string): HfRepoRef | null => {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const urlMatch = HF_URL_RE.exec(trimmed);
+  if (urlMatch) {
+    const owner = urlMatch[1] ?? "";
+    const repo = urlMatch[2] ?? "";
+    return { owner, repo, fullRepo: `${owner}/${repo}` };
+  }
+
+  const repoMatch = REPO_RE.exec(trimmed);
+  if (repoMatch) {
+    const owner = repoMatch[1] ?? "";
+    const repo = repoMatch[2] ?? "";
+    return { owner, repo, fullRepo: `${owner}/${repo}` };
+  }
+
+  return null;
+};
+
+const parseQuantization = (filename: string): string => {
+  const match = QUANT_RE.exec(filename);
+  return match?.[1]?.toUpperCase() ?? "unknown";
+};
+
+const fetchFileSizeMb = async (repo: string, filename: string): Promise<number> => {
+  try {
+    const url = `https://huggingface.co/${repo}/resolve/main/${filename}`;
+    const res = await fetch(url, { method: "HEAD" });
+    const contentLength = res.headers.get("content-length");
+    if (contentLength) {
+      return Math.round(parseInt(contentLength, 10) / (1024 * 1024));
+    }
+  } catch {
+    // 크기 미상으로 처리
+  }
+  return 0;
+};
+
+export class HfRepoError extends Error {
+  constructor(
+    message: string,
+    public readonly code: "not_found" | "private" | "no_gguf" | "network",
+  ) {
+    super(message);
+    this.name = "HfRepoError";
+  }
+}
+
+interface HfSibling {
+  rfilename: string;
+}
+
+export const listGgufFiles = async (ref: HfRepoRef): Promise<GgufFileInfo[]> => {
+  const apiUrl = `https://huggingface.co/api/models/${ref.fullRepo}`;
+
+  let data: { siblings?: HfSibling[] };
+  try {
+    const res = await fetch(apiUrl);
+    if (res.status === 404) {
+      throw new HfRepoError(
+        "레포를 찾을 수 없습니다. owner/repo가 맞는지 확인하세요.",
+        "not_found",
+      );
+    }
+    if (res.status === 401 || res.status === 403) {
+      throw new HfRepoError(
+        "비공개 레포는 아직 지원되지 않습니다.",
+        "private",
+      );
+    }
+    if (!res.ok) {
+      throw new HfRepoError(
+        `HuggingFace API 오류: ${res.status} ${res.statusText}`,
+        "network",
+      );
+    }
+    data = (await res.json()) as { siblings?: HfSibling[] };
+  } catch (err) {
+    if (err instanceof HfRepoError) throw err;
+    throw new HfRepoError(
+      `네트워크 오류: ${err instanceof Error ? err.message : String(err)}`,
+      "network",
+    );
+  }
+
+  const ggufFiles = (data.siblings ?? [])
+    .map((s) => s.rfilename)
+    .filter((name) => name.toLowerCase().endsWith(".gguf"));
+
+  if (ggufFiles.length === 0) {
+    throw new HfRepoError(
+      "이 레포에는 GGUF 파일이 없습니다.",
+      "no_gguf",
+    );
+  }
+
+  const results = await Promise.all(
+    ggufFiles.map(async (filename) => {
+      const sizeMb = await fetchFileSizeMb(ref.fullRepo, filename);
+      return {
+        filename,
+        quantization: parseQuantization(filename),
+        sizeMb,
+      };
+    }),
+  );
+
+  return results;
+};

--- a/src/cli/model-setup/models.ts
+++ b/src/cli/model-setup/models.ts
@@ -10,7 +10,29 @@ export interface TranslationModel {
   hfFile: string;
   sizeMb: number;
   quantization: string;
+  source?: "builtin" | "custom";
 }
+
+export const CUSTOM_MODEL_MENU_VALUE = "__custom_gguf__";
+export const CUSTOM_MODEL_RECENT_VALUE = "__custom_gguf_recent__";
+
+export const buildCustomTranslationModel = (input: {
+  hfRepo: string;
+  hfFile: string;
+  quantization: string;
+  sizeMb: number;
+}): TranslationModel => ({
+  id: `custom:${input.hfRepo}:${input.quantization}`,
+  displayName: `${input.hfRepo} (사용자 지정${input.sizeMb > 0 ? `, ${input.sizeMb}MB` : ""})`,
+  description: "사용자가 직접 지정한 HuggingFace GGUF 모델",
+  modelName: input.hfRepo,
+  role: "llm",
+  hfRepo: input.hfRepo,
+  hfFile: input.hfFile,
+  sizeMb: input.sizeMb,
+  quantization: input.quantization,
+  source: "custom",
+});
 
 export interface EmbeddingModel {
   id: string;

--- a/src/cli/repl-commands/index.ts
+++ b/src/cli/repl-commands/index.ts
@@ -27,7 +27,13 @@ import {
   CODEX_REASONING_EFFORT_VALUES,
   type CodexReasoningEffort,
 } from "../config/types.js";
-import { TRANSLATION_MODELS, type TranslationModel } from "../model-setup/models.js";
+import {
+  TRANSLATION_MODELS,
+  CUSTOM_MODEL_MENU_VALUE,
+  CUSTOM_MODEL_RECENT_VALUE,
+  buildCustomTranslationModel,
+  type TranslationModel,
+} from "../model-setup/models.js";
 import { downloadModel } from "../model-setup/download.js";
 import { updateEnvFile } from "../model-setup/env-writer.js";
 import { inspectLocalModelFile, shouldDownloadModelFile } from "../model-setup/file-status.js";
@@ -35,6 +41,9 @@ import {
   getDetoksModelDir,
   getDetoksModelFilePath,
 } from "../../core/model-store.js";
+import { loadLastCustomModel, saveCustomModel } from "../model-setup/custom-store.js";
+import { parseHfRepoInput, listGgufFiles, HfRepoError } from "../model-setup/hf-repo.js";
+import { promptLine } from "../interactive/prompt-line.js";
 
 export interface SlashCommand {
   name: string;
@@ -799,62 +808,9 @@ const getModelAssetStatus = (model: TranslationModel) => {
   return inspectLocalModelFile(getDetoksModelFilePath(model));
 };
 
-const handleTranslationModel = async (streams?: SelectWithArrowsStreams): Promise<boolean> => {
-  output.write(`\n${colors.title("한글→영어 번역 모델 선택\n")}`);
-
-  // 모델 목록 생성
-  const options = TRANSLATION_MODELS.map((model) => {
-    const fileStatus = getModelAssetStatus(model);
-    const status =
-      fileStatus.kind === "ready"
-        ? ` ${colors.success("[설치됨]")}`
-        : fileStatus.kind === "invalid"
-          ? ` ${colors.warning(`[손상됨:${fileStatus.reason}]`)}`
-          : "";
-    return {
-      value: model.id,
-      label: `${model.displayName}${status}`,
-      model,
-    };
-  });
-
-  // 모델 정보 표시
-  for (const opt of options) {
-    const model = opt.model;
-    if (model) {
-      output.write(`${colors.muted(opt.label)}\n`);
-      output.write(`   ${colors.muted(model.description)}\n`);
-      output.write("\n");
-    }
-  }
-
-  output.write(
-    colors.muted("손상된 모델은 선택 후 Enter를 누르면 재설치됩니다.\n\n"),
-  );
-
-  // 모델 선택
-  const selectedId = await selectWithArrows(
-    options.map((opt) => ({
-      value: opt.value,
-      label: opt.label,
-    })),
-    "모델 선택",
-    streams,
-  );
-
-  if (!selectedId) {
-    return true;
-  }
-
-  const selectedModel = TRANSLATION_MODELS.find((m) => m.id === selectedId);
-  if (!selectedModel) {
-    output.write(colors.error("\n✗ 모델을 찾을 수 없습니다.\n\n"));
-    return true;
-  }
-
+const applySelectedModel = async (selectedModel: TranslationModel): Promise<void> => {
   const fileStatus = getModelAssetStatus(selectedModel);
 
-  // 정상 파일은 재사용하고, 손상/누락 파일은 명시적 선택 시 재다운로드
   if (fileStatus.kind === "invalid") {
     output.write(
       colors.warning(
@@ -869,30 +825,16 @@ const handleTranslationModel = async (streams?: SelectWithArrowsStreams): Promis
         `\n⬇️  ${selectedModel.displayName} 다운로드 시작...\n\n`,
       ),
     );
-
-    try {
-      await downloadModel(selectedModel);
-    } catch (error) {
-      output.write(
-        colors.error(
-          `\n✗ 다운로드 실패. 인터넷 연결을 확인하고 다시 시도하세요.\n\n`,
-        ),
-      );
-      return true;
-    }
+    await downloadModel(selectedModel);
   }
 
-  // 환경변수 및 설정 업데이트
   process.env.LOCAL_LLM_MODEL_NAME = selectedModel.modelName;
   process.env.LOCAL_LLM_MODEL_DIR = getDetoksModelDir(selectedModel);
   process.env.LOCAL_LLM_MODEL_PATH = getDetoksModelFilePath(selectedModel);
-  process.env.LOCAL_LLM_HF_REPO = `${selectedModel.hfRepo}:Q4_K_S`;
+  process.env.LOCAL_LLM_HF_REPO = `${selectedModel.hfRepo}:${selectedModel.quantization}`;
   process.env.LOCAL_LLM_HF_FILE = selectedModel.hfFile;
 
-  // .env 파일 업데이트
   updateEnvFile(selectedModel, process.cwd());
-
-  // 설정 저장
   updateTranslationModel(selectedModel.modelName);
 
   output.write(
@@ -900,9 +842,175 @@ const handleTranslationModel = async (streams?: SelectWithArrowsStreams): Promis
       `\n✓ 번역 모델이 '${selectedModel.displayName}'로 변경되었습니다.\n`,
     ),
   );
-  output.write(
-    colors.muted(`  설정 저장됨: ~/.detoks/settings.json\n\n`),
+  output.write(colors.muted(`  설정 저장됨: ~/.detoks/settings.json\n\n`));
+};
+
+const runCustomModelFlow = async (streams?: SelectWithArrowsStreams): Promise<boolean> => {
+  const repoInput = await promptLine(
+    "HuggingFace 레포를 입력하세요 (owner/repo 또는 전체 URL)",
+    {
+      placeholder: "unsloth/Qwen3-14B-GGUF",
+      validate: (value) => {
+        if (!parseHfRepoInput(value)) {
+          return "올바른 형식으로 입력하세요 (예: owner/repo 또는 https://huggingface.co/owner/repo)";
+        }
+        return null;
+      },
+    },
   );
+
+  if (!repoInput) {
+    return true;
+  }
+
+  const ref = parseHfRepoInput(repoInput);
+  if (!ref) {
+    return true;
+  }
+
+  output.write(colors.muted("\n레포 확인 중...\n"));
+
+  let ggufFiles;
+  try {
+    ggufFiles = await listGgufFiles(ref);
+  } catch (err) {
+    const msg = err instanceof HfRepoError ? err.message : String(err);
+    output.write(colors.error(`\n✗ ${msg}\n\n`));
+    return true;
+  }
+
+  output.write(
+    colors.success(`✓ 레포에서 GGUF 파일 ${ggufFiles.length}개를 찾았습니다.\n\n`),
+  );
+
+  const quantOptions = ggufFiles.map((f) => {
+    const quant = f.quantization === "unknown" ? f.filename : f.quantization;
+    const size = f.sizeMb > 0 ? `${f.sizeMb}MB` : "크기 미상";
+    return {
+      value: f.filename,
+      label: `${quant}  (${f.filename}, ${size})`,
+    };
+  });
+
+  const selectedFile = await selectWithArrows(quantOptions, "양자화 선택", streams);
+
+  if (!selectedFile) {
+    return true;
+  }
+
+  const selectedInfo = ggufFiles.find((f) => f.filename === selectedFile);
+  if (!selectedInfo) {
+    return true;
+  }
+
+  const customModel = buildCustomTranslationModel({
+    hfRepo: ref.fullRepo,
+    hfFile: selectedInfo.filename,
+    quantization: selectedInfo.quantization,
+    sizeMb: selectedInfo.sizeMb,
+  });
+
+  try {
+    await applySelectedModel(customModel);
+  } catch {
+    output.write(colors.error(`\n✗ 다운로드 실패. 인터넷 연결을 확인하고 다시 시도하세요.\n\n`));
+    return true;
+  }
+
+  saveCustomModel({
+    hfRepo: customModel.hfRepo,
+    hfFile: customModel.hfFile,
+    quantization: customModel.quantization,
+    sizeMb: customModel.sizeMb,
+    savedAt: new Date().toISOString(),
+  });
+
+  return true;
+};
+
+const handleTranslationModel = async (streams?: SelectWithArrowsStreams): Promise<boolean> => {
+  output.write(`\n${colors.title("한글→영어 번역 모델 선택\n")}`);
+
+  const builtinOptions = TRANSLATION_MODELS.map((model) => {
+    const fileStatus = getModelAssetStatus(model);
+    const status =
+      fileStatus.kind === "ready"
+        ? ` ${colors.success("[설치됨]")}`
+        : fileStatus.kind === "invalid"
+          ? ` ${colors.warning(`[손상됨:${fileStatus.reason}]`)}`
+          : "";
+    return {
+      value: model.id,
+      label: `${model.displayName}${status}`,
+      model,
+    };
+  });
+
+  for (const opt of builtinOptions) {
+    output.write(`${colors.muted(opt.label)}\n`);
+    output.write(`   ${colors.muted(opt.model.description)}\n\n`);
+  }
+
+  output.write(colors.muted("손상된 모델은 선택 후 Enter를 누르면 재설치됩니다.\n\n"));
+
+  // 메뉴 옵션: 빌트인 3개 + 사용자 지정 + 최근 사용자 지정(있을 때만)
+  const menuOptions: SelectOption[] = builtinOptions.map((opt) => ({
+    value: opt.value,
+    label: opt.label,
+  }));
+
+  menuOptions.push({
+    value: CUSTOM_MODEL_MENU_VALUE,
+    label: "사용자 지정 모델 설정 (GGUF)",
+  });
+
+  const lastCustom = loadLastCustomModel();
+  if (lastCustom) {
+    const tempModel = buildCustomTranslationModel(lastCustom);
+    const fileStatus = getModelAssetStatus(tempModel);
+    const statusLabel =
+      fileStatus.kind === "ready"
+        ? ` ${colors.success("[설치됨]")}`
+        : fileStatus.kind === "invalid"
+          ? ` ${colors.warning("[손상됨]")}`
+          : "";
+    menuOptions.push({
+      value: CUSTOM_MODEL_RECENT_VALUE,
+      label: `이전 사용자 지정: ${lastCustom.hfRepo}:${lastCustom.quantization}${statusLabel}`,
+    });
+  }
+
+  const selectedId = await selectWithArrows(menuOptions, "모델 선택", streams);
+
+  if (!selectedId) {
+    return true;
+  }
+
+  if (selectedId === CUSTOM_MODEL_MENU_VALUE) {
+    return runCustomModelFlow(streams);
+  }
+
+  if (selectedId === CUSTOM_MODEL_RECENT_VALUE && lastCustom) {
+    const recentModel = buildCustomTranslationModel(lastCustom);
+    try {
+      await applySelectedModel(recentModel);
+    } catch {
+      output.write(colors.error(`\n✗ 다운로드 실패. 인터넷 연결을 확인하고 다시 시도하세요.\n\n`));
+    }
+    return true;
+  }
+
+  const selectedModel = TRANSLATION_MODELS.find((m) => m.id === selectedId);
+  if (!selectedModel) {
+    output.write(colors.error("\n✗ 모델을 찾을 수 없습니다.\n\n"));
+    return true;
+  }
+
+  try {
+    await applySelectedModel(selectedModel);
+  } catch {
+    output.write(colors.error(`\n✗ 다운로드 실패. 인터넷 연결을 확인하고 다시 시도하세요.\n\n`));
+  }
 
   return true;
 };


### PR DESCRIPTION
## Summary

- `/model` 메뉴에 **4번 항목 "사용자 지정 모델 설정 (GGUF)"** 를 추가
- HuggingFace 레포 주소 입력 → GGUF 파일 자동 조회 → 양자화 선택 → 다운로드 → 환경변수 저장까지 한 흐름으로 처리
- 마지막으로 사용한 커스텀 모델을 `~/.detoks/custom-models.json`에 저장해 다음 `/model` 진입 시 "이전 사용자 지정" 항목으로 바로 재선택 가능
- `LOCAL_LLM_HF_REPO` 에 `Q4_K_S`가 하드코딩된 기존 버그도 함께 수정 (`selectedModel.quantization` 사용)

## 변경 파일

| 종류 | 경로 | 내용 |
|---|---|---|
| 신규 | `src/cli/model-setup/hf-repo.ts` | HF API 조회, URL/repo 입력 파서, 에러 타입 |
| 신규 | `src/cli/interactive/prompt-line.ts` | readline 기반 단일 라인 텍스트 입력 헬퍼 |
| 신규 | `src/cli/model-setup/custom-store.ts` | `~/.detoks/custom-models.json` 영속화 |
| 수정 | `src/cli/model-setup/models.ts` | `source` 필드, `buildCustomTranslationModel`, `CUSTOM_MODEL_MENU_VALUE` 추가 |
| 수정 | `src/cli/repl-commands/index.ts` | `handleTranslationModel` 확장, `runCustomModelFlow` 추가, Q4_K_S 버그 수정 |

## Test plan

- [ ] `/model` 진입 시 "사용자 지정 모델 설정 (GGUF)" 항목이 4번째로 노출되는지 확인
- [ ] `unsloth/Qwen3.5-2B-GGUF` 같은 소형 레포 입력 → GGUF 파일 목록과 양자화 선택지가 출력되는지 확인
- [ ] 양자화 선택 후 다운로드 완료 → `~/.detoks/models/llm/.../` 파일 존재 확인
- [ ] `.env`의 `LOCAL_LLM_*` 변수가 올바르게 갱신됐는지 확인
- [ ] `~/.detoks/custom-models.json` 생성 확인
- [ ] `/model` 재진입 시 "이전 사용자 지정: ... [설치됨]" 옵션 노출 확인
- [ ] 잘못된 레포 입력 시 에러 안내 후 재입력 루프 동작 확인
- [ ] ESC / 빈 입력 취소 시 `.env` 미변경 확인
- [ ] 빌트인 3개 모델 기존 흐름 회귀 없는지 확인