### PR TITLE
feat(tui): 시각 폴리시 — empty state CTA · truncation marker · stage 시간 (P2-2~P2-5)

### DIFF
--- a/src/cli/tui/design/tokens.ts
+++ b/src/cli/tui/design/tokens.ts
@@ -53,6 +53,13 @@ export const glyph = {
   changeDelete: "-",
   changeRename: "→",
   changeUpdate: "~",
+  // Cache lifecycle markers — used by upcoming P1 cache live stream.
+  cacheHit: "▣",
+  cacheMiss: "▢",
+  cacheAdvise: "⚠",
+  // RAG markers — used by upcoming P1 RAG context summary in result panel.
+  ragInjected: "ⓘ",
+  ragSkipped: "○",
 } as const;
 
 export const spacing = {

--- a/src/cli/tui/panels/base.ts
+++ b/src/cli/tui/panels/base.ts
@@ -100,3 +100,11 @@ export const truncateByDisplayWidth = (
   line: string,
   maxWidth: number,
 ): string => ellipsisRight(line, maxWidth, glyph.ellipsisOneChar);
+
+// Marker text for hidden lines above/below a scrolled viewport.
+// Returns empty string when count <= 0; callers should skip rendering in that case.
+export const formatHiddenAboveMarker = (count: number): string =>
+  count > 0 ? `${glyph.ellipsisOneChar} ↑ ${count}줄 위` : "";
+
+export const formatHiddenBelowMarker = (count: number): string =>
+  count > 0 ? `${glyph.ellipsisOneChar} ↓ ${count}줄 아래` : "";

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -14,6 +14,8 @@ const EMBEDDED_PANE_SCROLLBACK_LIMIT = 500;
 const EMPTY_PANE_LINES = [
   "원본 CLI 출력이 이 영역에 표시됩니다.",
   "PTY 이벤트가 들어오면 버퍼를 이 패널에 렌더링합니다.",
+  "",
+  "Ctrl+T 어댑터 터미널 포커스 전환  ·  Esc / Ctrl+G detoks 입력으로 복귀",
 ] as const;
 
 const truncateToWidth = (line: string, maxWidth: number): string => {

--- a/src/cli/tui/panels/pipeline-status.ts
+++ b/src/cli/tui/panels/pipeline-status.ts
@@ -11,7 +11,14 @@ interface StageStatus {
   status: PipelineProgressStatus;
   message: string;
   timestamp: number;
+  startedAt?: number;
+  endedAt?: number;
 }
+
+const formatStageDuration = (durationMs: number): string => {
+  if (durationMs < 1000) return `${durationMs}ms`;
+  return `${(durationMs / 1000).toFixed(1)}s`;
+};
 
 const STATUS_ICONS: Record<PipelineProgressStatus, string> = {
   end: glyph.done,
@@ -54,11 +61,22 @@ export class PipelineStatusPanel {
   }
 
   update(event: PipelineProgressEvent): void {
-    this.stages.set(event.stage, {
+    const now = Date.now();
+    const prev = this.stages.get(event.stage);
+    const next: StageStatus = {
       status: event.status,
       message: event.message,
-      timestamp: Date.now(),
-    });
+      timestamp: now,
+      ...(prev?.startedAt !== undefined ? { startedAt: prev.startedAt } : {}),
+      ...(prev?.endedAt !== undefined ? { endedAt: prev.endedAt } : {}),
+    };
+    if (event.status === "start") {
+      next.startedAt = now;
+      delete next.endedAt;
+    } else if (event.status === "end" || event.status === "error") {
+      next.endedAt = now;
+    }
+    this.stages.set(event.stage, next);
   }
 
   updateActionTimelineEvent(event: ActionTimelineEvent): void {
@@ -76,11 +94,12 @@ export class PipelineStatusPanel {
   }
 
   reset(): void {
+    const now = Date.now();
     for (const stageName of STAGE_ORDER) {
       this.stages.set(stageName, {
         status: "start",
         message: "준비",
-        timestamp: Date.now(),
+        timestamp: now,
       });
     }
     this.latestWorkState = null;
@@ -141,10 +160,13 @@ export class PipelineStatusPanel {
       if (!stageStatus) continue;
 
       const icon = STATUS_ICONS[stageStatus.status];
+      const durationLabel = stageStatus.startedAt !== undefined && stageStatus.endedAt !== undefined
+        ? `  ${formatStageDuration(stageStatus.endedAt - stageStatus.startedAt)}`
+        : "";
       writePaddedLine(
         ctx,
         currentRow,
-        `${icon} ${stageName}`,
+        `${icon} ${stageName}${durationLabel}`,
         usableWidth,
         STATUS_STYLES[stageStatus.status],
       );

--- a/src/cli/tui/panels/result-summary.ts
+++ b/src/cli/tui/panels/result-summary.ts
@@ -10,6 +10,8 @@ import { glyph, statusColor } from "../design/tokens.js";
 const EMPTY_RESULT_LINES = [
   "실행 결과가 아직 없습니다.",
   "첫 실행 이후 작업 타임라인 · 다음 작업 · 사용량/압축 지표가 이 영역에 표시됩니다.",
+  "",
+  "이전 세션 보기: /session list  ·  특정 세션 이어가기: /session continue <id>",
 ] as const;
 
 export class ResultSummaryPanel {

--- a/src/cli/tui/panels/transcript.ts
+++ b/src/cli/tui/panels/transcript.ts
@@ -4,13 +4,19 @@ import type { PtyEvent } from "../../../integrations/subprocess/types.js";
 import type { ActionTimelineEvent } from "../../../core/timeline/types.js";
 import { getContentArea, getPanelHeight } from "../layout-manager.js";
 import { padDisplayWidth } from "../renderer.js";
-import { fillRemaining, truncateByLength } from "./base.js";
+import {
+  fillRemaining,
+  formatHiddenAboveMarker,
+  formatHiddenBelowMarker,
+  truncateByLength,
+} from "./base.js";
 import { statusColor } from "../design/tokens.js";
 
 const EMPTY_TRANSCRIPT_LINES = [
   "실행 기록이 아직 없습니다.",
   "명령을 실행하면 원본 CLI 출력이 이 영역에 표시됩니다.",
-  "↑/↓ 로 이전 출력 스크롤",
+  "",
+  "↑/↓ 이전 출력 스크롤  ·  PageUp/Down 빠른 이동  ·  /help 로 명령 보기",
 ] as const;
 
 const CODEX_LIFECYCLE_TYPES = new Set([
@@ -52,7 +58,7 @@ const sanitizeText = (value: string): string => stripControlSequences(value).rep
 
 const truncateLine = truncateByLength;
 
-type TranscriptEntryKind = "tool" | "validation" | "git" | "edit" | "final" | "diagnostic" | "recap" | "raw";
+type TranscriptEntryKind = "tool" | "validation" | "git" | "edit" | "final" | "diagnostic" | "recap" | "raw" | "marker";
 
 interface TranscriptEntry {
   kind: TranscriptEntryKind;
@@ -701,7 +707,25 @@ export class TranscriptPanel {
     );
     const endIdx = sourceEntries.length - effectiveScrollOffset;
     const startIdx = Math.max(0, endIdx - usableHeight);
-    const visibleEntries = sourceEntries.slice(startIdx, endIdx);
+    let visibleEntries = sourceEntries.slice(startIdx, endIdx);
+
+    // Truncation markers — only when content overflows (not in empty state).
+    if (!isEmptyState) {
+      const hiddenAbove = startIdx;
+      const hiddenBelow = sourceEntries.length - endIdx;
+      if (hiddenAbove > 0 && visibleEntries.length > 1) {
+        visibleEntries = [
+          { kind: "marker" as const, text: formatHiddenAboveMarker(hiddenAbove) },
+          ...visibleEntries.slice(1),
+        ];
+      }
+      if (hiddenBelow > 0 && visibleEntries.length > 1) {
+        visibleEntries = [
+          ...visibleEntries.slice(0, -1),
+          { kind: "marker" as const, text: formatHiddenBelowMarker(hiddenBelow) },
+        ];
+      }
+    }
 
     let currentRow = region.startRow;
     for (const entry of visibleEntries) {
@@ -717,11 +741,13 @@ export class TranscriptPanel {
       const paddedLine = padDisplayWidth(line, usableWidth);
       const displayLine = isEmptyState
         ? statusColor.muted(paddedLine)
-        : entry.kind === "diagnostic"
-          ? statusColor.error(paddedLine)
-          : entry.kind === "recap"
-            ? statusColor.info(paddedLine)
-            : paddedLine;
+        : entry.kind === "marker"
+          ? statusColor.muted(paddedLine)
+          : entry.kind === "diagnostic"
+            ? statusColor.error(paddedLine)
+            : entry.kind === "recap"
+              ? statusColor.info(paddedLine)
+              : paddedLine;
 
       screen.cursorMoveTo(currentRow, 0);
       screen.write(displayLine);

--- a/tests/ts/unit/cli/tui/design/tokens.test.ts
+++ b/tests/ts/unit/cli/tui/design/tokens.test.ts
@@ -52,6 +52,14 @@ describe("design tokens", () => {
         expect(typeof frame).toBe("string");
       }
     });
+
+    it("provides cache + RAG markers for upcoming P1 panels", () => {
+      expect(glyph.cacheHit).toBe("▣");
+      expect(glyph.cacheMiss).toBe("▢");
+      expect(glyph.cacheAdvise).toBe("⚠");
+      expect(glyph.ragInjected).toBe("ⓘ");
+      expect(glyph.ragSkipped).toBe("○");
+    });
   });
 
   describe("spacing & width", () => {

--- a/tests/ts/unit/cli/tui/panels/base.test.ts
+++ b/tests/ts/unit/cli/tui/panels/base.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   fillRemaining,
+  formatHiddenAboveMarker,
+  formatHiddenBelowMarker,
   renderEmptyState,
   truncateByDisplayWidth,
   truncateByLength,
@@ -115,6 +117,26 @@ describe("panel base helpers", () => {
       const text = "한국어테스트"; // 12 display cells
       const result = truncateByDisplayWidth(text, 5);
       expect(result.endsWith("…")).toBe(true);
+    });
+  });
+
+  describe("hidden-line markers", () => {
+    it("formats above marker with count", () => {
+      expect(formatHiddenAboveMarker(5)).toBe("… ↑ 5줄 위");
+    });
+
+    it("formats below marker with count", () => {
+      expect(formatHiddenBelowMarker(12)).toBe("… ↓ 12줄 아래");
+    });
+
+    it("returns empty string when count is zero", () => {
+      expect(formatHiddenAboveMarker(0)).toBe("");
+      expect(formatHiddenBelowMarker(0)).toBe("");
+    });
+
+    it("returns empty string when count is negative", () => {
+      expect(formatHiddenAboveMarker(-3)).toBe("");
+      expect(formatHiddenBelowMarker(-1)).toBe("");
     });
   });
 });

--- a/tests/ts/unit/cli/tui/panels/pipeline-status.test.ts
+++ b/tests/ts/unit/cli/tui/panels/pipeline-status.test.ts
@@ -301,4 +301,39 @@ describe("PipelineStatusPanel", () => {
       expect(calls.length).toBeGreaterThan(5);
     });
   });
+
+  describe("stage duration display", () => {
+    it("renders ms duration when a stage transitions start → end quickly", async () => {
+      panel.update({ stage: "Prompt Compiler", status: "start", message: "시작" });
+      // Tiny delay so endedAt > startedAt by some ms.
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      panel.update({ stage: "Prompt Compiler", status: "end", message: "완료" });
+
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("\n");
+      expect(output).toMatch(/Prompt Compiler\s+\d+ms/);
+    });
+
+    it("does not render duration before a stage has ended", () => {
+      panel.update({ stage: "Prompt Compiler", status: "start", message: "시작" });
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("\n");
+      const compilerLine = output.split("\n").find((l: string) => l.includes("Prompt Compiler"));
+      expect(compilerLine).toBeDefined();
+      expect(compilerLine).not.toMatch(/\d+ms/);
+      expect(compilerLine).not.toMatch(/\d+\.\d+s/);
+    });
+
+    it("clears duration when stage restarts via update(start)", () => {
+      panel.update({ stage: "Executor", status: "start", message: "1차" });
+      panel.update({ stage: "Executor", status: "end", message: "1차 완료" });
+      panel.update({ stage: "Executor", status: "start", message: "2차 시작" });
+
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("\n");
+      const executorLine = output.split("\n").find((l: string) => l.includes("Executor"));
+      expect(executorLine).toBeDefined();
+      expect(executorLine).not.toMatch(/\d+ms/);
+    });
+  });
 });

--- a/tests/ts/unit/cli/tui/panels/transcript.test.ts
+++ b/tests/ts/unit/cli/tui/panels/transcript.test.ts
@@ -466,4 +466,40 @@ describe("TranscriptPanel", () => {
       expect(output).toContain("파이프라인이 완료되었습니다.");
     });
   });
+
+  describe("truncation markers", () => {
+    it("shows '↓ N줄 아래' marker when scrolled up away from the bottom", () => {
+      // Region holds 10 rows (startRow 11..endRow 21). Add 30 entries so >10 hidden.
+      for (let i = 0; i < 30; i += 1) {
+        panel.append(`line ${i}`);
+      }
+      // Scroll up 5 entries so 5 lines remain hidden below.
+      for (let i = 0; i < 5; i += 1) panel.scrollUp();
+      mockScreen.write.mockClear();
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toContain("↓ 5줄 아래");
+    });
+
+    it("shows '↑ N줄 위' marker when entries overflow above visible range", () => {
+      // Region holds 10 rows. Add 30 entries — viewport at bottom shows last 10,
+      // so 20 lines remain hidden above.
+      for (let i = 0; i < 30; i += 1) {
+        panel.append(`line ${i}`);
+      }
+      mockScreen.write.mockClear();
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toContain("↑ 20줄 위");
+    });
+
+    it("shows no markers when content fits entirely in the viewport", () => {
+      panel.append("only line");
+      mockScreen.write.mockClear();
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).not.toContain("↑");
+      expect(output).not.toContain("↓");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

TUI UI/UX 개선 로드맵의 **PR3 / 6**. 토대(PR1·PR2) 위에서 **첫 사용자 가시 변화** — panel 별 1~2줄 수정만으로 4 가지 폴리시 적용.

- **P2-3 Empty state CTA**: transcript / result-summary / embedded-terminal pane 의 빈 상태에 다음 액션 힌트 추가.
- **P2-4 Truncation marker**: transcript 가 위/아래로 가린 줄을 "… ↑ N줄 위" / "… ↓ N줄 아래" 로 명시. 사용자가 스크롤 위치를 직관 인지 가능.
- **P2-5 Stage duration**: pipeline-status panel 의 각 stage 옆에 elapsed (예: `1.2s`, `850ms`) 표시. Stage 재시작 시 자동 clear.
- **P2-2 Cache/RAG 글리프**: 다음 PR (P1-1, P1-2) 에서 사용할 글리프 상수를 토큰에 사전 추가.

P2-1 (renderer/index 색 audit) 은 별도 후속 PR 로 분리.

## Why

PR1 (tokens + base helpers) · PR2 (event router + declarative layout) 가 머지되면서 토대가 마련됨. 이제 panel 한 곳을 손대면 토큰·헬퍼 덕에 자동으로 일관 적용되는 구조.

이번 PR 의 4 가지 폴리시는 사용자가 가장 자주 마주치는 **불친절 지점** 을 정조준:
- 빈 화면에서 "뭘 누르지?" 모름 → CTA 한 줄
- 스크롤 했는데 "위에 뭐가 있지?" 모름 → 명시적 marker
- "이 stage 가 얼마나 걸렸지?" 모름 → ms/s 표시

## Changes

| 파일 | 변경 |
|---|---|
| `src/cli/tui/design/tokens.ts` | 글리프 5개 추가 (cacheHit/cacheMiss/cacheAdvise/ragInjected/ragSkipped) |
| `src/cli/tui/panels/base.ts` | formatHiddenAboveMarker / formatHiddenBelowMarker 헬퍼 |
| `src/cli/tui/panels/pipeline-status.ts` | StageStatus 에 startedAt/endedAt, render 시 duration 표시. update() 가 lifecycle 추적 |
| `src/cli/tui/panels/transcript.ts` | TranscriptEntryKind 에 'marker' 추가, render 시 hidden marker 합성 |
| `src/cli/tui/panels/result-summary.ts` | empty state CTA 추가 |
| `src/cli/tui/panels/embedded-terminal.ts` | empty pane CTA 추가 |
| 테스트 4 file +11 tests | 토큰 글리프 / marker formatter / stage duration / transcript marker 렌더링 |

## Reviewer Notes

- **시각 변화는 의도된 것**: empty state CTA 라인, marker 텍스트, stage duration 표시 — 모두 사용자 가시.
- **호환성**: 기존 18 panel/util 테스트 모두 그대로 통과 (181 → 192 tests). marker 는 `entries.length` 가 viewport 미만일 때 표시 안 됨, duration 은 startedAt/endedAt 모두 있을 때만 표시.
- **글리프 추가 부분 (cacheHit/cacheMiss/cacheAdvise/ragInjected/ragSkipped)** 는 본 PR 에서 사용처 없음. 다음 PR(P1-1·P1-2) 의 cache live stream / RAG context summary panel 이 사용 예정. 미리 추가해둔 이유는 (1) 토큰 부분만 별 PR 로 쪼개면 노이즈, (2) P1 PR 의 surface area 를 최소화하기 위함.
- **Truncation marker 의 trade-off**: viewport 의 첫/마지막 row 를 marker 가 차지하므로 실제 콘텐츠 1줄을 가림. `visibleEntries.length > 1` 조건으로 매우 좁은 viewport 에서는 marker 생략.
- **Stage duration 의 정확도**: `Date.now()` 기반으로 설치된 timer 정밀도에 의존. 100ms 이내 stage 는 ms 단위, 그 이상은 1자리 소수 s. 충분히 직관적.
- **이전 panel 의 한국어 일관성 유지**: marker 와 CTA 모두 한국어 (CLAUDE.md 의 사용자 선호도 따름).

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- --run tests/ts/unit/cli/tui/` — 18 files, 192 tests 통과
- [x] 신규 11개 테스트 추가 통과 (토큰 1 + marker formatter 4 + stage duration 3 + transcript marker 3)
- [ ] 실 터미널 수동 검증 (다음 PR 머지 전 일괄):
  - 빈 detoks REPL 실행 → 3 panel 모두 CTA 노출 확인
  - 긴 codex/gemini 출력에서 transcript 스크롤 → marker 위/아래 표시 확인
  - 파이프라인 실행 → 각 stage 종료 시 duration 표시 확인

## Dependency

PR1 (#283) 머지됨, PR2 (#284) 머지됨. 본 PR 은 두 토대 위에 자연스럽게 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)