### PR TITLE
Add readable RAG context display and CLI summary

### DIFF
--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -96,6 +96,58 @@ function formatTaskStatusLabel(status: CliExecutionResult["taskRecords"][number]
   return "건너뜀";
 }
 
+function formatRagSourceLabel(sourceType: NonNullable<CliExecutionResult["ragContextSummary"]>["items"][number]["sourceType"]): string {
+  if (sourceType === "previous_request") return "이전 요청";
+  if (sourceType === "previous_output") return "이전 출력";
+  return "이전 작업";
+}
+
+function formatRagRelevanceLabel(relevance: NonNullable<CliExecutionResult["ragContextSummary"]>["items"][number]["relevance"]): string {
+  if (relevance === "high") return "높음";
+  if (relevance === "medium") return "중간";
+  return "낮음";
+}
+
+function formatRagSkipReason(reason: NonNullable<CliExecutionResult["ragContextSummary"]>["skipReason"]): string | null {
+  if (reason === "budget") return "컨텍스트 예산 초과";
+  if (reason === "empty_content") return "표시할 내용 없음";
+  if (reason === "disabled") return "메모리 비활성화";
+  if (reason === "error") return "검색 오류";
+  return null;
+}
+
+function buildRagContextLines(result: CliExecutionResult): string[] {
+  const summary = result.ragContextSummary;
+  if (!summary || summary.items.length === 0) {
+    return [];
+  }
+
+  const lines = ["", colors.header("관련 과거 컨텍스트")];
+  const skipReason = formatRagSkipReason(summary.skipReason);
+
+  for (const item of summary.items.slice(0, 3)) {
+    const sourceLabel = formatRagSourceLabel(item.sourceType);
+    const taskLabel = item.taskId ? ` ${item.taskId}` : "";
+    const action = item.injected
+      ? "내용을 참고했습니다"
+      : "비슷한 내용을 찾았지만 이번 프롬프트에는 넣지 않았습니다";
+    lines.push(`  ${colors.muted("·")} ${sourceLabel}${taskLabel}: ${translateVisibleText(item.preview)} ${action}`);
+    lines.push(
+      `    ${colors.muted("세션:")} ${item.sessionId} ${colors.muted("·")} ${colors.muted("관련도")} ${formatRagRelevanceLabel(item.relevance)}`,
+    );
+  }
+
+  if (summary.items.length > 3) {
+    lines.push(`    ${colors.muted(`외 ${summary.items.length - 3}개 관련 컨텍스트 생략`)}`);
+  }
+
+  if (summary.skipped > 0 && skipReason) {
+    lines.push(`    ${colors.muted("미사용 이유:")} ${skipReason}`);
+  }
+
+  return lines;
+}
+
 function buildKoreanExecutionSummary(result: CliExecutionResult): string[] {
   const lines: string[] = [];
   const requestText =
@@ -191,7 +243,10 @@ function formatResultHuman(result: CliExecutionResult, ok: boolean): string {
     );
   }
 
-  if (result.semanticContext && result.semanticContext.length > 0) {
+  const ragContextLines = buildRagContextLines(result);
+  if (ragContextLines.length > 0) {
+    lines.push(...ragContextLines);
+  } else if (result.semanticContext && result.semanticContext.length > 0) {
     lines.push("", colors.header("관련 과거 작업"));
     for (const item of result.semanticContext.slice(0, 3)) {
       const label = item.task_id ? `${item.kind}::${item.session_id}::${item.task_id}` : `${item.kind}::${item.session_id}`;

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -57,6 +57,8 @@ import type {
   TaskExecutionRecord,
   ResumeHintInfo,
   SemanticContextResult,
+  RagContextDisplayItem,
+  RagContextSummary,
 } from "./types.js";
 import { createActionTimelineEvent } from "../timeline/types.js";
 import type { ActionTimelineEvent } from "../timeline/types.js";
@@ -251,6 +253,37 @@ function extractRagMeta(task?: { title?: string; input_hash?: string; depends_on
     ...(task.title !== undefined ? { title: task.title } : {}),
     ...(task.input_hash !== undefined ? { input_hash: task.input_hash } : {}),
     ...(task.depends_on !== undefined ? { depends_on: task.depends_on } : {}),
+  };
+}
+
+function normalizeRagPreview(content: string, maxLength = 80): string {
+  const normalized = content.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+function toRagDisplaySourceType(kind: RagSnippet["kind"]): RagContextDisplayItem["sourceType"] {
+  if (kind === "prompt") return "previous_request";
+  if (kind === "output") return "previous_output";
+  return "previous_task";
+}
+
+function toRagRelevance(distance: number): RagContextDisplayItem["relevance"] {
+  if (distance <= 0.35) return "high";
+  if (distance <= 0.65) return "medium";
+  return "low";
+}
+
+function toRagDisplayItem(snippet: RagSnippet): RagContextDisplayItem {
+  return {
+    sourceType: toRagDisplaySourceType(snippet.kind),
+    sessionId: snippet.session_id,
+    ...(snippet.task_id ? { taskId: snippet.task_id } : {}),
+    preview: normalizeRagPreview(snippet.content),
+    relevance: toRagRelevance(snippet.distance),
+    injected: false,
   };
 }
 
@@ -723,6 +756,8 @@ export const orchestratePipeline = async (
   let ragEmbedder: EmbeddingService | undefined;
   let ragStore: VectorStore | undefined;
   const perTaskSnippets = new Map<string, RagSnippet[]>();
+  const ragDisplayItemsByTask = new Map<string, RagContextDisplayItem[]>();
+  let ragSkipReason: RagContextSummary["skipReason"] | undefined;
 
   // ── Step 1: Prompt compile + Role 2.1 handoff 생성 (Role 1) ──────────────
   let compiledPrompt;
@@ -1037,7 +1072,10 @@ export const orchestratePipeline = async (
             ...(h.meta.task_id ? { task_id: h.meta.task_id as string } : {}),
           })));
           const snippets = await loader.load(hits.slice(0, 1));
-          if (snippets.length > 0) perTaskSnippets.set(task.id, snippets);
+          if (snippets.length > 0) {
+            perTaskSnippets.set(task.id, snippets);
+            ragDisplayItemsByTask.set(task.id, snippets.map(toRagDisplayItem));
+          }
         }
       }
 
@@ -1330,6 +1368,11 @@ export const orchestratePipeline = async (
             ragContext = ragContextRaw;
             ragAddedDelta = ragTokensForTask;
             ragInjectedThisTask = true;
+            for (const item of ragDisplayItemsByTask.get(task.id) ?? []) {
+              item.injected = true;
+            }
+          } else {
+            ragSkipReason = "budget";
           }
         }
 
@@ -1508,6 +1551,16 @@ export const orchestratePipeline = async (
     ragContextInjected,
     cacheHitRate: graph.tasks.length > 0 ? cacheHitCount / graph.tasks.length : 0,
   };
+  const ragContextItems = Array.from(ragDisplayItemsByTask.values()).flat();
+  const ragContextSummary: RagContextSummary | undefined = ragContextItems.length > 0
+    ? {
+        found: ragContextItems.length,
+        injected: ragContextItems.filter((item) => item.injected).length,
+        skipped: ragContextItems.filter((item) => !item.injected).length,
+        ...(ragSkipReason ? { skipReason: ragSkipReason } : {}),
+        items: ragContextItems,
+      }
+    : undefined;
 
   return {
     ok: allOk,
@@ -1535,6 +1588,7 @@ export const orchestratePipeline = async (
     progressLog,
     ...(resumeHint ? { resumeHint } : {}),
     ...(semanticContext ? { semanticContext } : {}),
+    ...(ragContextSummary ? { ragContextSummary } : {}),
     tokenAccounting,
     costAccounting,
     lightQuality,

--- a/src/core/pipeline/types.ts
+++ b/src/core/pipeline/types.ts
@@ -90,6 +90,23 @@ export interface SemanticContextResult {
   task_id?: string;
 }
 
+export interface RagContextDisplayItem {
+  sourceType: "previous_request" | "previous_task" | "previous_output";
+  sessionId: string;
+  taskId?: string;
+  preview: string;
+  relevance: "high" | "medium" | "low";
+  injected: boolean;
+}
+
+export interface RagContextSummary {
+  found: number;
+  injected: number;
+  skipped: number;
+  skipReason?: "budget" | "empty_content" | "disabled" | "error";
+  items: RagContextDisplayItem[];
+}
+
 export interface PipelineExecutionResult {
   ok: boolean;
   mode: InteractionMode;
@@ -119,6 +136,7 @@ export interface PipelineExecutionResult {
   cacheHit?: CacheHitInfo;
   resumeHint?: ResumeHintInfo;
   semanticContext?: SemanticContextResult[];
+  ragContextSummary?: RagContextSummary;
   tokenAccounting?: TokenAccounting;
   costAccounting?: CostAccounting;
   lightQuality?: LightQualityCounters;

--- a/tests/ts/unit/cli/format.test.ts
+++ b/tests/ts/unit/cli/format.test.ts
@@ -131,6 +131,70 @@ describe("formatSuccess", () => {
     expect(formatted).toContain("로그인 오류 원인을 분석해줘");
     expect(formatted).not.toContain("Analyze the cause of the login error");
   });
+
+  it("renders readable RAG context summary without raw distance values", () => {
+    const formatted = formatSuccess(
+      {
+        ...result,
+        ragContextSummary: {
+          found: 2,
+          injected: 1,
+          skipped: 1,
+          skipReason: "budget" as const,
+          items: [
+            {
+              sourceType: "previous_task" as const,
+              sessionId: "a13f9c2b",
+              taskId: "t2",
+              preview: "로그인 토큰 갱신 로직 수정",
+              relevance: "high" as const,
+              injected: true,
+            },
+            {
+              sourceType: "previous_request" as const,
+              sessionId: "8b72d10e",
+              preview: "OAuth 콜백 에러 분석",
+              relevance: "medium" as const,
+              injected: false,
+            },
+          ],
+        },
+        semanticContext: [
+          { id: "task::a13f9c2b::t2", kind: "task" as const, session_id: "a13f9c2b", task_id: "t2", distance: 0.123 },
+        ],
+      },
+      false,
+    );
+
+    expect(formatted).toContain("관련 과거 컨텍스트");
+    expect(formatted).toContain("이전 작업 t2");
+    expect(formatted).toContain("로그인 토큰 갱신 로직 수정 내용을 참고했습니다");
+    expect(formatted).toContain("이전 요청");
+    expect(formatted).toContain("이번 프롬프트에는 넣지 않았습니다");
+    expect(formatted).toContain("관련도 높음");
+    expect(formatted).toContain("관련도 중간");
+    expect(formatted).toContain("미사용 이유:");
+    expect(formatted).toContain("컨텍스트 예산 초과");
+    expect(formatted).not.toContain("dist:");
+    expect(formatted).not.toContain("0.123");
+    expect(formatted).not.toContain("task::a13f9c2b::t2");
+  });
+
+  it("falls back to semanticContext when RAG display summary is absent", () => {
+    const formatted = formatSuccess(
+      {
+        ...result,
+        semanticContext: [
+          { id: "task::s1::t1", kind: "task" as const, session_id: "s1", task_id: "t1", distance: 0.456 },
+        ],
+      },
+      false,
+    );
+
+    expect(formatted).toContain("관련 과거 작업");
+    expect(formatted).toContain("task::s1::t1");
+    expect(formatted).toContain("dist: 0.456");
+  });
 });
 
 describe("formatError", () => {


### PR DESCRIPTION
## 요약

- `PipelineExecutionResult`에 사용자 표시용 `ragContextSummary`를 추가했습니다.
- RAG snippet을 이전 요청/작업/출력 라벨, 한 줄 preview, 관련도 라벨, 실제 주입 여부로 변환합니다.
- CLI 기본 출력에서 기존 내부 메타데이터 대신 사람이 읽기 쉬운 `관련 과거 컨텍스트` 섹션을 표시합니다.
- 기존 `semanticContext` 출력은 `ragContextSummary`가 없을 때 fallback으로 유지합니다.
- formatter 단위 테스트로 raw distance 비노출, 새 RAG 표시, fallback 동작을 검증했습니다.

## 관련 이슈

- Closes #278 

## 변경 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 문서 수정
- [x] 테스트 추가/수정

## 영향 범위

영향받는 모듈:

- `src/core/pipeline/types.ts` — `RagContextDisplayItem`, `RagContextSummary`, `PipelineExecutionResult.ragContextSummary` 추가
- `src/core/pipeline/orchestrator.ts` — RAG snippet을 사용자 표시용 summary로 변환하고 budget gate 주입 여부 반영
- `src/cli/format.ts` — 기본 human 출력에서 `관련 과거 컨텍스트` 섹션 표시
- `tests/ts/unit/cli/format.test.ts` — 새 RAG 표시와 fallback 테스트 추가

영향받지 않는 모듈:

- RAG vector store 검색 로직
- embedding/indexing 로직
- adapter 실행 경로
- session state 저장 포맷
- 기존 `semanticContext` 소비자
- TUI 렌더링 경로

## 수정 내역 상세

### 1. 사용자 표시용 RAG 결과 타입 추가

`PipelineExecutionResult`에 `ragContextSummary`를 추가했다.

```ts
export interface RagContextDisplayItem {
  sourceType: "previous_request" | "previous_task" | "previous_output";
  sessionId: string;
  taskId?: string;
  preview: string;
  relevance: "high" | "medium" | "low";
  injected: boolean;
}
```

기존 `semanticContext`는 제거하지 않았다. 디버깅/호환성을 위해 그대로 반환하며, CLI는 새 필드가 없을 때 기존 출력으로 fallback한다.

### 2. orchestrator에서 RAG display item 생성

RAG retrieval 후 로드된 snippet을 사용자 표시용 item으로 변환한다.

- `prompt` → `이전 요청`
- `task` → `이전 작업`
- `output` → `이전 출력`
- whitespace를 정리해 80자 preview 생성
- distance를 `high` / `medium` / `low`로 변환
- budget gate를 통과해 실제 프롬프트에 들어간 경우 `injected = true`

### 3. CLI human 출력 개선

기존 출력:

```text
관련 과거 작업
  · task::a13f9c2b::t2 (dist: 0.123)
```

변경 후 출력:

```text
관련 과거 컨텍스트
  · 이전 작업 t2: 로그인 토큰 갱신 로직 수정 내용을 참고했습니다
    세션: a13f9c2b · 관련도 높음
```

찾았지만 budget gate로 넣지 않은 항목은 아래처럼 구분한다.

```text
  · 이전 요청: OAuth 콜백 에러 분석 비슷한 내용을 찾았지만 이번 프롬프트에는 넣지 않았습니다
    세션: 8b72d10e · 관련도 중간
    미사용 이유: 컨텍스트 예산 초과
```

### 4. fallback 유지

`ragContextSummary`가 없고 `semanticContext`만 있는 경우 기존 `관련 과거 작업` 출력이 유지된다. 이전 결과 payload나 외부 소비자가 새 필드를 아직 제공하지 않아도 CLI가 깨지지 않는다.

## 테스트 방법

### 빌드

```bash
npm run build
```

결과:

```text
(오류 없음)
```

### 관련 단위 테스트

```bash
npx --no-install vitest run tests/ts/unit/cli/format.test.ts tests/ts/unit/core/rag/rag-context-loader.test.ts
```

결과:

```text
Test Files  2 passed (2)
Tests       23 passed (23)
```

### CI TypeScript job 재현

```bash
npm run typecheck &
LOCAL_LLM_AUTO_START=0 npx vitest run --passWithNoTests &
wait
```

결과:

```text
Test Files  101 passed | 1 skipped (102)
Tests       936 passed | 3 skipped (939)
```

### CI Python runtime gate 재현

CI의 `Reject Python runtime reintroduction` 검사와 동일한 조건을 로컬에서 실행했고 통과를 확인했다.

## 체크리스트

- [x] 로컬에서 테스트했습니다.
- [x] `npm run build` 통과를 확인했습니다.
- [x] CI와 동일한 `LOCAL_LLM_AUTO_START=0` 테스트 조건에서 전체 vitest 통과를 확인했습니다.
- [x] 새 CLI 출력에서 raw distance가 노출되지 않음을 테스트했습니다.
- [x] 기존 `semanticContext` fallback을 유지했습니다.
- [x] RAG 검색/indexing/adapter 실행 경로를 변경하지 않았습니다.

## 커밋 목록

| 커밋 | 내용 |
|---|---|
| `54636e6` | `feat: add rag context display summary` |
| `9fc2290` | `feat: show readable rag context in cli` |
| `908ece1` | `test: cover readable rag context output` |

## 리뷰어 참고사항

- 이번 변경은 RAG retrieval 자체의 정확도나 검색 범위를 바꾸지 않는다. 표시용 summary를 추가하고 CLI human 출력만 개선한다.
- `semanticContext`는 유지되므로 기존 verbose JSON·외부 소비자 호환성은 유지된다.
- `skipReason`은 현재 summary 단위로만 표현된다. 1차 구현에서는 budget gate 미사용 이유를 충분히 전달하는 목적이며, 필요하면 후속 PR에서 item별 skip reason으로 확장할 수 있다.
