### PR TITLE
refactor(tui): 이벤트 라우터 + 선언형 레이아웃 스키마 도입 (P0-2, P0-4)

### DIFF
--- a/src/cli/tui/event-router.ts
+++ b/src/cli/tui/event-router.ts
@@ -1,0 +1,52 @@
+import type { PipelineProgressEvent } from "../../core/pipeline/types.js";
+import type { ActionTimelineEvent } from "../../core/timeline/types.js";
+import type { PtyEvent } from "../../integrations/subprocess/types.js";
+import type { PipelineStatusPanel } from "./panels/pipeline-status.js";
+import type { TranscriptPanel } from "./panels/transcript.js";
+import type { EmbeddedTerminalPane } from "./panels/embedded-terminal.js";
+
+export type AdapterTranscriptSink = "transcript" | "embedded";
+
+export interface RouterSubscribers {
+  pipelinePanel: PipelineStatusPanel;
+  transcriptPanel: TranscriptPanel;
+  // Getter — the embedded pane reference can be swapped at runtime when a
+  // new conversation block starts. Resolving lazily avoids stale references.
+  getEmbeddedTerminalPane: () => EmbeddedTerminalPane;
+}
+
+/**
+ * Centralizes pipeline → panel event dispatch.
+ *
+ * P0 contract: pure forwarding to existing panel methods. No mode logic, no
+ * render scheduling — those remain in index.ts. This is the seam where P1
+ * subscribers (cache live stream, RAG summary, task DAG, etc.) will plug in.
+ */
+export class TuiEventRouter {
+  constructor(private readonly subs: RouterSubscribers) {}
+
+  routePipelineProgress(event: PipelineProgressEvent): void {
+    this.subs.pipelinePanel.update(event);
+  }
+
+  routeActionTimeline(event: ActionTimelineEvent): void {
+    this.subs.pipelinePanel.updateActionTimelineEvent(event);
+  }
+
+  routeAdapterEvent(event: PtyEvent, sink: AdapterTranscriptSink): void {
+    if (sink === "embedded") {
+      this.subs.getEmbeddedTerminalPane().addEvent(event);
+    } else {
+      this.subs.transcriptPanel.addEvent(event);
+    }
+  }
+
+  routeAdapterEventBatch(
+    events: readonly PtyEvent[],
+    sink: AdapterTranscriptSink,
+  ): void {
+    for (const event of events) {
+      this.routeAdapterEvent(event, sink);
+    }
+  }
+}

--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -30,6 +30,7 @@ import { TranscriptPanel } from "./panels/transcript.js";
 import { ResultSummaryPanel } from "./panels/result-summary.js";
 import { EmbeddedTerminalPane } from "./panels/embedded-terminal.js";
 import { renderSlashAutocompletePanel } from "./panels/slash-autocomplete.js";
+import { TuiEventRouter } from "./event-router.js";
 import {
   createEmbeddedTerminalFocusManager,
   isEmbeddedTerminalInterruptKey,
@@ -235,6 +236,11 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     const transcriptPanel = new TranscriptPanel();
     const resultPanel = new ResultSummaryPanel();
     let embeddedTerminalPane = new EmbeddedTerminalPane();
+    const eventRouter = new TuiEventRouter({
+      pipelinePanel,
+      transcriptPanel,
+      getEmbeddedTerminalPane: () => embeddedTerminalPane,
+    });
     const embeddedTerminalFocus = createEmbeddedTerminalFocusManager();
     let hasExecuted = false;
     let lastInputSeparatorRow = -1;
@@ -706,7 +712,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         ...(currentAdapterModel !== undefined ? { model: currentAdapterModel } : {}),
         ...(options.sessionId !== undefined ? { sessionId: options.sessionId } : {}),
         onEvent: (event) => {
-          embeddedTerminalPane.addEvent(event);
+          eventRouter.routeAdapterEvent(event, "embedded");
           render();
         },
       });
@@ -950,7 +956,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     let lastProgressRenderAt = 0;
     const PROGRESS_RENDER_INTERVAL_MS = 200;
     const onProgress = (event: PipelineProgressEvent): void => {
-      pipelinePanel.update(event);
+      eventRouter.routePipelineProgress(event);
       if (nativePassthroughMode && isExecuting) {
         return;
       }
@@ -1547,7 +1553,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
             }
 
             if (embeddedPaneMode) {
-              embeddedTerminalPane.addEvent(event);
+              eventRouter.routeAdapterEvent(event, "embedded");
               const interactionState = embeddedTerminalPane.getInteractionState();
               if (
                 interactionState?.kind === "approval" &&
@@ -1556,12 +1562,12 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
                 embeddedTerminalFocus.focusNative();
               }
             } else {
-              transcriptPanel.addEvent(event);
+              eventRouter.routeAdapterEvent(event, "transcript");
             }
             render();
           },
           onActionTimelineEvent: (event) => {
-            pipelinePanel.updateActionTimelineEvent(event);
+            eventRouter.routeActionTimeline(event);
             if (!nativePassthroughMode || !isExecuting) {
               render();
             }
@@ -1570,13 +1576,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
 
         // Phase 3.3: Feed PTY events to transcript panel
         if (!receivedLiveAdapterEvents && result.adapterTranscript?.events) {
-          for (const event of result.adapterTranscript.events) {
-            if (embeddedPaneMode) {
-              embeddedTerminalPane.addEvent(event);
-            } else {
-              transcriptPanel.addEvent(event);
-            }
-          }
+          eventRouter.routeAdapterEventBatch(
+            result.adapterTranscript.events,
+            embeddedPaneMode ? "embedded" : "transcript",
+          );
         }
 
         const hasVisibleOutput = embeddedPaneMode

--- a/src/cli/tui/layout-manager.ts
+++ b/src/cli/tui/layout-manager.ts
@@ -9,61 +9,146 @@ export interface PanelRegion {
 export interface LayoutConfig {
   rows: number;
   columns: number;
-  headerRegion: PanelRegion; // 제목 + 구분선 (3줄)
-  statusPanelRegion: PanelRegion; // 파이프라인 상태 (고정 8줄)
-  transcriptRegion: PanelRegion; // 실시간 출력 (가변)
-  resultRegion: PanelRegion; // 결과 요약 (가변)
-  inputRegion: PanelRegion; // 입력 + 푸터 (3줄)
+  headerRegion: PanelRegion;
+  statusPanelRegion: PanelRegion;
+  transcriptRegion: PanelRegion;
+  resultRegion: PanelRegion;
+  inputRegion: PanelRegion;
 }
 
-const MIN_TRANSCRIPT_ROWS = 5;
-const STATUS_PANEL_ROWS = 8; // 파이프라인 상태 + 옵션
-const HEADER_ROWS = 3; // 제목 + 구분선
-const INPUT_ROWS = 3; // 구분선 + 입력 + 푸터
+export type PanelMode = "fixed" | "flex";
+
+export interface PanelDef {
+  id: string;
+  mode: PanelMode;
+  rows?: number;     // mode="fixed"
+  weight?: number;   // mode="flex"
+  minRows?: number;  // mode="flex"
+}
+
+// Default schema preserves the historical 3 / 8 / 70% / 30% / 3 layout.
+// Order matters: panels before the first flex panel are anchored top-down,
+// panels after the last flex panel are anchored bottom-up. Flex panels fill
+// the remaining gap (which may be negative on very small terminals — that
+// historical quirk is preserved).
+export const DEFAULT_LAYOUT_SCHEMA: readonly PanelDef[] = [
+  { id: "header",     mode: "fixed", rows: 3 },
+  { id: "status",     mode: "fixed", rows: 8 },
+  { id: "transcript", mode: "flex",  weight: 7, minRows: 5 },
+  { id: "result",     mode: "flex",  weight: 3, minRows: 0 },
+  { id: "input",      mode: "fixed", rows: 3 },
+];
+
+const findFirstFlexIndex = (schema: readonly PanelDef[]): number =>
+  schema.findIndex((p) => p.mode === "flex");
+
+const findLastFlexIndex = (schema: readonly PanelDef[]): number => {
+  for (let i = schema.length - 1; i >= 0; i -= 1) {
+    if (schema[i]!.mode === "flex") return i;
+  }
+  return -1;
+};
+
+export const computeLayoutRegions = (
+  dims: ScreenDimensions,
+  schema: readonly PanelDef[] = DEFAULT_LAYOUT_SCHEMA,
+): Map<string, PanelRegion> => {
+  const { rows, columns } = dims;
+  const result = new Map<string, PanelRegion>();
+
+  const firstFlex = findFirstFlexIndex(schema);
+  const lastFlex = findLastFlexIndex(schema);
+
+  // No flex panels: pure fixed allocation top-down.
+  if (firstFlex === -1) {
+    let cursor = 0;
+    for (const panel of schema) {
+      const allocated = panel.rows ?? 0;
+      result.set(panel.id, { startRow: cursor, endRow: cursor + allocated, columns });
+      cursor += allocated;
+    }
+    return result;
+  }
+
+  // 1) Top fixed panels — anchored to row 0, growing downward.
+  let topCursor = 0;
+  for (let i = 0; i < firstFlex; i += 1) {
+    const panel = schema[i]!;
+    const allocated = panel.rows ?? 0;
+    result.set(panel.id, { startRow: topCursor, endRow: topCursor + allocated, columns });
+    topCursor += allocated;
+  }
+
+  // 2) Bottom fixed panels — anchored to dims.rows, growing upward.
+  const bottomFixed = schema.slice(lastFlex + 1);
+  const bottomFixedTotal = bottomFixed.reduce((sum, p) => sum + (p.rows ?? 0), 0);
+  const bottomStart = rows - bottomFixedTotal;
+
+  // 3) Flex panels fill the gap between top fixed and bottom fixed.
+  const flexPanels = schema.slice(firstFlex, lastFlex + 1);
+  const available = bottomStart - topCursor;
+  const totalWeight = flexPanels.reduce((sum, p) => sum + (p.weight ?? 0), 0);
+
+  const flexAllocations = new Map<string, number>();
+  let allocatedFlex = 0;
+  flexPanels.forEach((panel, index) => {
+    let allocation = totalWeight > 0
+      ? Math.floor((available * (panel.weight ?? 0)) / totalWeight)
+      : 0;
+    if (index === 0 && panel.minRows !== undefined) {
+      allocation = Math.max(panel.minRows, allocation);
+    }
+    flexAllocations.set(panel.id, allocation);
+    allocatedFlex += allocation;
+  });
+
+  // Last flex panel absorbs the rounding remainder so flex panels tile exactly.
+  if (flexPanels.length > 0) {
+    const last = flexPanels[flexPanels.length - 1]!;
+    const adjusted = Math.max(
+      last.minRows ?? 0,
+      (flexAllocations.get(last.id) ?? 0) + (available - allocatedFlex),
+    );
+    flexAllocations.set(last.id, adjusted);
+  }
+
+  // Place flex panels sequentially starting at topCursor.
+  let flexCursor = topCursor;
+  for (const panel of flexPanels) {
+    const allocated = flexAllocations.get(panel.id) ?? 0;
+    result.set(panel.id, {
+      startRow: flexCursor,
+      endRow: flexCursor + allocated,
+      columns,
+    });
+    flexCursor += allocated;
+  }
+
+  // 4) Place bottom fixed panels anchored to dims.rows.
+  let bottomCursor = bottomStart;
+  for (const panel of bottomFixed) {
+    const allocated = panel.rows ?? 0;
+    result.set(panel.id, {
+      startRow: bottomCursor,
+      endRow: bottomCursor + allocated,
+      columns,
+    });
+    bottomCursor += allocated;
+  }
+
+  return result;
+};
 
 export const computeLayout = (dims: ScreenDimensions): LayoutConfig => {
-  const { rows, columns } = dims;
-
-  // 최소 필요 높이: header + status + input + min_transcript
-  const minRequired = HEADER_ROWS + STATUS_PANEL_ROWS + INPUT_ROWS + MIN_TRANSCRIPT_ROWS;
-
-  let headerStartRow = 0;
-  let statusStartRow = headerStartRow + HEADER_ROWS;
-  let inputStartRow = rows - INPUT_ROWS;
-
-  // 가용 공간을 transcript와 result 사이에 분배
-  const availableForContent = inputStartRow - statusStartRow - STATUS_PANEL_ROWS;
-  const transcriptRows = Math.max(MIN_TRANSCRIPT_ROWS, Math.floor(availableForContent * 0.7));
-  const resultRows = Math.max(0, availableForContent - transcriptRows);
-
+  const regions = computeLayoutRegions(dims);
   return {
-    rows,
-    columns,
-    headerRegion: {
-      startRow: headerStartRow,
-      endRow: statusStartRow,
-      columns,
-    },
-    statusPanelRegion: {
-      startRow: statusStartRow,
-      endRow: statusStartRow + STATUS_PANEL_ROWS,
-      columns,
-    },
-    transcriptRegion: {
-      startRow: statusStartRow + STATUS_PANEL_ROWS,
-      endRow: statusStartRow + STATUS_PANEL_ROWS + transcriptRows,
-      columns,
-    },
-    resultRegion: {
-      startRow: statusStartRow + STATUS_PANEL_ROWS + transcriptRows,
-      endRow: inputStartRow,
-      columns,
-    },
-    inputRegion: {
-      startRow: inputStartRow,
-      endRow: rows,
-      columns,
-    },
+    rows: dims.rows,
+    columns: dims.columns,
+    headerRegion: regions.get("header")!,
+    statusPanelRegion: regions.get("status")!,
+    transcriptRegion: regions.get("transcript")!,
+    resultRegion: regions.get("result")!,
+    inputRegion: regions.get("input")!,
   };
 };
 
@@ -73,8 +158,6 @@ export const getPanelHeight = (region: PanelRegion): number => {
 
 export const getContentArea = (region: PanelRegion): { usableWidth: number; usableHeight: number } => {
   return {
-    // Panel regions already represent the drawable content area in the current TUI.
-    // Avoid subtracting extra "border" padding here so panes use the full width/height.
     usableWidth: Math.max(0, region.columns),
     usableHeight: Math.max(0, getPanelHeight(region)),
   };

--- a/tests/ts/unit/cli/tui/event-router.test.ts
+++ b/tests/ts/unit/cli/tui/event-router.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { TuiEventRouter, type RouterSubscribers } from "../../../../../src/cli/tui/event-router.js";
+import type { PipelineProgressEvent } from "../../../../../src/core/pipeline/types.js";
+import type { ActionTimelineEvent } from "../../../../../src/core/timeline/types.js";
+import type { PtyEvent } from "../../../../../src/integrations/subprocess/types.js";
+
+const makeSubs = () => {
+  const pipelinePanel = {
+    update: vi.fn(),
+    updateActionTimelineEvent: vi.fn(),
+  };
+  const transcriptPanel = { addEvent: vi.fn() };
+  const embeddedPane = { addEvent: vi.fn() };
+  const subs: RouterSubscribers = {
+    pipelinePanel: pipelinePanel as any,
+    transcriptPanel: transcriptPanel as any,
+    getEmbeddedTerminalPane: () => embeddedPane as any,
+  };
+  return { subs, pipelinePanel, transcriptPanel, embeddedPane };
+};
+
+describe("TuiEventRouter", () => {
+  it("routes pipeline progress to the pipeline panel only", () => {
+    const { subs, pipelinePanel, transcriptPanel, embeddedPane } = makeSubs();
+    const router = new TuiEventRouter(subs);
+    const event: PipelineProgressEvent = {
+      stage: "Prompt Compiler",
+      status: "end",
+      message: "ok",
+    };
+    router.routePipelineProgress(event);
+    expect(pipelinePanel.update).toHaveBeenCalledWith(event);
+    expect(transcriptPanel.addEvent).not.toHaveBeenCalled();
+    expect(embeddedPane.addEvent).not.toHaveBeenCalled();
+  });
+
+  it("routes action-timeline events to the pipeline panel", () => {
+    const { subs, pipelinePanel, transcriptPanel, embeddedPane } = makeSubs();
+    const router = new TuiEventRouter(subs);
+    const event: ActionTimelineEvent = {
+      kind: "cache_hit",
+      source: "pipeline",
+      summary: "x",
+    } as ActionTimelineEvent;
+    router.routeActionTimeline(event);
+    expect(pipelinePanel.updateActionTimelineEvent).toHaveBeenCalledWith(event);
+    expect(transcriptPanel.addEvent).not.toHaveBeenCalled();
+    expect(embeddedPane.addEvent).not.toHaveBeenCalled();
+  });
+
+  it("routes adapter events to transcript sink when requested", () => {
+    const { subs, transcriptPanel, embeddedPane } = makeSubs();
+    const router = new TuiEventRouter(subs);
+    const event: PtyEvent = { type: "chunk", stream: "stdout", data: "hi" } as PtyEvent;
+    router.routeAdapterEvent(event, "transcript");
+    expect(transcriptPanel.addEvent).toHaveBeenCalledWith(event);
+    expect(embeddedPane.addEvent).not.toHaveBeenCalled();
+  });
+
+  it("routes adapter events to embedded sink when requested", () => {
+    const { subs, transcriptPanel, embeddedPane } = makeSubs();
+    const router = new TuiEventRouter(subs);
+    const event: PtyEvent = { type: "chunk", stream: "stdout", data: "hi" } as PtyEvent;
+    router.routeAdapterEvent(event, "embedded");
+    expect(embeddedPane.addEvent).toHaveBeenCalledWith(event);
+    expect(transcriptPanel.addEvent).not.toHaveBeenCalled();
+  });
+
+  it("re-resolves the embedded pane through the getter on each call", () => {
+    let currentPane = { addEvent: vi.fn() };
+    const newPane = { addEvent: vi.fn() };
+    const subs: RouterSubscribers = {
+      pipelinePanel: { update: vi.fn(), updateActionTimelineEvent: vi.fn() } as any,
+      transcriptPanel: { addEvent: vi.fn() } as any,
+      getEmbeddedTerminalPane: () => currentPane as any,
+    };
+    const router = new TuiEventRouter(subs);
+    const event: PtyEvent = { type: "chunk", stream: "stdout", data: "a" } as PtyEvent;
+
+    router.routeAdapterEvent(event, "embedded");
+    expect(currentPane.addEvent).toHaveBeenCalledWith(event);
+
+    // Swap the pane (simulates a new conversation block) and dispatch again.
+    currentPane = newPane;
+    router.routeAdapterEvent(event, "embedded");
+    expect(newPane.addEvent).toHaveBeenCalledWith(event);
+  });
+
+  it("batches adapter events to the chosen sink", () => {
+    const { subs, transcriptPanel, embeddedPane } = makeSubs();
+    const router = new TuiEventRouter(subs);
+    const events: PtyEvent[] = [
+      { type: "chunk", stream: "stdout", data: "a" } as PtyEvent,
+      { type: "chunk", stream: "stdout", data: "b" } as PtyEvent,
+      { type: "exit", exitCode: 0 } as unknown as PtyEvent,
+    ];
+    router.routeAdapterEventBatch(events, "transcript");
+    expect(transcriptPanel.addEvent).toHaveBeenCalledTimes(3);
+    expect(embeddedPane.addEvent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ts/unit/cli/tui/layout-manager.test.ts
+++ b/tests/ts/unit/cli/tui/layout-manager.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { computeLayout, getPanelHeight, getContentArea } from "../../../../../src/cli/tui/layout-manager.js";
+import {
+  DEFAULT_LAYOUT_SCHEMA,
+  computeLayout,
+  computeLayoutRegions,
+  getContentArea,
+  getPanelHeight,
+  type PanelDef,
+} from "../../../../../src/cli/tui/layout-manager.js";
 
 describe("layout-manager", () => {
   describe("computeLayout", () => {
@@ -95,6 +102,88 @@ describe("layout-manager", () => {
       const region = { startRow: 5, endRow: 5, columns: 80 };
       expect(getPanelHeight(region)).toBe(0);
     });
+  });
+
+  describe("declarative schema", () => {
+    it("exposes the default schema with 5 named panels in the expected order", () => {
+      const ids = DEFAULT_LAYOUT_SCHEMA.map((p) => p.id);
+      expect(ids).toEqual(["header", "status", "transcript", "result", "input"]);
+    });
+
+    it("computeLayoutRegions returns a region for every schema panel", () => {
+      const regions = computeLayoutRegions({ rows: 30, columns: 100 });
+      for (const panel of DEFAULT_LAYOUT_SCHEMA) {
+        expect(regions.has(panel.id)).toBe(true);
+      }
+    });
+
+    it("flex panels tile exactly between top-fixed and bottom-fixed regions", () => {
+      const regions = computeLayoutRegions({ rows: 30, columns: 100 });
+      const transcript = regions.get("transcript")!;
+      const result = regions.get("result")!;
+      const status = regions.get("status")!;
+      const input = regions.get("input")!;
+      expect(transcript.startRow).toBe(status.endRow);
+      expect(transcript.endRow).toBe(result.startRow);
+      expect(result.endRow).toBe(input.startRow);
+    });
+
+    it("supports a custom schema with a different flex split", () => {
+      const schema: PanelDef[] = [
+        { id: "top", mode: "fixed", rows: 2 },
+        { id: "main", mode: "flex", weight: 1, minRows: 0 },
+        { id: "bottom", mode: "fixed", rows: 1 },
+      ];
+      const regions = computeLayoutRegions({ rows: 10, columns: 40 }, schema);
+      expect(regions.get("top")).toEqual({ startRow: 0, endRow: 2, columns: 40 });
+      expect(regions.get("main")).toEqual({ startRow: 2, endRow: 9, columns: 40 });
+      expect(regions.get("bottom")).toEqual({ startRow: 9, endRow: 10, columns: 40 });
+    });
+
+    it("handles schemas with multiple flex panels by weight", () => {
+      const schema: PanelDef[] = [
+        { id: "a", mode: "flex", weight: 1, minRows: 0 },
+        { id: "b", mode: "flex", weight: 3, minRows: 0 },
+      ];
+      const regions = computeLayoutRegions({ rows: 20, columns: 50 }, schema);
+      const a = regions.get("a")!;
+      const b = regions.get("b")!;
+      expect(getPanelHeight(a)).toBe(5);
+      expect(getPanelHeight(b)).toBe(15);
+      expect(a.endRow).toBe(b.startRow);
+    });
+
+    it("handles a schema with no flex panels (all fixed)", () => {
+      const schema: PanelDef[] = [
+        { id: "x", mode: "fixed", rows: 4 },
+        { id: "y", mode: "fixed", rows: 3 },
+      ];
+      const regions = computeLayoutRegions({ rows: 24, columns: 80 }, schema);
+      expect(regions.get("x")).toEqual({ startRow: 0, endRow: 4, columns: 80 });
+      expect(regions.get("y")).toEqual({ startRow: 4, endRow: 7, columns: 80 });
+    });
+  });
+
+  describe("size scenario matrix", () => {
+    const scenarios: Array<{ rows: number; columns: number }> = [
+      { rows: 24, columns: 80 },
+      { rows: 30, columns: 120 },
+      { rows: 50, columns: 200 },
+      { rows: 60, columns: 100 },
+      { rows: 20, columns: 60 },
+    ];
+
+    for (const { rows, columns } of scenarios) {
+      it(`tiles all regions without gaps for ${rows}x${columns}`, () => {
+        const layout = computeLayout({ rows, columns });
+        expect(layout.headerRegion.endRow).toBe(layout.statusPanelRegion.startRow);
+        expect(layout.statusPanelRegion.endRow).toBe(layout.transcriptRegion.startRow);
+        expect(layout.transcriptRegion.endRow).toBe(layout.resultRegion.startRow);
+        expect(layout.resultRegion.endRow).toBe(layout.inputRegion.startRow);
+        expect(layout.inputRegion.endRow).toBe(rows);
+        expect(layout.headerRegion.startRow).toBe(0);
+      });
+    }
   });
 
   describe("getContentArea", () => {


### PR DESCRIPTION
## Summary

TUI UI/UX 개선 로드맵의 **PR2 / 6**. 시각 변화 없는 순수 리팩토링.

- **P0-2**: `TuiEventRouter` 도입 — `PipelineProgress` / `ActionTimeline` / `PtyEvent` (adapter) 디스패치를 한 곳에서 관장. 새로운 panel·subscriber 가 추가될 때 라우터에만 등록하면 됨.
- **P0-4**: `layout-manager.ts` 를 선언형 `PanelDef[]` 스키마로 전환. 70/30 split 이 더 이상 하드코딩이 아니고, `DEFAULT_LAYOUT_SCHEMA` 한 줄 수정으로 panel 추가/순서 변경/숨김 가능.
- `src/cli/tui/index.ts` 의 4곳 직접 dispatch 를 라우터 경유로 교체.

## Why

[PR #283 (PR1)](https://github.com/tok-it/detoks/pull/283) 의 후속. P1(숨겨진 데이터 시각화)·P2(시각 폴리시)·P3(resizable panel 등) 가 추가될 때 매번 1,688 줄짜리 `index.ts` 와 명령형 `layout-manager.ts` 를 건드려야 하는 구조였음. 이벤트 라우팅과 레이아웃을 정형화하면 후속 PR 의 surface area 가 크게 줄어듦.

## Changes

| 파일 | 변경 내용 |
|---|---|
| `src/cli/tui/event-router.ts` | 신규 — `TuiEventRouter` 클래스, 4 routing 메서드 + lazy embedded pane getter |
| `src/cli/tui/layout-manager.ts` | `PanelDef` 스키마 + `computeLayoutRegions(dims, schema?)` 신규. 기존 `computeLayout` / `LayoutConfig` API 100% 호환. top-fixed / flex / bottom-fixed 3-구간 할당으로 historical edge case 보존. |
| `src/cli/tui/index.ts` | `onProgress` / `onAdapterEvent` (live) / `onActionTimelineEvent` / `embeddedNativeCliSession.onEvent` / batch dispatch 5 곳을 라우터 경유로 교체 |
| `tests/ts/unit/cli/tui/event-router.test.ts` | 신규 — 6 tests (각 routing 메서드 + getter 재해상 + 배치) |
| `tests/ts/unit/cli/tui/layout-manager.test.ts` | 10 → 21 tests (declarative schema 검증 6 + size matrix 5) |

## Reviewer Notes

- **시각/동작 변화 0**: 165개 TUI 단위 테스트 모두 통과 (router 6 + layout 21 신규 포함).
- **`getEmbeddedTerminalPane` 가 getter 인 이유**: `embeddedTerminalPane` 는 conversation block 시작마다 새 인스턴스로 swap 됨 (`src/cli/tui/index.ts:319`). 직접 참조하면 stale ref 가 됨. lazy 해상으로 항상 현재 인스턴스로 dispatch.
- **레이아웃 알고리즘의 historical quirk 보존**:
  - 작은 터미널(예: 10×40)에서 input region 이 bottom-up anchor → `transcriptRegion` 이 input 과 겹치는 broken state 그대로 보존 (기존 동작).
  - 첫 flex panel(transcript) 의 `minRows: 5` floor 보존.
  - last flex panel(result) 이 rounding remainder 흡수.
- **mode/focus 로직은 라우터 밖**: 라우터는 pure dispatch. embedded 모드 판단·approval focus 전환·렌더 스케줄링은 `index.ts` 에 유지 (책임 분리).

## Dependency

이 PR 자체는 dev 에 바로 머지 가능. PR #283 (PR1) 과는 독립이지만, 머지 순서에 따라 사소한 import 충돌 가능 (둘 다 `src/cli/tui/panels/*` 와 `src/cli/tui/index.ts` 를 손댐). PR #283 먼저 머지 후 본 PR 은 충돌 없이 통과할 것으로 예상.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- --run tests/ts/unit/cli/tui/` — 16 files, 165 tests 통과
- [x] 신규 router 6 + layout 11 추가 tests 통과
- [ ] PR #283 머지 후 rebase (예상 충돌 없음)
- [ ] 실 터미널 수동 검증 (P3 머지 전 일괄): codex/gemini 실행 시 동일 출력

🤖 Generated with [Claude Code](https://claude.com/claude-code)