### PR TITLE
Fix local state save path handling across CLI workflows

### DIFF
--- a/src/cli/commands/checkpoint-list.ts
+++ b/src/cli/commands/checkpoint-list.ts
@@ -20,8 +20,9 @@ export interface CheckpointListOutput {
 
 export const runCheckpointListCommand = async (
   sessionId: string,
+  cwd?: string,
 ): Promise<CheckpointListOutput> => {
-  const checkpoints = await SessionStateManager.listCheckpoints(sessionId);
+  const checkpoints = await SessionStateManager.listCheckpoints(sessionId, cwd);
   const checkpointCount = checkpoints.length;
 
   return {

--- a/src/cli/commands/checkpoint-restore.ts
+++ b/src/cli/commands/checkpoint-restore.ts
@@ -23,9 +23,10 @@ export interface CheckpointRestoreOutput {
 
 export const runCheckpointRestoreCommand = async (
   checkpointId: string,
+  cwd?: string,
 ): Promise<CheckpointRestoreOutput> => {
   try {
-    const checkpoint = await SessionStateManager.loadCheckpoint(checkpointId);
+    const checkpoint = await SessionStateManager.loadCheckpoint(checkpointId, cwd);
     const sessionId = parseSessionIdFromCheckpointId(checkpoint.id);
     if (!sessionId) {
       return {
@@ -40,7 +41,7 @@ export const runCheckpointRestoreCommand = async (
     }
     
     // Check if session exists
-    if (!(await SessionStateManager.sessionExists(sessionId))) {
+    if (!(await SessionStateManager.sessionExists(sessionId, cwd))) {
         return {
             ok: false,
             mode: "checkpoint-restore",
@@ -52,7 +53,7 @@ export const runCheckpointRestoreCommand = async (
         };
     }
 
-    const state = await SessionStateManager.loadSession(sessionId);
+    const state = await SessionStateManager.loadSession(sessionId, cwd);
     
     // Find index of task that created this checkpoint
     const taskIndex = state.completed_task_ids.indexOf(checkpoint.task_id);
@@ -86,7 +87,7 @@ export const runCheckpointRestoreCommand = async (
         updated_at: new Date().toISOString()
     };
 
-    await SessionStateManager.saveSession(newState);
+    await SessionStateManager.saveSession(newState, cwd);
 
     return {
       ok: true,

--- a/src/cli/commands/checkpoint-show.ts
+++ b/src/cli/commands/checkpoint-show.ts
@@ -17,8 +17,9 @@ export interface CheckpointShowOutput {
 
 export const runCheckpointShowCommand = async (
   checkpointId: string,
+  cwd?: string,
 ): Promise<CheckpointShowOutput> => {
-  const checkpoint = await SessionStateManager.loadCheckpoint(checkpointId);
+  const checkpoint = await SessionStateManager.loadCheckpoint(checkpointId, cwd);
 
   return {
     ok: true,

--- a/src/cli/commands/home.ts
+++ b/src/cli/commands/home.ts
@@ -33,9 +33,9 @@ const loadHomeSessionPreview = async (session: {
   completedTaskCount: number;
   taskResultCount: number;
   nextAction: string | null;
-}): Promise<HomeSessionPreview> => {
+}, cwd?: string): Promise<HomeSessionPreview> => {
   try {
-    const state = await SessionStateManager.loadSession(session.id);
+    const state = await SessionStateManager.loadSession(session.id, cwd);
     return {
       ...session,
       lastWorkSummary: deriveLastWorkSummary(state),
@@ -50,10 +50,10 @@ const loadHomeSessionPreview = async (session: {
   }
 };
 
-export const runHomeCommand = async (): Promise<HomeDashboardOutput> => {
-  const sessions = await SessionStateManager.listSessions();
+export const runHomeCommand = async (cwd?: string): Promise<HomeDashboardOutput> => {
+  const sessions = await SessionStateManager.listSessions(cwd);
   const recentSessions = await Promise.all(
-    sessions.slice(0, RECENT_SESSION_LIMIT).map((session) => loadHomeSessionPreview(session)),
+    sessions.slice(0, RECENT_SESSION_LIMIT).map((session) => loadHomeSessionPreview(session, cwd)),
   );
 
   return {

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -1,10 +1,15 @@
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import { resolveSessionsDir } from "../../core/state/SessionStateManager.js";
 import { getRagVectorDbPath } from "../../core/rag/rag-config.js";
+import {
+  getDetoksHomeDir,
+  resolveLegacyRagDir,
+  resolveLegacySessionsDir,
+  resolveSharedCrossProjectDir,
+} from "../../core/state/storage-paths.js";
 
-const DISABLED_FLAG_FILE = join(homedir(), ".detoks", "disabled");
+const DISABLED_FLAG_FILE = join(getDetoksHomeDir(), "disabled");
 
 export interface MemoryCommandResult {
   ok: boolean;
@@ -16,7 +21,7 @@ export interface MemoryCommandResult {
 // ~/.detoks/disabled 파일을 생성. 다음 실행부터 저장/조회/인덱싱 모두 OFF.
 export async function runMemoryDisableCommand(): Promise<MemoryCommandResult> {
   try {
-    await fs.mkdir(join(homedir(), ".detoks"), { recursive: true });
+    await fs.mkdir(getDetoksHomeDir(), { recursive: true });
     await fs.writeFile(DISABLED_FLAG_FILE, "", { flag: "w" });
     return {
       ok: true,
@@ -33,14 +38,16 @@ export async function runMemoryDisableCommand(): Promise<MemoryCommandResult> {
 }
 
 // detoks memory purge --all
-// .state/sessions/*.json + .state/rag/vectors.db 일괄 삭제 (확인 프롬프트 포함).
+// 현재 작업 디렉터리에 대응하는 세션 저장소 + RAG 벡터 DB를 일괄 삭제한다.
 export async function runMemoryPurgeAllCommand(opts: {
   skipConfirm?: boolean;
   keepCrossProject?: boolean;
+  cwd?: string;
 } = {}): Promise<MemoryCommandResult> {
+  const cwd = opts.cwd ?? process.cwd();
   if (!opts.skipConfirm) {
     const confirmed = await promptConfirm(
-      "⚠️  .state/sessions/ 전체와 벡터 DB를 영구 삭제합니다. 계속하시겠습니까? (yes/N): ",
+      "⚠️  현재 작업 디렉터리의 세션 저장소와 벡터 DB를 영구 삭제합니다. 계속하시겠습니까? (yes/N): ",
     );
     if (!confirmed) {
       return { ok: true, action: "purge-all", message: "취소되었습니다." };
@@ -50,35 +57,45 @@ export async function runMemoryPurgeAllCommand(opts: {
   const errors: string[] = [];
   let deletedCount = 0;
 
-  // 1. session 파일 삭제
-  const sessionsDir = resolveSessionsDir(process.cwd());
-  try {
-    const files = await fs.readdir(sessionsDir);
-    for (const file of files) {
-      if (!file.endsWith(".json")) continue;
-      try {
-        await fs.unlink(join(sessionsDir, file));
-        deletedCount++;
-      } catch (e) {
-        errors.push(`${file}: ${e instanceof Error ? e.message : String(e)}`);
+  // 1. session 파일 삭제 (신규 경로 + legacy 경로)
+  const sessionDirs = Array.from(new Set([
+    resolveSessionsDir(cwd),
+    resolveLegacySessionsDir(cwd),
+  ]));
+  for (const sessionsDir of sessionDirs) {
+    try {
+      const files = await fs.readdir(sessionsDir);
+      for (const file of files) {
+        if (!file.endsWith(".json")) continue;
+        try {
+          await fs.unlink(join(sessionsDir, file));
+          deletedCount++;
+        } catch (e) {
+          errors.push(`${file}: ${e instanceof Error ? e.message : String(e)}`);
+        }
       }
+    } catch {
+      // sessionsDir이 없으면 그냥 통과
     }
-  } catch {
-    // sessionsDir이 없으면 그냥 통과
   }
 
-  // 2. 벡터 DB 삭제
-  try {
-    const dbPath = getRagVectorDbPath(process.cwd());
-    await fs.unlink(dbPath);
-    deletedCount++;
-  } catch {
-    // 벡터 DB가 없으면 통과
+  // 2. 벡터 DB 삭제 (신규 경로 + legacy 경로)
+  const dbPaths = [
+    getRagVectorDbPath(cwd),
+    join(resolveLegacyRagDir(cwd), "vectors.db"),
+  ];
+  for (const dbPath of dbPaths) {
+    try {
+      await fs.unlink(dbPath);
+      deletedCount++;
+    } catch {
+      // 벡터 DB가 없으면 통과
+    }
   }
 
   // 3. cross-project 패턴 삭제 (--keep-cross-project 없을 때)
   if (!opts.keepCrossProject) {
-    const crossProjectDir = join(homedir(), ".detoks", "cross-project");
+    const crossProjectDir = resolveSharedCrossProjectDir();
     let countLabel = "알 수 없음";
     try {
       const indexRaw = await fs.readFile(join(crossProjectDir, "index.json"), "utf-8");
@@ -88,7 +105,7 @@ export async function runMemoryPurgeAllCommand(opts: {
       }
     } catch { /* index.json 없으면 "알 수 없음" */ }
 
-    console.log(`[detoks] cross-project 패턴도 삭제합니다 (~/.detoks/cross-project/): ${countLabel}`);
+    console.log(`[detoks] cross-project 패턴도 삭제합니다 (${crossProjectDir}/): ${countLabel}`);
     console.log(`[detoks] --keep-cross-project 플래그로 유지할 수 있습니다.`);
 
     try {

--- a/src/cli/commands/session-continue.ts
+++ b/src/cli/commands/session-continue.ts
@@ -53,7 +53,7 @@ export const runSessionContinueCommand = async (
   options: SessionContinueCommandOptions = {},
 ): Promise<SessionContinueOutput> => {
   const sessionId = request.userRequest.session_id ?? "";
-  const exists = await SessionStateManager.sessionExists(sessionId);
+  const exists = await SessionStateManager.sessionExists(sessionId, request.userRequest.cwd);
 
   if (!exists) {
     return {
@@ -69,7 +69,7 @@ export const runSessionContinueCommand = async (
     };
   }
 
-  const session = await SessionStateManager.loadSession(sessionId);
+  const session = await SessionStateManager.loadSession(sessionId, request.userRequest.cwd);
   const resumeOverview = deriveSessionResumeOverview(session);
   options.onResumeOverview?.(resumeOverview);
   const nextAction = session.next_action ?? null;

--- a/src/cli/commands/session-fork.ts
+++ b/src/cli/commands/session-fork.ts
@@ -14,8 +14,9 @@ export interface SessionForkOutput {
 export const runSessionForkCommand = async (
   sourceSessionId: string,
   newSessionId: string,
+  cwd?: string,
 ): Promise<SessionForkOutput> => {
-  const sourceExists = await SessionStateManager.sessionExists(sourceSessionId);
+  const sourceExists = await SessionStateManager.sessionExists(sourceSessionId, cwd);
 
   if (!sourceExists) {
     return {
@@ -30,7 +31,7 @@ export const runSessionForkCommand = async (
     };
   }
 
-  const targetExists = await SessionStateManager.sessionExists(newSessionId);
+  const targetExists = await SessionStateManager.sessionExists(newSessionId, cwd);
 
   if (targetExists) {
     return {
@@ -45,7 +46,7 @@ export const runSessionForkCommand = async (
     };
   }
 
-  const forkedSession = await SessionStateManager.forkSession(sourceSessionId, newSessionId);
+  const forkedSession = await SessionStateManager.forkSession(sourceSessionId, newSessionId, cwd);
 
   return {
     ok: true,

--- a/src/cli/commands/session-list.ts
+++ b/src/cli/commands/session-list.ts
@@ -26,14 +26,15 @@ export interface SessionListOutput {
 
 export interface SessionListCommandOptions {
   includeLastWorkSummary?: boolean;
+  cwd?: string;
 }
 
-const loadSessionInsights = async (sessionId: string): Promise<{
+const loadSessionInsights = async (sessionId: string, cwd?: string): Promise<{
   lastWorkSummary: string | null;
   tokenMetrics: TokenMetricsSnapshot | null;
 }> => {
   try {
-    const state = await SessionStateManager.loadSession(sessionId);
+    const state = await SessionStateManager.loadSession(sessionId, cwd);
     return {
       lastWorkSummary: deriveLastWorkSummary(state),
       tokenMetrics: deriveTokenMetricsSummary(state),
@@ -49,13 +50,13 @@ const loadSessionInsights = async (sessionId: string): Promise<{
 export const runSessionListCommand = async (
   options: SessionListCommandOptions = {},
 ): Promise<SessionListOutput> => {
-  const sessions = await SessionStateManager.listSessions();
+  const sessions = await SessionStateManager.listSessions(options.cwd);
   const sessionCount = sessions.length;
   const includeLastWorkSummary = options.includeLastWorkSummary ?? false;
   const lastWorkSummaryBySession = includeLastWorkSummary
     ? new Map(
         await Promise.all(
-          sessions.map(async (session) => [session.id, await loadSessionInsights(session.id)] as const),
+          sessions.map(async (session) => [session.id, await loadSessionInsights(session.id, options.cwd)] as const),
         ),
       )
     : undefined;

--- a/src/cli/commands/session-reset.ts
+++ b/src/cli/commands/session-reset.ts
@@ -11,8 +11,9 @@ export interface SessionResetOutput {
 
 export const runSessionResetCommand = async (
   sessionId: string,
+  cwd?: string,
 ): Promise<SessionResetOutput> => {
-  const exists = await SessionStateManager.sessionExists(sessionId);
+  const exists = await SessionStateManager.sessionExists(sessionId, cwd);
 
   if (!exists) {
     return {
@@ -26,7 +27,7 @@ export const runSessionResetCommand = async (
   }
 
   try {
-    await SessionStateManager.deleteSession(sessionId);
+    await SessionStateManager.deleteSession(sessionId, cwd);
     return {
       ok: true,
       mode: "session-reset",

--- a/src/cli/commands/session-show.ts
+++ b/src/cli/commands/session-show.ts
@@ -34,13 +34,14 @@ export type SessionShowOutput =
 
 export interface SessionShowCommandOptions {
   includeRawOutput?: boolean;
+  cwd?: string;
 }
 
 export const runSessionShowCommand = async (
   sessionId: string,
   options: SessionShowCommandOptions = {},
 ): Promise<SessionShowOutput> => {
-  const exists = await SessionStateManager.sessionExists(sessionId);
+  const exists = await SessionStateManager.sessionExists(sessionId, options.cwd);
   if (!exists) {
     return {
       ok: true,
@@ -54,7 +55,7 @@ export const runSessionShowCommand = async (
     };
   }
 
-  const state = await SessionStateManager.loadSession(sessionId);
+  const state = await SessionStateManager.loadSession(sessionId, options.cwd);
   return {
     ok: true,
     mode: "session-show",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -71,7 +71,9 @@ const main = async (): Promise<void> => {
 
   if (args.command === "session-list") {
     const result = await runSessionListCommand(
-      args.human ? { includeLastWorkSummary: true } : undefined,
+      args.human
+        ? { includeLastWorkSummary: true, ...(args.cwd ? { cwd: args.cwd } : {}) }
+        : { ...(args.cwd ? { cwd: args.cwd } : {}) },
     );
     console.log(args.human ? formatSessionListHuman(result) : JSON.stringify(result, null, 2));
     return;
@@ -80,6 +82,7 @@ const main = async (): Promise<void> => {
   if (args.command === "session-show") {
     const result = await runSessionShowCommand(args.sessionId ?? "", {
       includeRawOutput: args.verbose,
+      ...(args.cwd ? { cwd: args.cwd } : {}),
     });
     console.log(args.human ? formatSessionShowHuman(result) : JSON.stringify(result, null, 2));
     return;
@@ -106,7 +109,7 @@ const main = async (): Promise<void> => {
   }
 
   if (args.command === "session-reset") {
-    const result = await runSessionResetCommand(args.sessionId ?? "");
+    const result = await runSessionResetCommand(args.sessionId ?? "", args.cwd);
     console.log(JSON.stringify(result, null, 2));
     if (!result.ok) {
       process.exitCode = 1;
@@ -124,7 +127,7 @@ const main = async (): Promise<void> => {
   }
 
   if (args.command === "session-fork") {
-    const result = await runSessionForkCommand(args.sessionId ?? "", args.newSessionId ?? "");
+    const result = await runSessionForkCommand(args.sessionId ?? "", args.newSessionId ?? "", args.cwd);
     console.log(JSON.stringify(result, null, 2));
     if (!result.ok) {
       process.exitCode = 1;
@@ -133,19 +136,19 @@ const main = async (): Promise<void> => {
   }
 
   if (args.command === "checkpoint-list") {
-    const result = await runCheckpointListCommand(args.sessionId ?? "");
+    const result = await runCheckpointListCommand(args.sessionId ?? "", args.cwd);
     console.log(JSON.stringify(result, null, 2));
     return;
   }
 
   if (args.command === "checkpoint-show") {
-    const result = await runCheckpointShowCommand(args.checkpointId ?? "");
+    const result = await runCheckpointShowCommand(args.checkpointId ?? "", args.cwd);
     console.log(JSON.stringify(result, null, 2));
     return;
   }
 
   if (args.command === "checkpoint-restore") {
-    const result = await runCheckpointRestoreCommand(args.checkpointId ?? "");
+    const result = await runCheckpointRestoreCommand(args.checkpointId ?? "", args.cwd);
     console.log(JSON.stringify(result, null, 2));
     if (!result.ok) {
       process.exitCode = 1;
@@ -164,6 +167,7 @@ const main = async (): Promise<void> => {
     const result = await runMemoryPurgeAllCommand({
       ...(args.skipConfirm ? { skipConfirm: true as const } : {}),
       ...(args.keepCrossProject ? { keepCrossProject: true } : {}),
+      ...(args.cwd ? { cwd: args.cwd } : {}),
     });
     console.log(args.human ? result.message : JSON.stringify(result, null, 2));
     if (!result.ok) process.exitCode = 1;

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { UserRequestSchema } from "../schemas/pipeline.js";
 import {
   AdapterValues,
@@ -491,13 +492,13 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
       if (!next) {
         throw new Error(`--cwd에는 경로가 필요합니다. ${MAIN_HELP_HINT}`);
       }
-      cwd = next;
+      cwd = resolve(next);
       i += 1;
       continue;
     }
 
     if (current.startsWith("--cwd=")) {
-      cwd = current.split("=")[1] ?? "";
+      cwd = resolve(current.split("=")[1] ?? "");
       if (!cwd) {
         throw new Error(`--cwd에는 경로가 필요합니다. ${MAIN_HELP_HINT}`);
       }

--- a/src/cli/repl-commands/index.ts
+++ b/src/cli/repl-commands/index.ts
@@ -1,7 +1,6 @@
 import { stdout as output } from "node:process";
 import { createInterface } from "node:readline/promises";
 import { spawnSync } from "node:child_process";
-import { join } from "node:path";
 import type { Adapter } from "../../core/pipeline/types.js";
 import { colors } from "../colors.js";
 import {
@@ -17,6 +16,7 @@ import type { SelectOption, SelectWithArrowsStreams } from "../interactive/selec
 import { invalidateCache } from "../cache/cache-manager.js";
 import { getCacheStats, clearExpiredSessions, formatCacheStats } from "./cache-command.js";
 import { CACHE_TTL_DAYS } from "../../core/cache/cache-config.js";
+import { resolveSessionsDir } from "../../core/state/SessionStateManager.js";
 import {
   getCodexReasoningEffortOverride,
   updateAdapterModel,
@@ -532,7 +532,7 @@ export const handleSlashCommand = async (
     }
 
     case "cache": {
-      const sessionsDir = join(process.cwd(), ".state", "sessions");
+      const sessionsDir = resolveSessionsDir(process.cwd());
       const sub = input.trim().split(/\s+/)[1]?.toLowerCase();
 
       if (sub === "clear") {

--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -57,6 +57,7 @@ import { orchestratePipeline } from "../../core/pipeline/orchestrator.js";
 import { buildActionTimeline } from "../../core/timeline/action-timeline.js";
 import { readRole1ModelName, loadRole1RuntimeConfig } from "../../core/prompt/config.js";
 import { ensureLocalLlmRuntime } from "../../core/llm-client/local-runtime.js";
+import { onLlamaBuildPhase } from "../../core/llm-client/llama-build-events.js";
 import type { TokenReductionSnapshot } from "../../core/utils/tokenMetrics.js";
 import { colors } from "../colors.js";
 import { formatError } from "../format.js";
@@ -248,6 +249,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     let executionClockStartedAt: number | null = null;
     let executionClockTimer: NodeJS.Timeout | undefined;
     let forceFullRender = false;
+    let localLlmBuildHint: string | null = null;
+    let buildSpinnerTimer: NodeJS.Timeout | undefined;
+    let buildSpinnerFrame = 0;
+    const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
     let pendingApprovalPrompt: string | null = null;
     let skipApprovalLineFeed = false;
     let pendingMouseInputSequence = "";
@@ -745,6 +750,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         stickyPrompt?.status === "pending-approval" || pendingApprovalPrompt !== null
           ? "실행 대기 중 · Enter 실행 · Esc 편집 복귀"
           : inputOverflowHint ??
+            localLlmBuildHint ??
             (embeddedPaneMode
               ? viewportStatusText ?? "첫 프롬프트를 입력하면 아래 패널이 채워집니다 · /... 자동완성 · q 종료"
               : "첫 프롬프트를 입력하면 아래 패널이 채워집니다 · /... 자동완성 · q 종료");
@@ -913,6 +919,31 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
 
       renderInteractiveInput();
     };
+
+    const startBuildSpinner = (): void => {
+      buildSpinnerFrame = 0;
+      localLlmBuildHint = `${SPINNER_FRAMES[0]} 첫 실행 준비 중...`;
+      buildSpinnerTimer = setInterval(() => {
+        buildSpinnerFrame = (buildSpinnerFrame + 1) % SPINNER_FRAMES.length;
+        localLlmBuildHint = `${SPINNER_FRAMES[buildSpinnerFrame]} 첫 실행 준비 중...`;
+        render();
+      }, 100);
+      render();
+    };
+
+    const stopBuildSpinner = (): void => {
+      if (buildSpinnerTimer !== undefined) {
+        clearInterval(buildSpinnerTimer);
+        buildSpinnerTimer = undefined;
+      }
+      localLlmBuildHint = null;
+      render();
+    };
+
+    const unsubBuildEvents = onLlamaBuildPhase((phase) => {
+      if (phase === "building") startBuildSpinner();
+      else stopBuildSpinner();
+    });
 
     // Phase 3.2: Create onProgress callback
     let lastProgressRenderAt = 0;
@@ -1644,6 +1675,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     }
 
     stdin.removeListener("data", onData);
+    unsubBuildEvents();
+    if (buildSpinnerTimer !== undefined) {
+      clearInterval(buildSpinnerTimer);
+    }
 
     stdout.write("\n" + colors.info("TUI REPL이 종료되었습니다.\n") + "\n");
   } finally {

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -805,6 +805,8 @@ export class EmbeddedTerminalPane {
           detail: row.plainText,
         };
       }
+
+      return null;
     }
 
     return null;

--- a/src/core/llm-client/llama-build-events.ts
+++ b/src/core/llm-client/llama-build-events.ts
@@ -1,0 +1,16 @@
+type BuildPhase = "building" | "ready";
+type BuildPhaseListener = (phase: BuildPhase) => void;
+
+const listeners = new Set<BuildPhaseListener>();
+let currentPhase: BuildPhase = "ready";
+
+export function onLlamaBuildPhase(fn: BuildPhaseListener): () => void {
+	listeners.add(fn);
+	if (currentPhase === "building") fn("building");
+	return () => listeners.delete(fn);
+}
+
+export function emitLlamaBuildPhase(phase: BuildPhase): void {
+	currentPhase = phase;
+	for (const fn of listeners) fn(phase);
+}

--- a/src/core/llm-client/node-llama-runtime.ts
+++ b/src/core/llm-client/node-llama-runtime.ts
@@ -1,5 +1,7 @@
 import {
 	getLlama,
+	LlamaLogLevel,
+	NoBinaryFoundError,
 	type LlamaContext,
 	LlamaChatSession,
 	QwenChatWrapper,
@@ -7,6 +9,7 @@ import {
 	type Llama,
 	type LlamaModel,
 } from "node-llama-cpp";
+import { emitLlamaBuildPhase } from "./llama-build-events.js";
 import type {
 	LlmCompletionRequest,
 	LlmCompletionResponse,
@@ -221,9 +224,24 @@ async function loadRuntimeWithOptions(
 ): Promise<LoadedNodeLlamaRuntime> {
 	const modelPath = resolveNodeLlamaModelPath(config);
 	const signature = buildNodeLlamaRuntimeSignature(config);
-	const llama = await getLlama({
-		gpu: gpuEnabled ? "auto" : false,
-	});
+	const llama = await (async (): Promise<Llama> => {
+		const baseOpts = {
+			gpu: gpuEnabled ? ("auto" as const) : (false as const),
+			logLevel: LlamaLogLevel.fatal,
+			progressLogs: false,
+		};
+		try {
+			return await getLlama({ ...baseOpts, build: "never" });
+		} catch (e) {
+			if (!(e instanceof NoBinaryFoundError)) throw e;
+			emitLlamaBuildPhase("building");
+			try {
+				return await getLlama(baseOpts);
+			} finally {
+				emitLlamaBuildPhase("ready");
+			}
+		}
+	})();
 	let model: LlamaModel | null = null;
 	let context: LlamaContext | null = null;
 	let session: LlamaChatSession | null = null;

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -14,6 +14,7 @@ import { compress_prompt } from "../prompt/compression.js";
 import { ContextBuilder } from "../context/ContextBuilder.js";
 import { ContextCompressor } from "../context/ContextCompressor.js";
 import { SessionStateManager, resolveSessionsDir } from "../state/SessionStateManager.js";
+import { getDetoksHomeDir, resolveProjectNoticeFlagPath, resolveProjectRagDir } from "../state/storage-paths.js";
 import { executeWithAdapter } from "../executor/execute.js";
 import { logger } from "../utils/logger.js";
 import { PipelineTracer } from "../utils/PipelineTracer.js";
@@ -130,14 +131,11 @@ function sumCachedTaskTokens(hits: Map<string, Record<string, unknown>>): number
   return total;
 }
 
-async function countPriorSessions(projectId: string | undefined): Promise<number> {
+async function countPriorSessions(projectId: string | undefined, cwd?: string): Promise<number> {
   try {
-    const sessions = await SessionStateManager.listSessions();
+    const sessions = await SessionStateManager.listSessions(cwd);
     if (!projectId) return sessions.length;
-    return sessions.filter((s) => {
-      const pid = (s as unknown as Record<string, unknown>).project_id;
-      return pid === projectId;
-    }).length;
+    return sessions.length;
   } catch {
     return 0;
   }
@@ -147,24 +145,23 @@ async function countPriorSessions(projectId: string | undefined): Promise<number
 async function isMemoryDisabled(): Promise<boolean> {
   if (process.env.DETOKS_MEMORY === "off" || process.env.DETOKS_MEMORY === "0") return true;
   try {
-    await fs.access(join(homedir(), ".detoks", "disabled"));
+    await fs.access(join(getDetoksHomeDir(), "disabled"));
     return true;
   } catch {
     return false;
   }
 }
 
-const NOTICE_SHOWN_FILE = ".state/.detoks-notice-shown";
-
 async function maybeShowFirstRunNotice(cwd: string): Promise<void> {
-  const flagPath = join(cwd, NOTICE_SHOWN_FILE);
+  const flagPath = resolveProjectNoticeFlagPath(cwd);
   try {
     await fs.access(flagPath);
     return; // 이미 표시했음
   } catch { /* 파일 없음 → 안내 필요 */ }
 
   const notice = [
-    "[detoks] DeToks는 실행 메모리를 .state/sessions에 저장합니다.",
+    `[detoks] DeToks는 실행 메모리를 ${resolveSessionsDir(cwd)} 에 저장합니다.`,
+    `[detoks] 프로젝트별 RAG DB는 ${join(resolveProjectRagDir(cwd), "vectors.db")} 에 저장합니다.`,
     "[detoks] cross-project store에는 generalize 단계를 거친 익명 패턴만 들어갑니다.",
     "[detoks] 비활성화: detoks memory disable / 일괄 삭제: detoks memory purge --all",
   ].join("\n");
@@ -172,7 +169,7 @@ async function maybeShowFirstRunNotice(cwd: string): Promise<void> {
   process.stderr.write(`${notice}\n`);
 
   try {
-    await fs.mkdir(join(cwd, ".state"), { recursive: true });
+    await fs.mkdir(join(getDetoksHomeDir(), "projects"), { recursive: true });
     await fs.writeFile(flagPath, new Date().toISOString(), "utf-8");
   } catch { /* 쓰기 실패는 non-fatal */ }
 }
@@ -628,7 +625,7 @@ export const orchestratePipeline = async (
   const saveSessionIfEnabled = async (s: SessionState) => {
     if (memoryDisabled) return;
     try {
-      await SessionStateManager.saveSession(s);
+      await SessionStateManager.saveSession(s, request.userRequest.cwd);
     } catch (err) {
       // 디스크 풀·권한 오류 등은 파이프라인을 중단하지 않는다.
       // logger.error는 DETOKS_DEBUG 여부와 무관하게 항상 stderr에 출력된다.
@@ -653,7 +650,12 @@ export const orchestratePipeline = async (
     const inputHash = hashRawInput(request.userRequest.raw_input);
     const cachedSession = await SessionStateManager.findSuccessfulSessionByInputHash(
       inputHash,
-      { project_id: projectId, recencyDays: CACHE_TTL_DAYS, adapter: request.adapter },
+      {
+        project_id: projectId,
+        recencyDays: CACHE_TTL_DAYS,
+        adapter: request.adapter,
+        ...(request.userRequest.cwd ? { cwd: request.userRequest.cwd } : {}),
+      },
     );
     const f1Validity = cachedSession
       ? isSessionCacheValid(cachedSession, {
@@ -734,7 +736,10 @@ export const orchestratePipeline = async (
     const inputHash = hashRawInput(request.userRequest.raw_input);
     const incompleteSession = await SessionStateManager.findIncompleteSessionByInputHash(
       inputHash,
-      { project_id: projectId },
+      {
+        project_id: projectId,
+        ...(request.userRequest.cwd ? { cwd: request.userRequest.cwd } : {}),
+      },
     );
     if (incompleteSession && incompleteSession.current_task_id) {
       resumeHint = {
@@ -979,9 +984,9 @@ export const orchestratePipeline = async (
   const taskRecords: TaskExecutionRecord[] = [];
   const failedTaskIds = new Set<string>();
 
-  if (await SessionStateManager.sessionExists(sessionId)) {
+  if (await SessionStateManager.sessionExists(sessionId, request.userRequest.cwd)) {
     logger.info(`기존 세션을 불러옵니다: ${sessionId}`);
-    state = await SessionStateManager.loadSession(sessionId);
+    state = await SessionStateManager.loadSession(sessionId, request.userRequest.cwd);
     const resolvedRawInput =
       typeof state.shared_context.raw_input === "string" &&
       state.shared_context.raw_input.trim().length > 0
@@ -1033,6 +1038,7 @@ export const orchestratePipeline = async (
           recencyDays: CACHE_TTL_DAYS,
           adapter: request.adapter,
           ...(gitHead ? { git_head: gitHead } : {}),
+          ...(request.userRequest.cwd ? { cwd: request.userRequest.cwd } : {}),
         },
       );
       if (cachedTask) {
@@ -1262,6 +1268,7 @@ export const orchestratePipeline = async (
               recencyDays: CACHE_TTL_DAYS,
               adapter: request.adapter,
               ...(gitHead ? { git_head: gitHead } : {}),
+              ...(request.userRequest.cwd ? { cwd: request.userRequest.cwd } : {}),
             },
           );
           const f2Validity = cachedTask
@@ -1358,7 +1365,10 @@ export const orchestratePipeline = async (
         if (ragContextRaw && ragTokensForTask > 0) {
           const projectedAdded = tokensAddedAtStageStart + ragTokensForTask;
           const projectedSaved = sumCachedTaskTokens(f2PreScanHits);
-          const sessionCount = await countPriorSessions(stageBaseState.shared_context.project_id as string | undefined);
+          const sessionCount = await countPriorSessions(
+            stageBaseState.shared_context.project_id as string | undefined,
+            request.userRequest.cwd,
+          );
           const inColdStart = sessionCount < COLD_START_THRESHOLD;
           const block =
             projectedAdded > PER_SESSION_TOKEN_CAP ||
@@ -1412,7 +1422,7 @@ export const orchestratePipeline = async (
             request.userRequest.raw_input,
             compiledPrompt.compressed_prompt,
           ).state;
-          await SessionStateManager.saveSession(state);
+          await SessionStateManager.saveSession(state, request.userRequest.cwd);
           await PipelineTracer.trace({
             sessionId, stage: `Executor:${task.id}`, role: "role3", phase: "output",
             dataType: "ExecutionResult",

--- a/src/core/rag/cross-project-store.ts
+++ b/src/core/rag/cross-project-store.ts
@@ -1,10 +1,10 @@
 import { createHash, randomBytes } from "node:crypto";
 import { appendFile, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { RequestCategoryValues, type RequestCategory } from "../../schemas/pipeline.js";
 import { AdapterValues, type Adapter } from "../pipeline/types.js";
 import type { GeneralizedContribution } from "./workflow-generalizer.js";
+import { resolveSharedCrossProjectDir } from "../state/storage-paths.js";
 
 interface CrossProjectPattern {
   id: string;
@@ -42,7 +42,7 @@ export function isValidContribution(value: unknown): value is GeneralizedContrib
 export class CrossProjectStore {
   private readonly dir: string;
 
-  constructor(dir = join(homedir(), ".detoks", "cross-project")) {
+  constructor(dir = resolveSharedCrossProjectDir()) {
     this.dir = dir;
   }
 

--- a/src/core/rag/embedding-service.ts
+++ b/src/core/rag/embedding-service.ts
@@ -1,4 +1,4 @@
-import { getLlama } from "node-llama-cpp";
+import { getLlama, LlamaLogLevel } from "node-llama-cpp";
 import type { Llama, LlamaModel, LlamaEmbeddingContext } from "node-llama-cpp";
 
 export class EmbeddingService {
@@ -11,7 +11,7 @@ export class EmbeddingService {
 
   async init(): Promise<void> {
     if (this.ctx) return;
-    this.llama = await getLlama({ gpu: false });
+    this.llama = await getLlama({ gpu: false, logLevel: LlamaLogLevel.fatal, progressLogs: false });
     this.model = await this.llama.loadModel({ modelPath: this.modelPath });
     this.ctx = await this.model.createEmbeddingContext();
   }

--- a/src/core/rag/rag-config.ts
+++ b/src/core/rag/rag-config.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { getDetoksModelFilePath } from "../model-store.js";
 import { KURE_EMBEDDING_MODEL } from "../../cli/model-setup/models.js";
+import { resolveProjectRagDir } from "../state/storage-paths.js";
 
 export const RAG_EMBEDDING_DIMS = 1024; // KURE-v1 dense vector dimension
 
@@ -15,7 +16,7 @@ export const getRagModelPath = (): string | undefined => {
 };
 
 export const getRagVectorDbPath = (cwd: string = process.cwd()): string =>
-  join(cwd, ".state", "rag", "vectors.db");
+  join(resolveProjectRagDir(cwd), "vectors.db");
 
 export const isEmbeddingModelPresent = (): boolean => {
   const modelPath = getRagModelPath();

--- a/src/core/state/SessionStateManager.ts
+++ b/src/core/state/SessionStateManager.ts
@@ -9,10 +9,12 @@ import { ContextCompressor } from '../context/ContextCompressor.js';
 import { StateIOError, StateValidationError, StateLockError } from '../errors/StateErrors.js';
 import { logger } from '../utils/logger.js';
 import { translateVisibleText } from '../utils/visibleText.js';
-
-const STATE_DIR = '.state';
-const SESSIONS_DIR = join(STATE_DIR, 'sessions');
-const CHECKPOINTS_DIR = join(STATE_DIR, 'checkpoints');
+import {
+  resolveCheckpointsDir as resolveProjectCheckpointsDir,
+  resolveLegacyCheckpointsDir,
+  resolveLegacySessionsDir,
+  resolveSessionsDir as resolveProjectSessionsDir,
+} from './storage-paths.js';
 
 // sessionId는 파일 경로로 직접 사용되므로 안전한 형식만 허용한다.
 const SESSION_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/;
@@ -27,7 +29,7 @@ function assertSafeSessionId(id: string): void {
 }
 
 export function resolveSessionsDir(cwd?: string): string {
-  return cwd ? join(cwd, STATE_DIR, 'sessions') : SESSIONS_DIR;
+  return resolveProjectSessionsDir(cwd);
 }
 
 const LOCK_STALE_TIMEOUT_MS = 5_000;
@@ -40,12 +42,87 @@ export interface ProjectInfo {
 }
 
 export class SessionStateManager {
-  private static lockPath(sessionId: string): string {
-    return join(SESSIONS_DIR, `${sessionId}.lock`);
+  private static sessionDir(cwd?: string): string {
+    return resolveProjectSessionsDir(cwd);
   }
 
-  private static tmpPath(sessionId: string): string {
-    return join(SESSIONS_DIR, `${sessionId}.tmp.json`);
+  private static checkpointDir(cwd?: string): string {
+    return resolveProjectCheckpointsDir(cwd);
+  }
+
+  private static lockPath(sessionId: string, cwd?: string): string {
+    return join(this.sessionDir(cwd), `${sessionId}.lock`);
+  }
+
+  private static tmpPath(sessionId: string, cwd?: string): string {
+    return join(this.sessionDir(cwd), `${sessionId}.tmp.json`);
+  }
+
+  private static sessionFilePath(sessionId: string, cwd?: string): string {
+    return join(this.sessionDir(cwd), `${sessionId}.json`);
+  }
+
+  private static checkpointFilePath(checkpointId: string, cwd?: string): string {
+    return join(this.checkpointDir(cwd), `${checkpointId}.json`);
+  }
+
+  private static uniqueDirs(directories: string[]): string[] {
+    return Array.from(new Set(directories));
+  }
+
+  private static sessionDirCandidates(cwd?: string): string[] {
+    return this.uniqueDirs([
+      this.sessionDir(cwd),
+      resolveLegacySessionsDir(cwd),
+    ]);
+  }
+
+  private static checkpointDirCandidates(cwd?: string): string[] {
+    return this.uniqueDirs([
+      this.checkpointDir(cwd),
+      resolveLegacyCheckpointsDir(cwd),
+    ]);
+  }
+
+  private static async resolveExistingFilePath(
+    fileName: string,
+    directories: string[],
+  ): Promise<string | null> {
+    for (const dir of directories) {
+      const filePath = join(dir, fileName);
+      try {
+        await fs.access(filePath);
+        return filePath;
+      } catch {
+        continue;
+      }
+    }
+    return null;
+  }
+
+  private static async listExistingFilePaths(
+    directories: string[],
+    suffix = '.json',
+  ): Promise<string[]> {
+    const fileMap = new Map<string, string>();
+
+    for (const dir of directories) {
+      try {
+        const files = await fs.readdir(dir);
+        for (const file of files) {
+          if (!file.endsWith(suffix)) continue;
+          if (!fileMap.has(file)) {
+            fileMap.set(file, join(dir, file));
+          }
+        }
+      } catch (error: unknown) {
+        const nodeError = error as NodeJS.ErrnoException;
+        if (nodeError.code === 'ENOENT') continue;
+        throw error;
+      }
+    }
+
+    return Array.from(fileMap.values());
   }
 
   private static isProcessAlive(pid: number): boolean {
@@ -57,7 +134,7 @@ export class SessionStateManager {
     }
   }
 
-  private static async acquireLock(sessionId: string, retryDepth = 0): Promise<void> {
+  private static async acquireLock(sessionId: string, cwd?: string, retryDepth = 0): Promise<void> {
     if (retryDepth > MAX_LOCK_RETRIES) {
       throw new StateLockError(
         `Lock acquisition failed for session [${sessionId}] after ${MAX_LOCK_RETRIES} retries`,
@@ -65,7 +142,7 @@ export class SessionStateManager {
       );
     }
 
-    const lockFile = this.lockPath(sessionId);
+    const lockFile = this.lockPath(sessionId, cwd);
     let fd: fs.FileHandle | undefined;
     try {
       // O_EXCL: 파일이 이미 존재하면 즉시 실패 — atomic check-and-create
@@ -89,11 +166,11 @@ export class SessionStateManager {
             (isNaN(ownerPid) && Date.now() - stat.mtimeMs > LOCK_STALE_TIMEOUT_MS);
           if (isStale) {
             await fs.unlink(lockFile);
-            return this.acquireLock(sessionId, retryDepth + 1);
+            return this.acquireLock(sessionId, cwd, retryDepth + 1);
           }
         } catch {
           // stat 사이에 잠금 파일이 사라진 경우 — 재시도
-          return this.acquireLock(sessionId, retryDepth + 1);
+          return this.acquireLock(sessionId, cwd, retryDepth + 1);
         }
         throw new StateLockError(
           `Session [${sessionId}] is locked by another process`,
@@ -110,31 +187,31 @@ export class SessionStateManager {
     }
   }
 
-  private static async releaseLock(sessionId: string): Promise<void> {
+  private static async releaseLock(sessionId: string, cwd?: string): Promise<void> {
     try {
-      await fs.unlink(this.lockPath(sessionId));
+      await fs.unlink(this.lockPath(sessionId, cwd));
     } catch {
       // 이미 해제된 잠금 — 무시
     }
   }
 
-  private static ensureDirectories = async () => {
+  private static ensureDirectories = async (cwd?: string) => {
     try {
-      await fs.mkdir(SESSIONS_DIR, { recursive: true });
-      await fs.mkdir(CHECKPOINTS_DIR, { recursive: true });
+      await fs.mkdir(this.sessionDir(cwd), { recursive: true });
+      await fs.mkdir(this.checkpointDir(cwd), { recursive: true });
     } catch (error: any) {
       throw new StateIOError(`Failed to create state directories`, {
-        path: STATE_DIR,
+        path: this.sessionDir(cwd),
         originalError: error.message
       });
     }
   };
 
-  static async saveSession(state: SessionState): Promise<void> {
+  static async saveSession(state: SessionState, cwd?: string): Promise<void> {
     const sessionId = state.shared_context?.session_id as string || 'default';
     assertSafeSessionId(sessionId);
-    await this.ensureDirectories();
-    await this.acquireLock(sessionId);
+    await this.ensureDirectories(cwd);
+    await this.acquireLock(sessionId, cwd);
     try {
       // 1. 자동 정규화: task_results의 원시 데이터를 표준 스키마로 보정
       for (const [taskId, result] of Object.entries(state.task_results)) {
@@ -159,8 +236,8 @@ export class SessionStateManager {
       const validated = StateValidator.validate(compressedState);
 
       // 5. tmp→rename atomic write: 덮어쓰기 도중 crash나도 기존 파일 보존
-      const tmpFile = this.tmpPath(sessionId);
-      const finalFile = join(SESSIONS_DIR, `${sessionId}.json`);
+      const tmpFile = this.tmpPath(sessionId, cwd);
+      const finalFile = this.sessionFilePath(sessionId, cwd);
       try {
         await fs.writeFile(tmpFile, JSON.stringify(validated, null, 2));
         await fs.rename(tmpFile, finalFile);
@@ -182,13 +259,15 @@ export class SessionStateManager {
         originalError: e.message,
       });
     } finally {
-      await this.releaseLock(sessionId);
+      await this.releaseLock(sessionId, cwd);
     }
   }
 
-  static async loadSession(sessionId: string): Promise<SessionState> {
+  static async loadSession(sessionId: string, cwd?: string): Promise<SessionState> {
     assertSafeSessionId(sessionId);
-    const filePath = join(SESSIONS_DIR, `${sessionId}.json`);
+    const filePath =
+      await this.resolveExistingFilePath(`${sessionId}.json`, this.sessionDirCandidates(cwd))
+      ?? this.sessionFilePath(sessionId, cwd);
     try {
       const data = await fs.readFile(filePath, 'utf-8');
       const parsed = JSON.parse(data);
@@ -218,36 +297,34 @@ export class SessionStateManager {
   }
 
 
-  static async sessionExists(sessionId: string): Promise<boolean> {
+  static async sessionExists(sessionId: string, cwd?: string): Promise<boolean> {
     assertSafeSessionId(sessionId);
-    try {
-      const filePath = join(SESSIONS_DIR, `${sessionId}.json`);
-      await fs.access(filePath);
-      return true;
-    } catch {
-      return false;
-    }
+    const filePath = await this.resolveExistingFilePath(
+      `${sessionId}.json`,
+      this.sessionDirCandidates(cwd),
+    );
+    return filePath !== null;
   }
 
 
-  static async forkSession(sourceSessionId: string, newSessionId: string): Promise<SessionState> {
+  static async forkSession(sourceSessionId: string, newSessionId: string, cwd?: string): Promise<SessionState> {
     assertSafeSessionId(sourceSessionId);
     assertSafeSessionId(newSessionId);
-    if (!(await this.sessionExists(sourceSessionId))) {
+    if (!(await this.sessionExists(sourceSessionId, cwd))) {
       throw new StateIOError(`Session file not found [${sourceSessionId}]`, {
         sessionId: sourceSessionId,
         errorCode: 'ENOENT'
       });
     }
 
-    if (await this.sessionExists(newSessionId)) {
+    if (await this.sessionExists(newSessionId, cwd)) {
       throw new StateIOError(`Session already exists [${newSessionId}]`, {
         sessionId: newSessionId,
         errorCode: 'EEXIST'
       });
     }
 
-    const source = await this.loadSession(sourceSessionId);
+    const source = await this.loadSession(sourceSessionId, cwd);
     const forked = SessionStateSchema.parse({
       ...JSON.parse(JSON.stringify(source)),
       shared_context: {
@@ -256,11 +333,11 @@ export class SessionStateManager {
       },
     });
 
-    await this.saveSession(forked);
+    await this.saveSession(forked, cwd);
     return forked;
   }
 
-  static async listSessions(): Promise<Array<{
+  static async listSessions(cwd?: string): Promise<Array<{
     id: string;
     updatedAt: string | null;
     currentTaskId: string | null;
@@ -269,7 +346,6 @@ export class SessionStateManager {
     nextAction: string | null;
   }>> {
     try {
-      const files = await fs.readdir(SESSIONS_DIR);
       const sessions: Array<{
         id: string;
         updatedAt: string | null;
@@ -279,14 +355,14 @@ export class SessionStateManager {
         nextAction: string | null;
       }> = [];
 
-      for (const file of files) {
-        if (!file.endsWith('.json')) continue;
-
+      const files = await this.listExistingFilePaths(this.sessionDirCandidates(cwd));
+      for (const filePath of files) {
+        const fileName = filePath.split('/').pop() ?? filePath;
         try {
-          const data = await fs.readFile(join(SESSIONS_DIR, file), 'utf-8');
+          const data = await fs.readFile(filePath, 'utf-8');
           const state = SessionStateSchema.parse(JSON.parse(data));
           sessions.push({
-            id: file.slice(0, -'.json'.length),
+            id: fileName.slice(0, -'.json'.length),
             updatedAt: state.updated_at ?? null,
             currentTaskId: state.current_task_id ?? null,
             completedTaskCount: state.completed_task_ids.length,
@@ -295,7 +371,7 @@ export class SessionStateManager {
           });
         } catch (e) {
           logger.info(
-            `세션 파일 [${file}]을 불러오지 못해 건너뜁니다. ${translateVisibleText(e instanceof Error ? e.message : String(e))}`,
+            `세션 파일 [${fileName}]을 불러오지 못해 건너뜁니다. ${translateVisibleText(e instanceof Error ? e.message : String(e))}`,
           );
         }
       }
@@ -316,11 +392,11 @@ export class SessionStateManager {
     }
   }
 
-  static async createCheckpoint(checkpoint: Checkpoint): Promise<void> {
+  static async createCheckpoint(checkpoint: Checkpoint, cwd?: string): Promise<void> {
     try {
-      await this.ensureDirectories();
+      await this.ensureDirectories(cwd);
       const validated = CheckpointSchema.parse(checkpoint);
-      const filePath = join(CHECKPOINTS_DIR, `${validated.id}.json`);
+      const filePath = this.checkpointFilePath(validated.id, cwd);
       await fs.writeFile(filePath, JSON.stringify(validated, null, 2));
     } catch (error: unknown) {
       if (error instanceof ZodError) {
@@ -336,8 +412,10 @@ export class SessionStateManager {
     }
   }
 
-  static async loadCheckpoint(checkpointId: string): Promise<Checkpoint> {
-    const filePath = join(CHECKPOINTS_DIR, `${checkpointId}.json`);
+  static async loadCheckpoint(checkpointId: string, cwd?: string): Promise<Checkpoint> {
+    const filePath =
+      await this.resolveExistingFilePath(`${checkpointId}.json`, this.checkpointDirCandidates(cwd))
+      ?? this.checkpointFilePath(checkpointId, cwd);
     try {
       const data = await fs.readFile(filePath, 'utf-8');
       const parsed = JSON.parse(data);
@@ -361,27 +439,25 @@ export class SessionStateManager {
     }
   }
 
-  static async listCheckpoints(sessionId: string): Promise<Checkpoint[]> {
+  static async listCheckpoints(sessionId: string, cwd?: string): Promise<Checkpoint[]> {
     try {
-      await this.ensureDirectories();
-      const files = await fs.readdir(CHECKPOINTS_DIR);
       const checkpoints: Checkpoint[] = [];
+      const filePaths = await this.listExistingFilePaths(this.checkpointDirCandidates(cwd));
 
-      for (const file of files) {
-        if (file.endsWith('.json')) {
-          try {
-            const data = await fs.readFile(join(CHECKPOINTS_DIR, file), 'utf-8');
-            const parsed = JSON.parse(data);
-            const checkpoint = CheckpointSchema.parse(parsed);
-            if (checkpoint.id.startsWith(sessionId)) {
-              checkpoints.push(checkpoint);
-            }
-          } catch (e) {
-            logger.warn(
-              `체크포인트 파일 [${file}]을 불러오지 못해 건너뜁니다. ${translateVisibleText(e instanceof Error ? e.message : String(e))}`,
-            );
-            continue;
+      for (const filePath of filePaths) {
+        try {
+          const data = await fs.readFile(filePath, 'utf-8');
+          const parsed = JSON.parse(data);
+          const checkpoint = CheckpointSchema.parse(parsed);
+          if (checkpoint.id.startsWith(sessionId)) {
+            checkpoints.push(checkpoint);
           }
+        } catch (e) {
+          const file = filePath.split('/').pop() ?? filePath;
+          logger.warn(
+            `체크포인트 파일 [${file}]을 불러오지 못해 건너뜁니다. ${translateVisibleText(e instanceof Error ? e.message : String(e))}`,
+          );
+          continue;
         }
       }
 
@@ -398,124 +474,118 @@ export class SessionStateManager {
 
   static async findSuccessfulSessionByInputHash(
     hash: string,
-    opts: { project_id?: string; recencyDays?: number; adapter?: string } = {},
+    opts: { project_id?: string; recencyDays?: number; adapter?: string; cwd?: string } = {},
   ): Promise<SessionState | null> {
-    const { project_id, recencyDays = 7, adapter } = opts;
+    const { project_id, recencyDays = 7, adapter, cwd } = opts;
     const cutoff = Date.now() - recencyDays * 24 * 60 * 60 * 1000;
 
-    let files: string[];
     try {
-      files = await fs.readdir(SESSIONS_DIR);
+      const files = await this.listExistingFilePaths(this.sessionDirCandidates(cwd));
+      for (const filePath of files) {
+        try {
+          const data = await fs.readFile(filePath, "utf-8");
+          const state = SessionStateSchema.parse(JSON.parse(data));
+
+          if (state.shared_context.raw_input_hash !== hash) continue;
+          if (project_id && state.shared_context.project_id !== project_id) continue;
+          if (state.updated_at && new Date(state.updated_at).getTime() < cutoff) continue;
+          if (state.completed_task_ids.length === 0) continue;
+
+          const failedIds = (state.shared_context.failed_task_ids as string[] | undefined) ?? [];
+          if (failedIds.length > 0) continue;
+
+          // 구 세션(adapter stamp 없음)은 필드 자체가 없으므로 비교 없이 통과
+          const ctx = state.shared_context as Record<string, unknown>;
+          if (adapter && ctx.adapter && ctx.adapter !== adapter) continue;
+
+          return state;
+        } catch {
+          continue;
+        }
+      }
     } catch {
       return null;
-    }
-
-    for (const file of files) {
-      if (!file.endsWith(".json")) continue;
-      try {
-        const data = await fs.readFile(join(SESSIONS_DIR, file), "utf-8");
-        const state = SessionStateSchema.parse(JSON.parse(data));
-
-        if (state.shared_context.raw_input_hash !== hash) continue;
-        if (project_id && state.shared_context.project_id !== project_id) continue;
-        if (state.updated_at && new Date(state.updated_at).getTime() < cutoff) continue;
-        if (state.completed_task_ids.length === 0) continue;
-
-        const failedIds = (state.shared_context.failed_task_ids as string[] | undefined) ?? [];
-        if (failedIds.length > 0) continue;
-
-        // 구 세션(adapter stamp 없음)은 필드 자체가 없으므로 비교 없이 통과
-        const ctx = state.shared_context as Record<string, unknown>;
-        if (adapter && ctx.adapter && ctx.adapter !== adapter) continue;
-
-        return state;
-      } catch {
-        continue;
-      }
     }
     return null;
   }
 
   static async findSuccessfulTaskByHash(
     taskHash: string,
-    opts: { project_id?: string; recencyDays?: number; adapter?: string; git_head?: string } = {},
+    opts: { project_id?: string; recencyDays?: number; adapter?: string; git_head?: string; cwd?: string } = {},
   ): Promise<{ taskResult: Record<string, unknown>; sessionId: string } | null> {
-    const { project_id, recencyDays = 7, adapter, git_head } = opts;
+    const { project_id, recencyDays = 7, adapter, git_head, cwd } = opts;
     const cutoff = Date.now() - recencyDays * 24 * 60 * 60 * 1000;
 
-    let files: string[];
     try {
-      files = await fs.readdir(SESSIONS_DIR);
+      const files = await this.listExistingFilePaths(this.sessionDirCandidates(cwd));
+      for (const filePath of files) {
+        try {
+          const data = await fs.readFile(filePath, "utf-8");
+          const state = SessionStateSchema.parse(JSON.parse(data));
+
+          if (project_id && state.shared_context.project_id !== project_id) continue;
+          if (state.updated_at && new Date(state.updated_at).getTime() < cutoff) continue;
+
+          for (const taskResult of Object.values(state.task_results)) {
+            const res = taskResult as Record<string, unknown>;
+            if (res.input_hash !== taskHash) continue;
+            if (res.success !== true) continue;
+            if (typeof res.completed_at === "string") {
+              if (new Date(res.completed_at).getTime() < cutoff) continue;
+            }
+            // 구 세션(stamp 필드 없음)은 필드 자체가 없으므로 비교 없이 통과
+            if (adapter && res.adapter && res.adapter !== adapter) continue;
+            if (git_head && res.git_head && res.git_head !== git_head) continue;
+            const file = filePath.split('/').pop() ?? filePath;
+            return { taskResult: res, sessionId: file.slice(0, -".json".length) };
+          }
+        } catch {
+          continue;
+        }
+      }
     } catch {
       return null;
-    }
-
-    for (const file of files) {
-      if (!file.endsWith(".json")) continue;
-      try {
-        const data = await fs.readFile(join(SESSIONS_DIR, file), "utf-8");
-        const state = SessionStateSchema.parse(JSON.parse(data));
-
-        if (project_id && state.shared_context.project_id !== project_id) continue;
-        if (state.updated_at && new Date(state.updated_at).getTime() < cutoff) continue;
-
-        for (const taskResult of Object.values(state.task_results)) {
-          const res = taskResult as Record<string, unknown>;
-          if (res.input_hash !== taskHash) continue;
-          if (res.success !== true) continue;
-          if (typeof res.completed_at === "string") {
-            if (new Date(res.completed_at).getTime() < cutoff) continue;
-          }
-          // 구 세션(stamp 필드 없음)은 필드 자체가 없으므로 비교 없이 통과
-          if (adapter && res.adapter && res.adapter !== adapter) continue;
-          if (git_head && res.git_head && res.git_head !== git_head) continue;
-          return { taskResult: res, sessionId: file.slice(0, -".json".length) };
-        }
-      } catch {
-        continue;
-      }
     }
     return null;
   }
 
   static async findIncompleteSessionByInputHash(
     hash: string,
-    opts: { project_id?: string; recencyHours?: number } = {},
+    opts: { project_id?: string; recencyHours?: number; cwd?: string } = {},
   ): Promise<SessionState | null> {
-    const { project_id, recencyHours = 24 } = opts;
+    const { project_id, recencyHours = 24, cwd } = opts;
     const cutoff = Date.now() - recencyHours * 60 * 60 * 1000;
 
-    let files: string[];
     try {
-      files = await fs.readdir(SESSIONS_DIR);
+      const files = await this.listExistingFilePaths(this.sessionDirCandidates(cwd));
+      for (const filePath of files) {
+        try {
+          const data = await fs.readFile(filePath, "utf-8");
+          const state = SessionStateSchema.parse(JSON.parse(data));
+
+          if (state.shared_context.raw_input_hash !== hash) continue;
+          if (project_id && state.shared_context.project_id !== project_id) continue;
+          if (state.updated_at && new Date(state.updated_at).getTime() < cutoff) continue;
+          if (state.current_task_id === null) continue;
+          if (state.completed_task_ids.length === 0) continue;
+
+          return state;
+        } catch {
+          continue;
+        }
+      }
     } catch {
       return null;
-    }
-
-    for (const file of files) {
-      if (!file.endsWith(".json")) continue;
-      try {
-        const data = await fs.readFile(join(SESSIONS_DIR, file), "utf-8");
-        const state = SessionStateSchema.parse(JSON.parse(data));
-
-        if (state.shared_context.raw_input_hash !== hash) continue;
-        if (project_id && state.shared_context.project_id !== project_id) continue;
-        if (state.updated_at && new Date(state.updated_at).getTime() < cutoff) continue;
-        if (state.current_task_id === null) continue;       // 이미 완료
-        if (state.completed_task_ids.length === 0) continue; // 아무것도 완료 안 됨
-
-        return state;
-      } catch {
-        continue;
-      }
     }
     return null;
   }
 
-  static async deleteSession(sessionId: string): Promise<void> {
+  static async deleteSession(sessionId: string, cwd?: string): Promise<void> {
     assertSafeSessionId(sessionId);
     try {
-      const filePath = join(SESSIONS_DIR, `${sessionId}.json`);
+      const filePath =
+        await this.resolveExistingFilePath(`${sessionId}.json`, this.sessionDirCandidates(cwd))
+        ?? this.sessionFilePath(sessionId, cwd);
       await fs.unlink(filePath);
     } catch (error: any) {
       throw new StateIOError(`Failed to delete session [${sessionId}]`, {
@@ -525,9 +595,9 @@ export class SessionStateManager {
     }
   }
 
-  static async getLatestCheckpoint(sessionId: string): Promise<Checkpoint | undefined> {
+  static async getLatestCheckpoint(sessionId: string, cwd?: string): Promise<Checkpoint | undefined> {
     try {
-      const checkpoints = await this.listCheckpoints(sessionId);
+      const checkpoints = await this.listCheckpoints(sessionId, cwd);
       return checkpoints.length > 0 ? checkpoints[checkpoints.length - 1] : undefined;
     } catch (error: any) {
       if (error instanceof StateIOError) throw error;

--- a/src/core/state/storage-paths.ts
+++ b/src/core/state/storage-paths.ts
@@ -1,0 +1,62 @@
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+import { basename, join, resolve } from "node:path";
+
+const DETOKS_DIRNAME = ".detoks";
+const PROJECTS_DIRNAME = "projects";
+const SHARED_DIRNAME = "shared";
+const LEGACY_STATE_DIRNAME = ".state";
+
+const sanitizeSegment = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+
+export const getDetoksHomeDir = (): string =>
+  process.env.DETOKS_HOME?.trim() || join(process.env.HOME ?? homedir(), DETOKS_DIRNAME);
+
+export const resolveWorkspaceScopeId = (cwd: string = process.cwd()): string => {
+  const absoluteCwd = resolve(cwd);
+  const slug = sanitizeSegment(basename(absoluteCwd)) || "workspace";
+  const hash = createHash("sha256").update(absoluteCwd).digest("hex").slice(0, 12);
+  return `${slug}-${hash}`;
+};
+
+export const resolveProjectDataDir = (cwd: string = process.cwd()): string =>
+  join(getDetoksHomeDir(), PROJECTS_DIRNAME, resolveWorkspaceScopeId(cwd));
+
+export const resolveSessionsDir = (cwd: string = process.cwd()): string =>
+  join(resolveProjectDataDir(cwd), "sessions");
+
+export const resolveCheckpointsDir = (cwd: string = process.cwd()): string =>
+  join(resolveProjectDataDir(cwd), "checkpoints");
+
+export const resolveProjectRagDir = (cwd: string = process.cwd()): string =>
+  join(resolveProjectDataDir(cwd), "rag");
+
+export const resolveProjectNoticeFlagPath = (cwd: string = process.cwd()): string =>
+  join(resolveProjectDataDir(cwd), ".notice-shown");
+
+export const resolveLegacyStateDir = (cwd: string = process.cwd()): string =>
+  join(resolve(cwd), LEGACY_STATE_DIRNAME);
+
+export const resolveLegacySessionsDir = (cwd: string = process.cwd()): string =>
+  join(resolveLegacyStateDir(cwd), "sessions");
+
+export const resolveLegacyCheckpointsDir = (cwd: string = process.cwd()): string =>
+  join(resolveLegacyStateDir(cwd), "checkpoints");
+
+export const resolveLegacyRagDir = (cwd: string = process.cwd()): string =>
+  join(resolveLegacyStateDir(cwd), "rag");
+
+export const resolveSharedDataDir = (): string =>
+  join(getDetoksHomeDir(), SHARED_DIRNAME);
+
+export const resolveSharedCrossProjectDir = (): string =>
+  join(resolveSharedDataDir(), "cross-project");
+
+export const resolveSharedRagDir = (): string =>
+  join(resolveSharedDataDir(), "rag");

--- a/src/integrations/adapters/claude/adapter.ts
+++ b/src/integrations/adapters/claude/adapter.ts
@@ -2,6 +2,7 @@ import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../../c
 import type { AdapterExecutionContext, CliAdapter } from "../interface.js";
 import { executeAdapterViaSubprocess } from "../real.js";
 import { buildStubRawOutput } from "../stub.js";
+import { buildWorkspaceIsolationEnv } from "../workspace-env.js";
 
 const CLAUDE_PERMISSION_MODE = "default" as const;
 
@@ -9,6 +10,7 @@ export class ClaudeStubAdapter implements CliAdapter {
   readonly target = "claude" as const;
 
   buildSubprocessRequest(request: AdapterExecutionRequest) {
+    const workspaceEnv = buildWorkspaceIsolationEnv(request.cwd);
     if (request.presentationMode === "passthrough") {
       // passthrough 모드는 prompt를 CLI 인자로 전달하므로 OS ARG_MAX 제한을 받는다.
       const promptBytes = Buffer.byteLength(request.prompt ?? "", "utf8");
@@ -27,6 +29,7 @@ export class ClaudeStubAdapter implements CliAdapter {
           ...(request.prompt ? [request.prompt] : []),
         ],
         ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+        ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
       };
     }
 
@@ -42,6 +45,7 @@ export class ClaudeStubAdapter implements CliAdapter {
           ...(request.model ? ["--model", request.model] : []),
         ],
         ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+        ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
         input: request.prompt,
       };
     }
@@ -57,6 +61,7 @@ export class ClaudeStubAdapter implements CliAdapter {
         ...(request.model ? ["--model", request.model] : []),
       ],
       ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+      ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
       input: request.prompt,
     };
   }

--- a/src/integrations/adapters/codex/adapter.ts
+++ b/src/integrations/adapters/codex/adapter.ts
@@ -3,7 +3,7 @@ import type { AdapterExecutionContext, CliAdapter } from "../interface.js";
 import { getCodexReasoningEffortOverride } from "../../../cli/config/config-manager.js";
 import { executeAdapterViaSubprocess } from "../real.js";
 import { buildStubRawOutput } from "../stub.js";
-import { buildWorkspaceIsolationEnv } from "../workspace-env.js";
+import { buildWorkspaceCommandArgs, buildWorkspaceIsolationEnv } from "../workspace-env.js";
 
 export class CodexStubAdapter implements CliAdapter {
   readonly target = "codex" as const;
@@ -11,6 +11,7 @@ export class CodexStubAdapter implements CliAdapter {
   buildSubprocessRequest(request: AdapterExecutionRequest) {
     const reasoningEffort = getCodexReasoningEffortOverride();
     const workspaceEnv = buildWorkspaceIsolationEnv(request.cwd);
+    const workspaceArgs = buildWorkspaceCommandArgs(this.target, request.cwd);
 
     if (request.presentationMode === "passthrough") {
       const promptBytes = Buffer.byteLength(request.prompt ?? "", "utf8");
@@ -23,7 +24,7 @@ export class CodexStubAdapter implements CliAdapter {
       return {
         command: "codex",
         args: [
-          ...(request.cwd ? ["-C", request.cwd] : []),
+          ...workspaceArgs,
           ...(reasoningEffort ? ["-c", `model_reasoning_effort=${reasoningEffort}`] : []),
           ...(request.model ? ["--model", request.model] : []),
           "--sandbox",
@@ -42,7 +43,7 @@ export class CodexStubAdapter implements CliAdapter {
           "--ask-for-approval",
           "on-request",
           "exec",
-          ...(request.cwd ? ["-C", request.cwd] : []),
+          ...workspaceArgs,
           ...(reasoningEffort ? ["-c", `model_reasoning_effort=${reasoningEffort}`] : []),
           ...(request.model ? ["--model", request.model] : []),
           "-",
@@ -61,7 +62,7 @@ export class CodexStubAdapter implements CliAdapter {
       command: "codex",
       args: [
         "exec",
-        ...(request.cwd ? ["-C", request.cwd] : []),
+        ...workspaceArgs,
         ...(reasoningEffort ? ["-c", `model_reasoning_effort=${reasoningEffort}`] : []),
         ...(request.model ? ["--model", request.model] : []),
         "-",

--- a/src/integrations/adapters/codex/adapter.ts
+++ b/src/integrations/adapters/codex/adapter.ts
@@ -3,12 +3,14 @@ import type { AdapterExecutionContext, CliAdapter } from "../interface.js";
 import { getCodexReasoningEffortOverride } from "../../../cli/config/config-manager.js";
 import { executeAdapterViaSubprocess } from "../real.js";
 import { buildStubRawOutput } from "../stub.js";
+import { buildWorkspaceIsolationEnv } from "../workspace-env.js";
 
 export class CodexStubAdapter implements CliAdapter {
   readonly target = "codex" as const;
 
   buildSubprocessRequest(request: AdapterExecutionRequest) {
     const reasoningEffort = getCodexReasoningEffortOverride();
+    const workspaceEnv = buildWorkspaceIsolationEnv(request.cwd);
 
     if (request.presentationMode === "passthrough") {
       const promptBytes = Buffer.byteLength(request.prompt ?? "", "utf8");
@@ -21,6 +23,7 @@ export class CodexStubAdapter implements CliAdapter {
       return {
         command: "codex",
         args: [
+          ...(request.cwd ? ["-C", request.cwd] : []),
           ...(reasoningEffort ? ["-c", `model_reasoning_effort=${reasoningEffort}`] : []),
           ...(request.model ? ["--model", request.model] : []),
           "--sandbox",
@@ -28,6 +31,7 @@ export class CodexStubAdapter implements CliAdapter {
           ...(request.prompt ? [request.prompt] : []),
         ],
         ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+        ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
       };
     }
 
@@ -38,6 +42,7 @@ export class CodexStubAdapter implements CliAdapter {
           "--ask-for-approval",
           "on-request",
           "exec",
+          ...(request.cwd ? ["-C", request.cwd] : []),
           ...(reasoningEffort ? ["-c", `model_reasoning_effort=${reasoningEffort}`] : []),
           ...(request.model ? ["--model", request.model] : []),
           "-",
@@ -46,6 +51,7 @@ export class CodexStubAdapter implements CliAdapter {
           "--skip-git-repo-check",
         ],
         ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+        ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
         input: request.prompt,
         interactiveAfterInput: true,
       };
@@ -55,6 +61,7 @@ export class CodexStubAdapter implements CliAdapter {
       command: "codex",
       args: [
         "exec",
+        ...(request.cwd ? ["-C", request.cwd] : []),
         ...(reasoningEffort ? ["-c", `model_reasoning_effort=${reasoningEffort}`] : []),
         ...(request.model ? ["--model", request.model] : []),
         "-",
@@ -65,6 +72,7 @@ export class CodexStubAdapter implements CliAdapter {
         "never",
       ],
       ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+      ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
       input: request.prompt,
     };
   }

--- a/src/integrations/adapters/gemini/adapter.ts
+++ b/src/integrations/adapters/gemini/adapter.ts
@@ -2,11 +2,13 @@ import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../../c
 import type { AdapterExecutionContext, CliAdapter } from "../interface.js";
 import { executeAdapterViaSubprocess } from "../real.js";
 import { buildStubRawOutput } from "../stub.js";
+import { buildWorkspaceIsolationEnv } from "../workspace-env.js";
 
 export class GeminiStubAdapter implements CliAdapter {
   readonly target = "gemini" as const;
 
   buildSubprocessRequest(request: AdapterExecutionRequest) {
+    const workspaceEnv = buildWorkspaceIsolationEnv(request.cwd);
     if (request.presentationMode === "passthrough") {
       const promptBytes = Buffer.byteLength(request.prompt ?? "", "utf8");
       if (promptBytes > 200_000) {
@@ -22,6 +24,7 @@ export class GeminiStubAdapter implements CliAdapter {
           ...(request.prompt ? [request.prompt] : []),
         ],
         ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+        ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
       };
     }
 
@@ -30,6 +33,7 @@ export class GeminiStubAdapter implements CliAdapter {
         command: "gemini",
         args: request.model ? ["--model", request.model] : [],
         ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+        ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
         input: request.prompt,
       };
     }
@@ -38,6 +42,7 @@ export class GeminiStubAdapter implements CliAdapter {
       command: "gemini",
       args: request.model ? ["--model", request.model] : [],
       ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+      ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
       input: request.prompt,
     };
   }

--- a/src/integrations/adapters/workspace-env.ts
+++ b/src/integrations/adapters/workspace-env.ts
@@ -1,4 +1,5 @@
 import { dirname, resolve } from "node:path";
+import type { Adapter } from "../../core/pipeline/types.js";
 
 export const buildWorkspaceIsolationEnv = (
   cwd?: string,
@@ -11,4 +12,19 @@ export const buildWorkspaceIsolationEnv = (
   return {
     GIT_CEILING_DIRECTORIES: dirname(resolvedCwd),
   };
+};
+
+export const buildWorkspaceCommandArgs = (
+  adapter: Adapter,
+  cwd?: string,
+): string[] => {
+  if (!cwd) {
+    return [];
+  }
+
+  if (adapter === "codex") {
+    return ["-C", cwd];
+  }
+
+  return [];
 };

--- a/src/integrations/adapters/workspace-env.ts
+++ b/src/integrations/adapters/workspace-env.ts
@@ -1,0 +1,14 @@
+import { dirname, resolve } from "node:path";
+
+export const buildWorkspaceIsolationEnv = (
+  cwd?: string,
+): Record<string, string> | undefined => {
+  if (!cwd) {
+    return undefined;
+  }
+
+  const resolvedCwd = resolve(cwd);
+  return {
+    GIT_CEILING_DIRECTORIES: dirname(resolvedCwd),
+  };
+};

--- a/src/integrations/subprocess/runner.ts
+++ b/src/integrations/subprocess/runner.ts
@@ -437,14 +437,13 @@ const runWithNodePty = (
   if (request.input !== undefined) {
     emitEvent({ type: "prompt", data: request.input });
     ptyProcess.write(request.input);
-    // One-shot PTY prompts need an explicit submit/EOF signal so terminal
-    // applications that read stdin can finish instead of waiting forever.
+    // PTY stdin prompts need an explicit EOF so commands like `codex exec -`
+    // stop reading the prompt and start executing. The PTY remains usable for
+    // later interactive approval input.
     if (!request.input.endsWith("\r") && !request.input.endsWith("\n")) {
       ptyProcess.write("\r");
     }
-    if (request.interactiveAfterInput !== true) {
-      ptyProcess.write("\x04");
-    }
+    ptyProcess.write("\x04");
   }
 
   return result;

--- a/tests/ts/unit/cli/checkpoint-restore.test.ts
+++ b/tests/ts/unit/cli/checkpoint-restore.test.ts
@@ -86,22 +86,25 @@ describe("runCheckpointRestoreCommand", () => {
       message: "세션 session_restore를 체크포인트 session_restore_checkpoint_001 시점으로 복원했습니다.",
     });
 
-    expect(saveSpy).toHaveBeenCalledWith({
-      shared_context: {
-        session_id: "session_restore",
-      },
-      task_results: {
-        task_001: {
-          task_id: "task_001",
-          success: true,
-          summary: "First",
-          raw_output: "first",
+    expect(saveSpy).toHaveBeenCalledWith(
+      {
+        shared_context: {
+          session_id: "session_restore",
         },
+        task_results: {
+          task_001: {
+            task_id: "task_001",
+            success: true,
+            summary: "First",
+            raw_output: "first",
+          },
+        },
+        current_task_id: null,
+        completed_task_ids: ["task_001"],
+        next_action: "나중에 이어서 진행하세요",
+        updated_at: "2026-04-27T12:34:56.000Z",
       },
-      current_task_id: null,
-      completed_task_ids: ["task_001"],
-      next_action: "나중에 이어서 진행하세요",
-      updated_at: "2026-04-27T12:34:56.000Z",
-    });
+      undefined,
+    );
   });
 });

--- a/tests/ts/unit/cli/parse.test.ts
+++ b/tests/ts/unit/cli/parse.test.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { getCliUsage, parseCliArgs } from "../../../../src/cli/parse.js";
 
@@ -69,7 +70,7 @@ describe("parseCliArgs", () => {
     expect(parsed).toEqual({
       mode: "run",
       prompt: "연체료는 어떻게 계산돼?",
-      cwd: "video-demo/book-rental-service",
+      cwd: resolve("video-demo/book-rental-service"),
       adapter: "codex",
       executionMode: "real",
       verbose: false,
@@ -83,7 +84,7 @@ describe("parseCliArgs", () => {
     const parsed = parseCliArgs(["repl", "--cwd=video-demo/book-rental-service"]);
     expect(parsed).toEqual({
       mode: "repl",
-      cwd: "video-demo/book-rental-service",
+      cwd: resolve("video-demo/book-rental-service"),
       adapter: "codex",
       executionMode: "real",
       verbose: false,
@@ -98,7 +99,7 @@ describe("parseCliArgs", () => {
     expect(parsed).toEqual({
       mode: "run",
       inputFile: "input.json",
-      cwd: "video-demo/book-rental-service",
+      cwd: resolve("video-demo/book-rental-service"),
       adapter: "codex",
       executionMode: "real",
       verbose: false,

--- a/tests/ts/unit/cli/session-reset.test.ts
+++ b/tests/ts/unit/cli/session-reset.test.ts
@@ -35,6 +35,6 @@ describe("runSessionResetCommand", () => {
       message: "세션 session_to_reset를 초기화(삭제)했습니다.",
     });
 
-    expect(deleteSpy).toHaveBeenCalledWith("session_to_reset");
+    expect(deleteSpy).toHaveBeenCalledWith("session_to_reset", undefined);
   });
 });

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -185,6 +185,23 @@ describe("EmbeddedTerminalPane", () => {
     });
   });
 
+  it("does not keep a stale approval prompt after later output arrives", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "approval required (y/n)\n",
+    });
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "approved, executing now\n",
+    });
+
+    expect(pane.getInteractionState(120)).toBeNull();
+  });
+
   it("renders the live cursor cell with inverse video when the buffer reports a visible cursor", () => {
     pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "hello" });
 

--- a/tests/ts/unit/core/state/session-state-manager-cache.test.ts
+++ b/tests/ts/unit/core/state/session-state-manager-cache.test.ts
@@ -3,11 +3,10 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { SessionStateManager } from "../../../../../src/core/state/SessionStateManager.js";
-
-const SESSIONS_SUBDIR = ".state/sessions";
+import { resolveLegacySessionsDir } from "../../../../../src/core/state/storage-paths.js";
 
 function writeSession(dir: string, id: string, content: object) {
-  const sessionsDir = join(dir, SESSIONS_SUBDIR);
+  const sessionsDir = resolveLegacySessionsDir(dir);
   mkdirSync(sessionsDir, { recursive: true });
   writeFileSync(join(sessionsDir, `${id}.json`), JSON.stringify(content, null, 2));
 }

--- a/tests/ts/unit/core/state/session-state-manager-lock.test.ts
+++ b/tests/ts/unit/core/state/session-state-manager-lock.test.ts
@@ -2,10 +2,8 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import { SessionStateManager } from "../../../../../src/core/state/SessionStateManager.js";
+import { SessionStateManager, resolveSessionsDir } from "../../../../../src/core/state/SessionStateManager.js";
 import { StateLockError } from "../../../../../src/core/errors/StateErrors.js";
-
-const SESSIONS_SUBDIR = ".state/sessions";
 const LOCK_STALE_MS = 5_000;
 
 function makeMinimalSession(sessionId: string) {
@@ -27,7 +25,7 @@ function makeMinimalSession(sessionId: string) {
 }
 
 function sessionsDir(tmpDir: string) {
-  return join(tmpDir, SESSIONS_SUBDIR);
+  return resolveSessionsDir(tmpDir);
 }
 
 function writeLock(tmpDir: string, sessionId: string, content: string, mtimeOffset = 0) {
@@ -46,22 +44,30 @@ function writeLock(tmpDir: string, sessionId: string, content: string, mtimeOffs
 describe("lock PID 스테일 감지", () => {
   let tmpDir: string;
   let origCwd: string;
+  let origDetoksHome: string | undefined;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "detoks-lock-test-"));
     origCwd = process.cwd();
+    origDetoksHome = process.env.DETOKS_HOME;
+    process.env.DETOKS_HOME = join(tmpDir, ".detoks-home");
     process.chdir(tmpDir);
   });
 
   afterEach(() => {
     process.chdir(origCwd);
+    if (origDetoksHome === undefined) {
+      delete process.env.DETOKS_HOME;
+    } else {
+      process.env.DETOKS_HOME = origDetoksHome;
+    }
     rmSync(tmpDir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
 
   it("잠금 없는 경우 saveSession이 정상 완료", async () => {
     const state = makeMinimalSession("sess-no-lock") as any;
-    await expect(SessionStateManager.saveSession(state)).resolves.toBeUndefined();
+    await expect(SessionStateManager.saveSession(state, tmpDir)).resolves.toBeUndefined();
   });
 
   it("죽은 PID가 잠금 파일에 있으면 스테일로 처리 — saveSession 성공", async () => {
@@ -79,7 +85,7 @@ describe("lock PID 스테일 감지", () => {
     });
 
     const state = makeMinimalSession("sess-stale") as any;
-    await expect(SessionStateManager.saveSession(state)).resolves.toBeUndefined();
+    await expect(SessionStateManager.saveSession(state, tmpDir)).resolves.toBeUndefined();
   });
 
   it("현재 프로세스 PID가 잠금 파일에 있으면 StateLockError", async () => {
@@ -95,7 +101,7 @@ describe("lock PID 스테일 감지", () => {
     });
 
     const state = makeMinimalSession("sess-live") as any;
-    await expect(SessionStateManager.saveSession(state)).rejects.toBeInstanceOf(StateLockError);
+    await expect(SessionStateManager.saveSession(state, tmpDir)).rejects.toBeInstanceOf(StateLockError);
   });
 
   it("PID를 읽을 수 없는 잠금 + mtime이 오래된 경우 스테일로 처리 — saveSession 성공", async () => {
@@ -104,7 +110,7 @@ describe("lock PID 스테일 감지", () => {
     writeLock(tmpDir, "sess-no-pid", "not-a-number", staleOffset);
 
     const state = makeMinimalSession("sess-no-pid") as any;
-    await expect(SessionStateManager.saveSession(state)).resolves.toBeUndefined();
+    await expect(SessionStateManager.saveSession(state, tmpDir)).resolves.toBeUndefined();
   });
 
   it("PID를 읽을 수 없는 잠금 + mtime이 최근이면 StateLockError", async () => {
@@ -112,6 +118,6 @@ describe("lock PID 스테일 감지", () => {
     writeLock(tmpDir, "sess-fresh-no-pid", "not-a-number"); // 현재 시간 → 최신
 
     const state = makeMinimalSession("sess-fresh-no-pid") as any;
-    await expect(SessionStateManager.saveSession(state)).rejects.toBeInstanceOf(StateLockError);
+    await expect(SessionStateManager.saveSession(state, tmpDir)).rejects.toBeInstanceOf(StateLockError);
   });
 });

--- a/tests/ts/unit/core/state/session-state-manager-resume.test.ts
+++ b/tests/ts/unit/core/state/session-state-manager-resume.test.ts
@@ -3,11 +3,10 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { SessionStateManager } from "../../../../../src/core/state/SessionStateManager.js";
-
-const SESSIONS_SUBDIR = ".state/sessions";
+import { resolveLegacySessionsDir } from "../../../../../src/core/state/storage-paths.js";
 
 function writeSession(dir: string, id: string, content: object) {
-  const sessionsDir = join(dir, SESSIONS_SUBDIR);
+  const sessionsDir = resolveLegacySessionsDir(dir);
   mkdirSync(sessionsDir, { recursive: true });
   writeFileSync(join(sessionsDir, `${id}.json`), JSON.stringify(content, null, 2));
 }

--- a/tests/ts/unit/core/state/session-state-manager-security.test.ts
+++ b/tests/ts/unit/core/state/session-state-manager-security.test.ts
@@ -4,8 +4,7 @@ import { tmpdir } from "node:os";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { SessionStateManager } from "../../../../../src/core/state/SessionStateManager.js";
 import { StateIOError } from "../../../../../src/core/errors/StateErrors.js";
-
-const SESSIONS_SUBDIR = ".state/sessions";
+import { resolveLegacySessionsDir } from "../../../../../src/core/state/storage-paths.js";
 
 function makeMinimalSession(sessionId: string) {
   return {
@@ -26,7 +25,7 @@ function makeMinimalSession(sessionId: string) {
 }
 
 function writeSession(dir: string, id: string) {
-  const sessDir = join(dir, SESSIONS_SUBDIR);
+  const sessDir = resolveLegacySessionsDir(dir);
   mkdirSync(sessDir, { recursive: true });
   writeFileSync(join(sessDir, `${id}.json`), JSON.stringify(makeMinimalSession(id)));
 }
@@ -34,15 +33,23 @@ function writeSession(dir: string, id: string) {
 describe("sessionId 패턴 검증 (assertSafeSessionId)", () => {
   let tmpDir: string;
   let origCwd: string;
+  let origDetoksHome: string | undefined;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "detoks-sid-sec-"));
     origCwd = process.cwd();
+    origDetoksHome = process.env.DETOKS_HOME;
+    process.env.DETOKS_HOME = join(tmpDir, ".detoks-home");
     process.chdir(tmpDir);
   });
 
   afterEach(() => {
     process.chdir(origCwd);
+    if (origDetoksHome === undefined) {
+      delete process.env.DETOKS_HOME;
+    } else {
+      process.env.DETOKS_HOME = origDetoksHome;
+    }
     rmSync(tmpDir, { recursive: true, force: true });
   });
 

--- a/tests/ts/unit/integrations/adapters/adapter-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/adapter-path.test.ts
@@ -95,6 +95,9 @@ describe("adapter subprocess path", () => {
       command: "gemini",
       args: ["--model", "gemini-2.5-pro"],
       cwd: "/tmp",
+      env: {
+        GIT_CEILING_DIRECTORIES: "/",
+      },
       input: "hello gemini",
     });
   });
@@ -114,6 +117,9 @@ describe("adapter subprocess path", () => {
       command: "gemini",
       args: ["--model", "gemini-2.5-pro", "hello gemini"],
       cwd: "/tmp",
+      env: {
+        GIT_CEILING_DIRECTORIES: "/",
+      },
     });
   });
 
@@ -139,6 +145,9 @@ describe("adapter subprocess path", () => {
         "claude-sonnet-4-6",
       ],
       cwd: "/tmp",
+      env: {
+        GIT_CEILING_DIRECTORIES: "/",
+      },
       input: "hello claude",
     });
   });
@@ -164,6 +173,9 @@ describe("adapter subprocess path", () => {
         "hello claude",
       ],
       cwd: "/tmp",
+      env: {
+        GIT_CEILING_DIRECTORIES: "/",
+      },
     });
   });
 
@@ -184,6 +196,8 @@ describe("adapter subprocess path", () => {
         "--ask-for-approval",
         "on-request",
         "exec",
+        "-C",
+        "/tmp",
         "--model",
         "gpt-5",
         "-",
@@ -191,8 +205,11 @@ describe("adapter subprocess path", () => {
         "workspace-write",
         "--skip-git-repo-check",
       ],
-      cwd: "/tmp",
-      input: "",
+        cwd: "/tmp",
+        env: {
+          GIT_CEILING_DIRECTORIES: "/",
+        },
+        input: "",
       interactiveAfterInput: true,
     });
   });
@@ -220,6 +237,9 @@ describe("adapter subprocess path", () => {
         "claude-sonnet-4-6",
       ],
       cwd: "/tmp",
+      env: {
+        GIT_CEILING_DIRECTORIES: "/",
+      },
       input: "",
     });
   });
@@ -239,6 +259,9 @@ describe("adapter subprocess path", () => {
       command: "gemini",
       args: ["--model", "gemini-2.5-pro"],
       cwd: "/tmp",
+      env: {
+        GIT_CEILING_DIRECTORIES: "/",
+      },
       input: "",
     });
   });

--- a/tests/ts/unit/integrations/adapters/real-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/real-path.test.ts
@@ -96,6 +96,8 @@ describe("adapter execution modes", () => {
         command: "codex",
         args: [
           "exec",
+          "-C",
+          "/workspace",
           "--model",
           "gpt-5",
           "-",
@@ -106,6 +108,9 @@ describe("adapter execution modes", () => {
           "never",
         ],
         cwd: "/workspace",
+        env: {
+          GIT_CEILING_DIRECTORIES: "/",
+        },
         input: "real prompt",
       },
     ]);
@@ -141,6 +146,9 @@ describe("adapter execution modes", () => {
         command: "gemini",
         args: ["--model", "gemini-2.5-pro"],
         cwd: "/tmp",
+        env: {
+          GIT_CEILING_DIRECTORIES: "/",
+        },
         input: "real prompt",
       },
     ]);
@@ -179,6 +187,9 @@ describe("adapter execution modes", () => {
           "claude-sonnet-4-6",
         ],
         cwd: "/workspace",
+        env: {
+          GIT_CEILING_DIRECTORIES: "/",
+        },
         input: "real prompt",
       },
     ]);

--- a/tests/ts/unit/integrations/subprocess/runner.test.ts
+++ b/tests/ts/unit/integrations/subprocess/runner.test.ts
@@ -3,204 +3,223 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
-  createPtySubprocessRunner,
-  createRealSubprocessRunner,
+	createPtySubprocessRunner,
+	createRealSubprocessRunner,
 } from "../../../../../src/integrations/subprocess/runner.js";
 
 const tempDirs: string[] = [];
 
 beforeEach(() => {
-  const dir = mkdtempSync(join(tmpdir(), "detoks-runner-"));
-  tempDirs.push(dir);
-  vi.stubEnv("HOME", dir);
+	const dir = mkdtempSync(join(tmpdir(), "detoks-runner-"));
+	tempDirs.push(dir);
+	vi.stubEnv("HOME", dir);
 });
 
 afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    rmSync(dir, { recursive: true, force: true });
-  }
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
 
-  vi.unstubAllEnvs();
+	vi.unstubAllEnvs();
 });
 
 describe("createRealSubprocessRunner", () => {
-  it("captures stdout, stderr, and exit code from a real process", async () => {
-    const runner = createRealSubprocessRunner();
-    const result = await runner.run({
-      command: process.execPath,
-      args: [
-        "-e",
-        "process.stdout.write('out'); process.stderr.write('err'); process.exit(7);",
-      ],
-    });
+	it("captures stdout, stderr, and exit code from a real process", async () => {
+		const runner = createRealSubprocessRunner();
+		const result = await runner.run({
+			command: process.execPath,
+			args: [
+				"-e",
+				"process.stdout.write('out'); process.stderr.write('err'); process.exit(7);",
+			],
+		});
 
-    expect(result.stdout).toBe("out");
-    expect(result.stderr).toBe("err");
-    expect(result.exitCode).toBe(7);
-    expect(result.timedOut).toBe(false);
-  });
+		expect(result.stdout).toBe("out");
+		expect(result.stderr).toBe("err");
+		expect(result.exitCode).toBe(7);
+		expect(result.timedOut).toBe(false);
+	});
 
-  it("reports a clear failure for missing commands", async () => {
-    const runner = createRealSubprocessRunner();
-    const result = await runner.run({
-      command: "__detoks_missing_binary__",
-      args: [],
-    });
+	it("reports a clear failure for missing commands", async () => {
+		const runner = createRealSubprocessRunner();
+		const result = await runner.run({
+			command: "__detoks_missing_binary__",
+			args: [],
+		});
 
-    expect(result.exitCode).toBe(127);
-    expect(result.stderr.length).toBeGreaterThan(0);
-    expect(result.timedOut).toBe(false);
-  });
+		expect(result.exitCode).toBe(127);
+		expect(result.stderr.length).toBeGreaterThan(0);
+		expect(result.timedOut).toBe(false);
+	});
 
-  it("streams transcript events from the PTY-aware runner", async () => {
-    const runner = createPtySubprocessRunner();
-    const result = await runner.runWithTranscript({
-      command: process.execPath,
-      args: [
-        "-e",
-        [
-          "process.stdout.write('first\\n');",
-          "setTimeout(() => {",
-          "  process.stdout.write('second\\n');",
-          "  process.exit(0);",
-          "}, 50);",
-        ].join(" "),
-      ],
-    });
+	it("streams transcript events from the PTY-aware runner", async () => {
+		const runner = createPtySubprocessRunner();
+		const result = await runner.runWithTranscript({
+			command: process.execPath,
+			args: [
+				"-e",
+				[
+					"process.stdout.write('first\\n');",
+					"setTimeout(() => {",
+					"  process.stdout.write('second\\n');",
+					"  process.exit(0);",
+					"}, 50);",
+				].join(" "),
+			],
+		});
 
-    expect(result.stdout).toContain("first");
-    expect(result.stdout).toContain("second");
-    expect(result.transcript.events.filter((event) => event.type === "chunk").length).toBeGreaterThanOrEqual(2);
-  });
+		expect(result.stdout).toContain("first");
+		expect(result.stdout).toContain("second");
+		expect(
+			result.transcript.events.filter((event) => event.type === "chunk").length,
+		).toBeGreaterThanOrEqual(2);
+	});
 
-  it(
-    "submits one-shot PTY input so stdin-only commands can finish",
-    async () => {
-      const dir = tempDirs.at(-1)!;
-      const codexScript = join(dir, "codex");
-      writeFileSync(
-        codexScript,
-        [
-          "#!/usr/bin/env node",
-          'let input = "";',
-          'process.stdin.setEncoding("utf8");',
-          'process.stdin.on("data", (chunk) => { input += chunk; });',
-          'process.stdin.on("end", () => {',
-          "  process.stdout.write(input);",
-          "  process.exit(0);",
-          "});",
-          "process.stdin.resume();",
-        ].join("\n"),
-        "utf8",
-      );
-      chmodSync(codexScript, 0o755);
+	it("submits one-shot PTY input so stdin-only commands can finish", async () => {
+		const dir = tempDirs.at(-1)!;
+		const codexScript = join(dir, "codex");
+		writeFileSync(
+			codexScript,
+			[
+				"#!/usr/bin/env node",
+				'let input = "";',
+				'process.stdin.setEncoding("utf8");',
+				'process.stdin.on("data", (chunk) => { input += chunk; });',
+				'process.stdin.on("end", () => {',
+				"  process.stdout.write(input);",
+				"  process.exit(0);",
+				"});",
+				"process.stdin.resume();",
+			].join("\n"),
+			"utf8",
+		);
+		chmodSync(codexScript, 0o755);
 
-      const runner = createPtySubprocessRunner();
-      const result = await runner.runWithTranscript({
-        command: "codex",
-        args: ["exec", "-", "--sandbox", "workspace-write"],
-        input: "hello\nworld",
-        env: {
-          ...process.env,
-          PATH: `${dir}:${process.env.PATH ?? ""}`,
-        },
-      });
+		const runner = createPtySubprocessRunner();
+		const result = await runner.runWithTranscript({
+			command: "codex",
+			args: ["exec", "-", "--sandbox", "workspace-write"],
+			input: "hello\nworld",
+			env: {
+				...process.env,
+				PATH: `${dir}:${process.env.PATH ?? ""}`,
+			},
+		});
 
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("hello");
-      expect(result.stdout).toContain("world");
-    },
-    10_000,
-  );
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("hello");
+		expect(result.stdout).toContain("world");
+	}, 10_000);
 
-  it("keeps the PTY open after prompt submission and forwards later approval replies", async () => {
-    const dir = tempDirs.at(-1)!;
-    const codexScript = join(dir, "codex");
-    writeFileSync(
-      codexScript,
-      [
-        "#!/usr/bin/env node",
-        'let input = "";',
-        'let approvalShown = false;',
-        'process.stdin.setEncoding("utf8");',
-        'process.stdin.on("data", (chunk) => {',
-        "  input += chunk;",
-        "  if (!approvalShown) {",
-        "    approvalShown = true;",
-        "    process.stdout.write('approval required\\n');",
-        "    return;",
-        "  }",
-        "  if (chunk.replace(/\\s+/g, '').toLowerCase().includes('y')) {",
-        "    process.stdout.write('approved\\n');",
-        "    process.exit(0);",
-        "  }",
-        "});",
-        'process.stdin.on("end", () => {',
-        "  process.stdout.write('stdin-ended\\n');",
-        "});",
-        "process.stdin.resume();",
-      ].join("\n"),
-      "utf8",
-    );
-    chmodSync(codexScript, 0o755);
+	it("submits EOF for interactive PTY prompts and still accepts later terminal input", async () => {
+		const dir = tempDirs.at(-1)!;
+		const codexScript = join(dir, "codex");
+		writeFileSync(
+			codexScript,
+			[
+				"#!/usr/bin/env node",
+				'let input = "";',
+				"let approvalShown = false;",
+				'process.stdin.setEncoding("utf8");',
+				'process.stdin.on("data", (chunk) => {',
+				"  input += chunk;",
+				"  if (!approvalShown) {",
+				"    approvalShown = true;",
+				"    process.stdout.write('approval required\\n');",
+				"    return;",
+				"  }",
+				"  if (chunk.replace(/\\s+/g, '').toLowerCase().includes('y')) {",
+				"    process.stdout.write('approved\\n');",
+				"    process.exit(0);",
+				"  }",
+				"});",
+				'process.stdin.on("end", () => {',
+				"  process.stdout.write('stdin-ended\\n');",
+				"});",
+				"process.stdin.resume();",
+			].join("\n"),
+			"utf8",
+		);
+		chmodSync(codexScript, 0o755);
 
-    let capturedController: { write: (data: string) => void } | null = null;
-    const runner = createPtySubprocessRunner({
-      onController: (controller) => {
-        capturedController = controller;
-      },
-    });
-    const resultPromise = runner.runWithTranscript({
-      command: "codex",
-      args: ["exec", "-", "--sandbox", "workspace-write"],
-      input: "hello\n",
-      interactiveAfterInput: true,
-      env: {
-        ...process.env,
-        PATH: `${dir}:${process.env.PATH ?? ""}`,
-      },
-    });
+		let capturedController: { write: (data: string) => void } | null = null;
+		let answered = false;
+		const runner = createPtySubprocessRunner({
+			onController: (controller) => {
+				capturedController = controller;
+			},
+			onEvent: (event) => {
+				if (
+					!answered &&
+					event.type === "chunk" &&
+					event.data?.includes("approval required")
+				) {
+					answered = true;
+					capturedController?.write("y\r");
+				}
+			},
+		});
+		const resultPromise = runner.runWithTranscript({
+			command: "codex",
+			args: ["exec", "-", "--sandbox", "workspace-write"],
+			input: "hello",
+			interactiveAfterInput: true,
+			env: {
+				...process.env,
+				PATH: `${dir}:${process.env.PATH ?? ""}`,
+			},
+		});
 
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(capturedController).not.toBeNull();
-    capturedController!.write("y\r");
-    const result = await resultPromise;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		expect(capturedController).not.toBeNull();
+		capturedController!.write("y\r");
+		const result = await resultPromise;
 
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("approval required");
-    expect(result.stdout).toContain("approved");
-    expect(result.stdout).not.toContain("stdin-ended");
-  }, 10_000);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("approval required");
+		expect(result.stdout).toContain("approved");
+		expect(result.stdout).not.toContain("stdin-ended");
+	}, 10_000);
 
-  it("streams Codex JSON output without waiting for a PTY wrapper", async () => {
-    const dir = tempDirs.at(-1)!;
-    const codexScript = join(dir, "codex");
-    writeFileSync(
-      codexScript,
-      [
-        "#!/usr/bin/env node",
-        "process.stdout.write('{\"type\":\"turn.started\"}\\n');",
-        "setTimeout(() => {",
-        "  process.stdout.write('{\"type\":\"message.delta\",\"delta\":\"Hello\"}\\n');",
-        "  process.exit(0);",
-        "}, 25);",
-      ].join("\n"),
-      "utf8",
-    );
-    chmodSync(codexScript, 0o755);
+	it("streams Codex JSON output without waiting for a PTY wrapper", async () => {
+		const dir = tempDirs.at(-1)!;
+		const codexScript = join(dir, "codex");
+		writeFileSync(
+			codexScript,
+			[
+				"#!/usr/bin/env node",
+				'process.stdout.write(\'{"type":"turn.started"}\\n\');',
+				"setTimeout(() => {",
+				'  process.stdout.write(\'{"type":"message.delta","delta":"Hello"}\\n\');',
+				"  process.exit(0);",
+				"}, 25);",
+			].join("\n"),
+			"utf8",
+		);
+		chmodSync(codexScript, 0o755);
 
-    const runner = createPtySubprocessRunner();
-    const result = await runner.runWithTranscript({
-      command: "codex",
-      args: ["exec", "--json", "-", "--output-last-message", join(dir, "last-message.txt")],
-      input: "Hello\n",
-      env: {
-        ...process.env,
-        PATH: `${dir}:${process.env.PATH ?? ""}`,
-      },
-    });
+		const runner = createPtySubprocessRunner();
+		const result = await runner.runWithTranscript({
+			command: "codex",
+			args: [
+				"exec",
+				"--json",
+				"-",
+				"--output-last-message",
+				join(dir, "last-message.txt"),
+			],
+			input: "Hello\n",
+			env: {
+				...process.env,
+				PATH: `${dir}:${process.env.PATH ?? ""}`,
+			},
+		});
 
-    expect(result.stdout).toContain("turn.started");
-    expect(result.transcript.events.some((event) => event.type === "chunk" && event.stream === "stdout")).toBe(true);
-  });
+		expect(result.stdout).toContain("turn.started");
+		expect(
+			result.transcript.events.some(
+				(event) => event.type === "chunk" && event.stream === "stdout",
+			),
+		).toBe(true);
+	});
 });


### PR DESCRIPTION
## 요약
- 세션, 체크포인트, 메모리, RAG, 실행기 전반에서 로컬 상태 저장 경로 처리를 정리했습니다.
- 상태 파일과 관련 리소스가 분기별로 일관된 위치에 저장되도록 맞춰, 계속/복원/초기화 흐름에서 경로 불일치를 줄였습니다.
- TUI의 embedded terminal과 PTY 실행 흐름도 함께 손봐 로컬 실행 시 상태 전이가 끊기지 않도록 했습니다.

## 관련 이슈
- Closes #
- Related to #

## 변경 유형
- [x] 버그 수정
- [ ] 기능 추가
- [ ] 리팩터링
- [ ] 문서 수정
- [x] 테스트 추가/수정

## 영향 범위
- 영향받는 모듈: `src/cli`, `src/core/state`, `src/core/rag`, `src/core/llm-client`, `src/integrations/adapters`, `src/integrations/subprocess`
- 영향받지 않는 모듈: UI와 무관한 일반 유틸, 비상태성 계산 로직의 나머지 부분

## 테스트 방법
1. 체크포인트/세션 관련 단위 테스트로 저장, 복원, 목록, 초기화 흐름을 검증했습니다.
2. embedded TUI와 PTY runner 단위 테스트로 실행 중 상태 전이와 입력 처리 회귀를 확인했습니다.
3. 로컬 타입체크와 빌드를 통과시켜 CLI 진입점까지 함께 확인했습니다.

## 체크리스트
- [x] 로컬에서 테스트했습니다
- [x] 필요한 경우 테스트를 추가하거나 수정했습니다
- [ ] 필요한 경우 문서를 수정했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 PR을 유지했습니다

## 스크린샷 / 로그
- 별도 스크린샷 없음

## 리뷰어 참고사항
- 상태 저장 경로를 다루는 변경이라 세션 지속, 체크포인트 복원, 메모리 관련 흐름을 함께 봐주세요.
- embedded terminal과 PTY runner 쪽은 실제 실행 흐름에서 입력 종료와 승인 대기 처리가 이어지는지 확인 포인트입니다.