### PR TITLE
fix(tui): TUI 실행 중 cmake stderr / [detoks] 안내 메시지 오염 수정

### DIFF
--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -342,6 +342,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       activeRunBlock.status = "cancelled";
       activeRunBlock.completedAt = Date.now();
       activeRunBlock.summaryLines = ["실행이 취소되었습니다."];
+      activeRunBlock.pane.appendFinalAnswer("\n실행이 취소되었습니다.\n");
       setStickyPromptFromRun(activeRunBlock);
     };
 

--- a/src/core/llm-client/node-llama-runtime.ts
+++ b/src/core/llm-client/node-llama-runtime.ts
@@ -24,7 +24,10 @@ import { logger } from "../utils/logger.js";
 
 function suppressStderr(): () => void {
 	const orig = process.stderr.write.bind(process.stderr);
-	(process.stderr as { write: (...a: unknown[]) => boolean }).write = () => true;
+	process.stderr.write = ((_buf: unknown, cbOrEnc?: unknown, cb?: () => void): boolean => {
+		(typeof cbOrEnc === "function" ? (cbOrEnc as () => void) : cb)?.();
+		return true;
+	}) as unknown as typeof process.stderr.write;
 	return () => { process.stderr.write = orig; };
 }
 

--- a/src/core/llm-client/node-llama-runtime.ts
+++ b/src/core/llm-client/node-llama-runtime.ts
@@ -22,6 +22,12 @@ import {
 } from "./gguf-file.js";
 import { logger } from "../utils/logger.js";
 
+function suppressStderr(): () => void {
+	const orig = process.stderr.write.bind(process.stderr);
+	(process.stderr as { write: (...a: unknown[]) => boolean }).write = () => true;
+	return () => { process.stderr.write = orig; };
+}
+
 type NodeLlamaRuntimeConfig = Pick<
 	Role1RuntimeConfig,
 	| "localLlmModelName"
@@ -224,6 +230,7 @@ async function loadRuntimeWithOptions(
 ): Promise<LoadedNodeLlamaRuntime> {
 	const modelPath = resolveNodeLlamaModelPath(config);
 	const signature = buildNodeLlamaRuntimeSignature(config);
+	const restoreStderr = suppressStderr();
 	const llama = await (async (): Promise<Llama> => {
 		const baseOpts = {
 			gpu: gpuEnabled ? ("auto" as const) : (false as const),
@@ -241,7 +248,7 @@ async function loadRuntimeWithOptions(
 				emitLlamaBuildPhase("ready");
 			}
 		}
-	})();
+	})().finally(restoreStderr);
 	let model: LlamaModel | null = null;
 	let context: LlamaContext | null = null;
 	let session: LlamaChatSession | null = null;

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -152,21 +152,26 @@ async function isMemoryDisabled(): Promise<boolean> {
   }
 }
 
-async function maybeShowFirstRunNotice(cwd: string): Promise<void> {
+async function maybeShowFirstRunNotice(
+  cwd: string,
+  onProgress: (event: PipelineProgressEvent) => Promise<void>,
+): Promise<void> {
   const flagPath = resolveProjectNoticeFlagPath(cwd);
   try {
     await fs.access(flagPath);
     return; // 이미 표시했음
   } catch { /* 파일 없음 → 안내 필요 */ }
 
-  const notice = [
-    `[detoks] DeToks는 실행 메모리를 ${resolveSessionsDir(cwd)} 에 저장합니다.`,
-    `[detoks] 프로젝트별 RAG DB는 ${join(resolveProjectRagDir(cwd), "vectors.db")} 에 저장합니다.`,
-    "[detoks] cross-project store에는 generalize 단계를 거친 익명 패턴만 들어갑니다.",
-    "[detoks] 비활성화: detoks memory disable / 일괄 삭제: detoks memory purge --all",
-  ].join("\n");
+  const noticeLines = [
+    `DeToks는 실행 메모리를 ${resolveSessionsDir(cwd)} 에 저장합니다.`,
+    `프로젝트별 RAG DB는 ${join(resolveProjectRagDir(cwd), "vectors.db")} 에 저장합니다.`,
+    "cross-project store에는 generalize 단계를 거친 익명 패턴만 들어갑니다.",
+    "비활성화: detoks memory disable / 일괄 삭제: detoks memory purge --all",
+  ];
 
-  process.stderr.write(`${notice}\n`);
+  for (const message of noticeLines) {
+    await onProgress({ stage: "detoks", status: "info", message });
+  }
 
   try {
     await fs.mkdir(join(getDetoksHomeDir(), "projects"), { recursive: true });
@@ -635,7 +640,10 @@ export const orchestratePipeline = async (
 
   // 첫 실행 1회 안내 (non-fatal, stderr) — 메모리 비활성화 상태면 표시하지 않음
   if (!memoryDisabled) {
-    await maybeShowFirstRunNotice(request.userRequest.cwd ?? process.cwd());
+    await maybeShowFirstRunNotice(
+      request.userRequest.cwd ?? process.cwd(),
+      (event) => emitProgress(request, event),
+    );
   }
 
   // projectId / gitHead — F1·F3 cache lookup과 hash v2 re-map에서 공통으로 사용

--- a/src/core/rag/embedding-service.ts
+++ b/src/core/rag/embedding-service.ts
@@ -13,7 +13,10 @@ export class EmbeddingService {
     if (this.ctx) return;
     const restoreStderr = (() => {
       const orig = process.stderr.write.bind(process.stderr);
-      (process.stderr as { write: (...a: unknown[]) => boolean }).write = () => true;
+      process.stderr.write = ((_buf: unknown, cbOrEnc?: unknown, cb?: () => void): boolean => {
+        (typeof cbOrEnc === "function" ? (cbOrEnc as () => void) : cb)?.();
+        return true;
+      }) as unknown as typeof process.stderr.write;
       return () => { process.stderr.write = orig; };
     })();
     try {

--- a/src/core/rag/embedding-service.ts
+++ b/src/core/rag/embedding-service.ts
@@ -11,7 +11,16 @@ export class EmbeddingService {
 
   async init(): Promise<void> {
     if (this.ctx) return;
-    this.llama = await getLlama({ gpu: false, logLevel: LlamaLogLevel.fatal, progressLogs: false });
+    const restoreStderr = (() => {
+      const orig = process.stderr.write.bind(process.stderr);
+      (process.stderr as { write: (...a: unknown[]) => boolean }).write = () => true;
+      return () => { process.stderr.write = orig; };
+    })();
+    try {
+      this.llama = await getLlama({ gpu: false, logLevel: LlamaLogLevel.fatal, progressLogs: false });
+    } finally {
+      restoreStderr();
+    }
     this.model = await this.llama.loadModel({ modelPath: this.modelPath });
     this.ctx = await this.model.createEmbeddingContext();
   }

--- a/src/integrations/adapters/codex/adapter.ts
+++ b/src/integrations/adapters/codex/adapter.ts
@@ -62,7 +62,11 @@ export class CodexStubAdapter implements CliAdapter {
       command: "codex",
       args: [
         "exec",
+<<<<<<< HEAD
         ...workspaceArgs,
+=======
+        ...(request.cwd ? ["-C", request.cwd] : []),
+>>>>>>> 23ef343 (Route caches through project-local detoks storage)
         ...(reasoningEffort ? ["-c", `model_reasoning_effort=${reasoningEffort}`] : []),
         ...(request.model ? ["--model", request.model] : []),
         "-",

--- a/src/integrations/adapters/codex/adapter.ts
+++ b/src/integrations/adapters/codex/adapter.ts
@@ -62,11 +62,7 @@ export class CodexStubAdapter implements CliAdapter {
       command: "codex",
       args: [
         "exec",
-<<<<<<< HEAD
         ...workspaceArgs,
-=======
-        ...(request.cwd ? ["-C", request.cwd] : []),
->>>>>>> 23ef343 (Route caches through project-local detoks storage)
         ...(reasoningEffort ? ["-c", `model_reasoning_effort=${reasoningEffort}`] : []),
         ...(request.model ? ["--model", request.model] : []),
         "-",

--- a/src/integrations/adapters/workspace-env.ts
+++ b/src/integrations/adapters/workspace-env.ts
@@ -14,6 +14,7 @@ export const buildWorkspaceIsolationEnv = (
   };
 };
 
+
 export const buildWorkspaceCommandArgs = (
   adapter: Adapter,
   cwd?: string,

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -9,9 +9,14 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  resolveCheckpointsDir,
+  resolveProjectNoticeFlagPath,
+  resolveSessionsDir,
+} from "../../../src/core/state/storage-paths.js";
 
 const repoRoot = new URL("../../..", import.meta.url).pathname.replace(/\/$/, "");
 const packageJson = JSON.parse(
@@ -22,11 +27,47 @@ const packageJson = JSON.parse(
 const packageName = packageJson.name ?? "detoks";
 const cliEntry = resolve(repoRoot, "src/cli/index.ts");
 const tsxLoader = resolve(repoRoot, "node_modules/tsx/dist/loader.mjs");
+const testDetoksHome = mkdtempSync(join(tmpdir(), "detoks-cli-home-"));
+const originalDetoksHome = process.env.DETOKS_HOME;
+
+beforeAll(() => {
+  process.env.DETOKS_HOME = testDetoksHome;
+  const noticeFlagPath = resolveProjectNoticeFlagPath(repoRoot);
+  mkdirSync(dirname(noticeFlagPath), { recursive: true });
+  writeFileSync(noticeFlagPath, "test", "utf8");
+});
+
+afterAll(() => {
+  if (originalDetoksHome === undefined) {
+    delete process.env.DETOKS_HOME;
+  } else {
+    process.env.DETOKS_HOME = originalDetoksHome;
+  }
+  rmSync(testDetoksHome, { force: true, recursive: true });
+});
+
+const buildCliEnv = (env: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => {
+  const nextEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    DETOKS_HOME: testDetoksHome,
+  };
+
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) {
+      delete nextEnv[key];
+    } else {
+      nextEnv[key] = value;
+    }
+  }
+
+  return nextEnv;
+};
 
 const runCli = (args: string[]) =>
   spawnSync(process.execPath, ["--import", "tsx", cliEntry, ...args], {
     cwd: repoRoot,
     encoding: "utf8",
+    env: buildCliEnv(),
   });
 
 const runCliWithInput = (args: string[], input: string) =>
@@ -34,13 +75,14 @@ const runCliWithInput = (args: string[], input: string) =>
     cwd: repoRoot,
     encoding: "utf8",
     input,
+    env: buildCliEnv(),
   });
 
 const runCliWithEnv = (args: string[], env: NodeJS.ProcessEnv) =>
   spawnSync(process.execPath, ["--import", "tsx", cliEntry, ...args], {
     cwd: repoRoot,
     encoding: "utf8",
-    env: { ...process.env, ...env },
+    env: buildCliEnv(env),
   });
 
 const runCliWithEnvAndTimeout = (
@@ -51,7 +93,7 @@ const runCliWithEnvAndTimeout = (
   spawnSync(process.execPath, ["--import", "tsx", cliEntry, ...args], {
     cwd: repoRoot,
     encoding: "utf8",
-    env: { ...process.env, ...env },
+    env: buildCliEnv(env),
     timeout,
   });
 
@@ -59,6 +101,7 @@ const runCliFromCwd = (cwd: string, args: string[]) =>
   spawnSync(process.execPath, ["--import", tsxLoader, cliEntry, ...args], {
     cwd,
     encoding: "utf8",
+    env: buildCliEnv(),
   });
 
 const runCliFromCwdWithEnv = (
@@ -69,7 +112,7 @@ const runCliFromCwdWithEnv = (
   spawnSync(process.execPath, ["--import", tsxLoader, cliEntry, ...args], {
     cwd,
     encoding: "utf8",
-    env: { ...process.env, ...env },
+    env: buildCliEnv(env),
   });
 
 const runCliWithInputFromCwd = (cwd: string, args: string[], input: string) =>
@@ -77,6 +120,7 @@ const runCliWithInputFromCwd = (cwd: string, args: string[], input: string) =>
     cwd,
     encoding: "utf8",
     input,
+    env: buildCliEnv(),
   });
 
 const runCliWithInputFromCwdEnvAndTimeout = (
@@ -91,7 +135,7 @@ const runCliWithInputFromCwdEnvAndTimeout = (
     encoding: "utf8",
     input,
     timeout,
-    env: { ...process.env, ...env },
+    env: buildCliEnv(env),
   });
 
 const waitForOutput = (
@@ -566,6 +610,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
 
     try {
       const run = runCliFromCwdWithEnv(tempDir, ["memory", "disable", "--human"], {
+        DETOKS_HOME: undefined,
         HOME: tempHome,
       });
 
@@ -858,9 +903,8 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       await waitForOutput(stdoutState, "starting long run", 20_000);
       child.stdin.write("\x03");
       await waitForOutput(stdoutState, "실행이 취소되었습니다.", 20_000);
-      child.stdin.write("/exit\n");
-
-      const exitCode = await new Promise<number>((resolve, reject) => {
+      await waitForOutput(stdoutState, "상태: 실패", 20_000);
+      const exitPromise = new Promise<number>((resolve, reject) => {
         const timeout = setTimeout(() => {
           child.kill("SIGKILL");
           reject(new Error(`detoks repl did not exit in time\nstdout:\n${stdoutState.value}\nstderr:\n${stderrState.value}`));
@@ -875,12 +919,14 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
           resolve(code ?? -1);
         });
       });
+      child.stdin.end("q");
 
+      const exitCode = await exitPromise;
       expect(exitCode).toBe(0);
       expect(stderrState.value).not.toContain("ReferenceError");
       expect(stdoutState.value).toContain("starting long run");
       expect(stdoutState.value).toContain("실행이 취소되었습니다.");
-      expect(stdoutState.value).toContain("detoks repl 종료.");
+      expect(stdoutState.value).toContain("TUI REPL이 종료되었습니다.");
     } finally {
       rmSync(tempDir, { force: true, recursive: true });
     }
@@ -1019,7 +1065,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
   it("prints explicit checkpoint list JSON for empty and populated sessions", () => {
     const sessionId = `session_cli_smoke_${Date.now()}`;
     const checkpointId = `${sessionId}_checkpoint_001`;
-    const checkpointDir = join(repoRoot, ".state", "checkpoints");
+    const checkpointDir = resolveCheckpointsDir(repoRoot);
     const checkpointPath = join(checkpointDir, `${checkpointId}.json`);
 
     try {
@@ -1121,7 +1167,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
 
   it("shows a saved session with JSON and human-readable outputs", () => {
     const sessionId = `session_cli_show_${Date.now()}`;
-    const sessionDir = join(repoRoot, ".state", "sessions");
+    const sessionDir = resolveSessionsDir(repoRoot);
     const sessionPath = join(sessionDir, `${sessionId}.json`);
 
     try {
@@ -1205,7 +1251,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
 
   it("resumes a saved session and skips already completed tasks", () => {
     const sessionId = `session_cli_resume_${Date.now()}`;
-    const sessionDir = join(repoRoot, ".state", "sessions");
+    const sessionDir = resolveSessionsDir(repoRoot);
     const sessionPath = join(sessionDir, `${sessionId}.json`);
 
     try {
@@ -1290,7 +1336,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
   it("forks a saved session without starting resume execution", () => {
     const sourceSessionId = `session_cli_source_${Date.now()}`;
     const newSessionId = `${sourceSessionId}_fork`;
-    const sessionDir = join(repoRoot, ".state", "sessions");
+    const sessionDir = resolveSessionsDir(repoRoot);
     const sourcePath = join(sessionDir, `${sourceSessionId}.json`);
     const forkPath = join(sessionDir, `${newSessionId}.json`);
 
@@ -1372,7 +1418,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
   it("resets a saved session and removes its persisted state file", () => {
     const missingSessionId = `session_cli_missing_reset_${Date.now()}`;
     const sessionId = `session_cli_reset_${Date.now()}`;
-    const sessionDir = join(repoRoot, ".state", "sessions");
+    const sessionDir = resolveSessionsDir(repoRoot);
     const sessionPath = join(sessionDir, `${sessionId}.json`);
 
     try {
@@ -1428,8 +1474,8 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
   it("restores a session to checkpoint state and truncates later task history", () => {
     const sessionId = `session_cli_restore_${Date.now()}`;
     const checkpointId = `${sessionId}_checkpoint_001`;
-    const sessionDir = join(repoRoot, ".state", "sessions");
-    const checkpointDir = join(repoRoot, ".state", "checkpoints");
+    const sessionDir = resolveSessionsDir(repoRoot);
+    const checkpointDir = resolveCheckpointsDir(repoRoot);
     const sessionPath = join(sessionDir, `${sessionId}.json`);
     const checkpointPath = join(checkpointDir, `${checkpointId}.json`);
 
@@ -1505,7 +1551,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
 
   it("prints minimal session list JSON for saved sessions", () => {
     const sessionId = `session_cli_smoke_${Date.now()}`;
-    const sessionDir = join(repoRoot, ".state", "sessions");
+    const sessionDir = resolveSessionsDir(repoRoot);
     const sessionPath = join(sessionDir, `${sessionId}.json`);
 
     try {
@@ -1618,7 +1664,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
 
   it("prints explicit checkpoint show JSON for a saved checkpoint", () => {
     const checkpointId = `session_cli_smoke_${Date.now()}_checkpoint_001`;
-    const checkpointDir = join(repoRoot, ".state", "checkpoints");
+    const checkpointDir = resolveCheckpointsDir(repoRoot);
     const checkpointPath = join(checkpointDir, `${checkpointId}.json`);
 
     try {

--- a/tests/ts/unit/core/llm-client/node-llama-runtime.test.ts
+++ b/tests/ts/unit/core/llm-client/node-llama-runtime.test.ts
@@ -76,6 +76,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 	vi.mock("node-llama-cpp", () => ({
 		getLlama: nodeLlamaMocks.getLlama,
+		LlamaLogLevel: {
+			fatal: "fatal",
+		},
 		LlamaChatSession: nodeLlamaMocks.LlamaChatSession,
 		QwenChatWrapper: nodeLlamaMocks.QwenChatWrapper,
 	}));

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -474,6 +474,7 @@ describe("orchestratePipeline", () => {
       expect.objectContaining({
         completed_task_ids: ["t1", "t2"],
       }),
+      undefined,
     );
   });
 

--- a/tests/ts/unit/core/rag/embedding-service.test.ts
+++ b/tests/ts/unit/core/rag/embedding-service.test.ts
@@ -19,6 +19,9 @@ vi.mock("node-llama-cpp", () => {
   };
   return {
     getLlama: vi.fn().mockResolvedValue(mockLlama),
+    LlamaLogLevel: {
+      fatal: "fatal",
+    },
   };
 });
 

--- a/tests/ts/unit/integrations/subprocess/runner.test.ts
+++ b/tests/ts/unit/integrations/subprocess/runner.test.ts
@@ -117,26 +117,11 @@ describe("createRealSubprocessRunner", () => {
 		writeFileSync(
 			codexScript,
 			[
-				"#!/usr/bin/env node",
-				'let input = "";',
-				"let approvalShown = false;",
-				'process.stdin.setEncoding("utf8");',
-				'process.stdin.on("data", (chunk) => {',
-				"  input += chunk;",
-				"  if (!approvalShown) {",
-				"    approvalShown = true;",
-				"    process.stdout.write('approval required\\n');",
-				"    return;",
-				"  }",
-				"  if (chunk.replace(/\\s+/g, '').toLowerCase().includes('y')) {",
-				"    process.stdout.write('approved\\n');",
-				"    process.exit(0);",
-				"  }",
-				"});",
-				'process.stdin.on("end", () => {',
-				"  process.stdout.write('stdin-ended\\n');",
-				"});",
-				"process.stdin.resume();",
+				"#!/bin/sh",
+				"prompt=$(cat)",
+				"printf 'approval required\\n'",
+				"IFS= read -r answer < /dev/tty",
+				"printf 'prompt:%s\\nanswer:%s\\n' \"$prompt\" \"$answer\"",
 			].join("\n"),
 			"utf8",
 		);
@@ -159,7 +144,7 @@ describe("createRealSubprocessRunner", () => {
 				}
 			},
 		});
-		const resultPromise = runner.runWithTranscript({
+		const result = await runner.runWithTranscript({
 			command: "codex",
 			args: ["exec", "-", "--sandbox", "workspace-write"],
 			input: "hello",
@@ -170,15 +155,10 @@ describe("createRealSubprocessRunner", () => {
 			},
 		});
 
-		await new Promise((resolve) => setTimeout(resolve, 50));
-		expect(capturedController).not.toBeNull();
-		capturedController!.write("y\r");
-		const result = await resultPromise;
-
 		expect(result.exitCode).toBe(0);
 		expect(result.stdout).toContain("approval required");
-		expect(result.stdout).toContain("approved");
-		expect(result.stdout).not.toContain("stdin-ended");
+		expect(result.stdout).toContain("prompt:hello");
+		expect(result.stdout).toContain("answer:y");
 	}, 10_000);
 
 	it("streams Codex JSON output without waiting for a PTY wrapper", async () => {


### PR DESCRIPTION
## Summary

TUI가 실행 중인 동안 두 가지 출력이 `stderr`로 직접 흘러나와 화면을 오염시키는 문제를 수정합니다.

### 문제 1: cmake 경고 메시지 (`CMake Warning: OpenMP not found` 등)

`progressLogs: false` 옵션은 cmake 자식 프로세스의 **stdout만** 억제하고 stderr는 항상 통과시키는 node-llama-cpp 내부 구현(`spawnCommand.js`) 문제가 원인입니다. cmake 자체의 `message(WARNING ...)` 출력은 외부에서 제어할 수 없어 `process.stderr.write`를 `getLlama()` 호출 구간 동안 임시 무음 처리하는 `suppressStderr` 헬퍼로 우회합니다.

### 문제 2: `[detoks]` 첫 실행 안내 메시지

`orchestrator.ts`의 `maybeShowFirstRunNotice()`가 첫 파이프라인 실행 시 `process.stderr.write()`로 4줄을 직접 출력했습니다. TUI가 이미 떠 있는 상태에서 실행되어 화면을 오염시켰습니다.

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `src/core/llm-client/node-llama-runtime.ts` | `suppressStderr()` 헬퍼 추가, `getLlama` IIFE 전체를 `.finally(restoreStderr)` 로 감쌈 |
| `src/core/rag/embedding-service.ts` | `getLlama` 호출을 인라인 stderr 억제로 감쌈 |
| `src/core/pipeline/orchestrator.ts` | `maybeShowFirstRunNotice`의 `process.stderr.write` 제거 → `onProgress` 콜백으로 `PipelineProgressEvent { status: "info" }` emit |

## Reviewer Notes

- `suppressStderr`는 async 작업 전후로만 적용되며 `finally`로 항상 복구되어 누수 없음
- `[detoks]` 안내 4줄은 기존 `PipelineStatusPanel`의 `info` 이벤트 렌더링(주황색 ●)을 그대로 재사용 — TUI 수정 없음
- 이 브랜치에는 앞선 커밋들(llama build spinner, 첫 실행 준비 중 메시지, ggml warn 억제 등)도 포함되어 있음