### PR TITLE
feat(tui): 캐시 라이브 스트림 + RAG 컨텍스트 요약 표시 (P1-1, P1-2)

### DIFF
--- a/src/cli/tui/panels/pipeline-status.ts
+++ b/src/cli/tui/panels/pipeline-status.ts
@@ -15,10 +15,19 @@ interface StageStatus {
   endedAt?: number;
 }
 
+interface CacheCounters {
+  hit: number;
+  miss: number;
+  advise: number;
+}
+
 const formatStageDuration = (durationMs: number): string => {
   if (durationMs < 1000) return `${durationMs}ms`;
   return `${(durationMs / 1000).toFixed(1)}s`;
 };
+
+const isZeroCacheCounters = (c: CacheCounters): boolean =>
+  c.hit === 0 && c.miss === 0 && c.advise === 0;
 
 const STATUS_ICONS: Record<PipelineProgressStatus, string> = {
   end: glyph.done,
@@ -49,6 +58,8 @@ export class PipelineStatusPanel {
   private latestWorkState: string | null = null;
   private latestWorkStateDetail: string | null = null;
   private executionStartedAt: number | null = null;
+  private cacheCounters: CacheCounters = { hit: 0, miss: 0, advise: 0 };
+  private latestCacheEvent: { kind: "hit" | "miss" | "advise"; summary: string } | null = null;
 
   constructor() {
     for (const stageName of STAGE_ORDER) {
@@ -80,6 +91,18 @@ export class PipelineStatusPanel {
   }
 
   updateActionTimelineEvent(event: ActionTimelineEvent): void {
+    // Track cache lifecycle events for the cache summary line.
+    if (event.kind === "cache_hit") {
+      this.cacheCounters.hit += 1;
+      this.latestCacheEvent = { kind: "hit", summary: event.summary };
+    } else if (event.kind === "cache_miss") {
+      this.cacheCounters.miss += 1;
+      this.latestCacheEvent = { kind: "miss", summary: event.summary };
+    } else if (event.kind === "cache_advise") {
+      this.cacheCounters.advise += 1;
+      this.latestCacheEvent = { kind: "advise", summary: event.summary };
+    }
+
     const workState = deriveActionWorkState(event);
     if (!workState) {
       return;
@@ -105,6 +128,8 @@ export class PipelineStatusPanel {
     this.latestWorkState = null;
     this.latestWorkStateDetail = null;
     this.executionStartedAt = null;
+    this.cacheCounters = { hit: 0, miss: 0, advise: 0 };
+    this.latestCacheEvent = null;
   }
 
   render(ctx: RenderContext, region: PanelRegion): void {
@@ -170,6 +195,18 @@ export class PipelineStatusPanel {
         usableWidth,
         STATUS_STYLES[stageStatus.status],
       );
+      currentRow += 1;
+    }
+
+    // Cache summary line — only render when at least one cache event was seen.
+    if (currentRow < region.endRow && !isZeroCacheCounters(this.cacheCounters)) {
+      const c = this.cacheCounters;
+      const parts: string[] = [];
+      if (c.hit > 0) parts.push(`${glyph.cacheHit} ${c.hit} hit`);
+      if (c.miss > 0) parts.push(`${glyph.cacheMiss} ${c.miss} miss`);
+      if (c.advise > 0) parts.push(`${glyph.cacheAdvise} ${c.advise} advise`);
+      const summary = `캐시  ${parts.join("  ")}`;
+      writePaddedLine(ctx, currentRow, summary, usableWidth, statusColor.muted);
       currentRow += 1;
     }
 

--- a/src/cli/tui/panels/result-summary.ts
+++ b/src/cli/tui/panels/result-summary.ts
@@ -1,11 +1,48 @@
 import type { RenderContext } from "../renderer.js";
 import type { PanelRegion } from "../layout-manager.js";
-import type { PipelineExecutionResult } from "../../../core/pipeline/types.js";
+import type {
+  PipelineExecutionResult,
+  RagContextDisplayItem,
+  RagContextSummary,
+} from "../../../core/pipeline/types.js";
 import type { TokenReductionSnapshot } from "../../../core/utils/tokenMetrics.js";
 import { getTurnRecapLines } from "../../../core/timeline/action-timeline.js";
 import { getContentArea } from "../layout-manager.js";
 import { fillRemaining, truncateByLength, writePaddedLine } from "./base.js";
 import { glyph, statusColor } from "../design/tokens.js";
+
+const RAG_SOURCE_LABEL: Record<RagContextDisplayItem["sourceType"], string> = {
+  previous_request: "이전 요청",
+  previous_task: "이전 task",
+  previous_output: "이전 결과",
+};
+
+const RAG_SKIP_REASON_LABEL: Record<NonNullable<RagContextSummary["skipReason"]>, string> = {
+  budget: "토큰 예산 초과",
+  empty_content: "본문 비어있음",
+  disabled: "비활성화",
+  error: "오류",
+};
+
+const formatRagSummaryLine = (summary: RagContextSummary): string => {
+  const parts = [`${glyph.ragInjected} ${summary.injected}개 주입`];
+  if (summary.skipped > 0) {
+    parts.push(`${glyph.ragSkipped} ${summary.skipped}개 스킵`);
+  }
+  const tail = summary.skipReason
+    ? `  (스킵 사유: ${RAG_SKIP_REASON_LABEL[summary.skipReason]})`
+    : "";
+  return `RAG  ${summary.found}개 발견 · ${parts.join(" · ")}${tail}`;
+};
+
+const formatRagItemLine = (item: RagContextDisplayItem): string => {
+  const marker = item.injected ? glyph.ragInjected : glyph.ragSkipped;
+  const label = RAG_SOURCE_LABEL[item.sourceType];
+  const sessionShort = item.sessionId.slice(0, 8);
+  const taskFragment = item.taskId ? ` ${item.taskId}` : "";
+  const preview = item.preview.replace(/\s+/g, " ").trim();
+  return `  ${marker} [${item.relevance}] ${label} (${sessionShort}${taskFragment}) — ${preview}`;
+};
 
 const EMPTY_RESULT_LINES = [
   "실행 결과가 아직 없습니다.",
@@ -90,6 +127,16 @@ export class ResultSummaryPanel {
         lines.push(`  결과 요약 압축: ${this.formatTokenReduction(this.result.tokenMetrics.output)}`);
       } else if (this.result.promptTokenSavings) {
         lines.push(`  프롬프트 압축: ${this.formatTokenReduction(this.result.promptTokenSavings)}`);
+      }
+    }
+
+    const rag = this.result.ragContextSummary;
+    if (rag && rag.found > 0) {
+      lines.push("");
+      lines.push(formatRagSummaryLine(rag));
+      // Show top 3 items so users can see which past sessions were pulled in.
+      for (const item of rag.items.slice(0, 3)) {
+        lines.push(formatRagItemLine(item));
       }
     }
 

--- a/tests/ts/unit/cli/tui/panels/pipeline-status.test.ts
+++ b/tests/ts/unit/cli/tui/panels/pipeline-status.test.ts
@@ -336,4 +336,49 @@ describe("PipelineStatusPanel", () => {
       expect(executorLine).not.toMatch(/\d+ms/);
     });
   });
+
+  describe("cache event live stream", () => {
+    const cacheEvent = (kind: "cache_hit" | "cache_miss" | "cache_advise", summary: string): ActionTimelineEvent => ({
+      kind,
+      source: "pipeline",
+      summary,
+      timestamp: Date.now(),
+    });
+
+    it("does not render cache summary line when no cache events have arrived", () => {
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("\n");
+      expect(output).not.toContain("캐시");
+    });
+
+    it("renders accumulated counters with hit/miss/advise glyphs", () => {
+      panel.updateActionTimelineEvent(cacheEvent("cache_hit", "F1 hit"));
+      panel.updateActionTimelineEvent(cacheEvent("cache_hit", "F2 hit"));
+      panel.updateActionTimelineEvent(cacheEvent("cache_miss", "F2 miss"));
+      panel.updateActionTimelineEvent(cacheEvent("cache_advise", "F1 advise"));
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("\n");
+      expect(output).toContain("캐시");
+      expect(output).toContain("▣ 2 hit");
+      expect(output).toContain("▢ 1 miss");
+      expect(output).toContain("⚠ 1 advise");
+    });
+
+    it("omits zero-count categories from the summary", () => {
+      panel.updateActionTimelineEvent(cacheEvent("cache_hit", "F1 hit"));
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("\n");
+      expect(output).toContain("▣ 1 hit");
+      expect(output).not.toContain("0 miss");
+      expect(output).not.toContain("0 advise");
+    });
+
+    it("clears cache counters on reset", () => {
+      panel.updateActionTimelineEvent(cacheEvent("cache_hit", "F1 hit"));
+      panel.reset();
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("\n");
+      expect(output).not.toContain("캐시");
+    });
+  });
 });

--- a/tests/ts/unit/cli/tui/panels/result-summary.test.ts
+++ b/tests/ts/unit/cli/tui/panels/result-summary.test.ts
@@ -384,4 +384,86 @@ describe("ResultSummaryPanel", () => {
       expect(calls.length).toBeLessThanOrEqual(regionHeight);
     });
   });
+
+  describe("RAG context summary section", () => {
+    it("renders summary line + top items when found > 0", () => {
+      const result = mockResult({
+        ragContextSummary: {
+          found: 3,
+          injected: 1,
+          skipped: 2,
+          skipReason: "budget",
+          items: [
+            {
+              sourceType: "previous_task",
+              sessionId: "abcdef1234567890",
+              taskId: "t2",
+              preview: "Refactor user-service to extract auth middleware",
+              relevance: "high",
+              injected: true,
+            },
+            {
+              sourceType: "previous_request",
+              sessionId: "fedcba9876543210",
+              preview: "Update README with new API examples",
+              relevance: "medium",
+              injected: false,
+            },
+          ],
+        },
+      });
+      panel.setResult(result);
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toContain("RAG");
+      expect(output).toContain("3개 발견");
+      expect(output).toContain("1개 주입");
+      expect(output).toContain("2개 스킵");
+      expect(output).toContain("토큰 예산 초과");
+      expect(output).toContain("이전 task");
+      expect(output).toContain("abcdef12");
+      expect(output).toContain("Refactor user-service");
+    });
+
+    it("omits the section entirely when ragContextSummary is absent", () => {
+      panel.setResult(mockResult());
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).not.toContain("RAG");
+    });
+
+    it("omits the section when found is zero (no past matches)", () => {
+      panel.setResult(
+        mockResult({
+          ragContextSummary: { found: 0, injected: 0, skipped: 0, items: [] },
+        }),
+      );
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).not.toContain("RAG");
+    });
+
+    it("limits item rendering to top 3", () => {
+      const items = Array.from({ length: 5 }, (_, i) => ({
+        sourceType: "previous_task" as const,
+        sessionId: `session-${i.toString().padStart(8, "0")}`,
+        taskId: `t${i}`,
+        preview: `preview ${i}`,
+        relevance: "low" as const,
+        injected: i < 1,
+      }));
+      panel.setResult(
+        mockResult({
+          ragContextSummary: { found: 5, injected: 1, skipped: 4, items },
+        }),
+      );
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toContain("preview 0");
+      expect(output).toContain("preview 1");
+      expect(output).toContain("preview 2");
+      expect(output).not.toContain("preview 3");
+      expect(output).not.toContain("preview 4");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

TUI UI/UX 개선 로드맵의 **PR4 / 6** — 첫 P1(숨겨진 데이터 시각화) 단계. 파이프라인이 이미 emit 하는데 TUI 가 무시하고 있던 두 가지 데이터를 사용자에게 노출.

- **P1-1 캐시 라이브 스트림** (pipeline-status panel): F1/F2 cache 결정을 실행 중에 한눈에. `▣ 2 hit  ▢ 1 miss  ⚠ 1 advise` 형태로 누적 표시.
- **P1-2 RAG 컨텍스트 요약** (result-summary panel): 어떤 과거 세션이 끌려와 프롬프트에 주입됐는지 + 어떤 게 budget gate 로 스킵됐는지 + 그 이유.

## Why

[orchestrator.ts:675-730](https://github.com/tok-it/detoks/blob/dev/src/core/pipeline/orchestrator.ts#L675-L730) 와 [:1564-1573](https://github.com/tok-it/detoks/blob/dev/src/core/pipeline/orchestrator.ts#L1564-L1573) 가 풍부한 cache lifecycle / RAG snippet 데이터를 emit 하고 있었지만, TUI 는 cache 이벤트의 `summary` 만 work-state 표시에 잠깐 활용하고 나머지 (`kind`/`details`/`taskId`) 는 모두 버렸음. RAG summary 는 result panel 에서 아예 렌더링되지 않았음.

이제 사용자가:
- 실행 중에 "지금 캐시 hit 됐나? 새로 도는 건가?" 직관 인지
- 실행 후에 "어떤 이전 세션이 도움이 됐고, 어떤 건 토큰 예산 때문에 빠졌는지" 확인

## Changes

| 파일 | 변경 |
|---|---|
| `src/cli/tui/panels/pipeline-status.ts` | `CacheCounters` 인터페이스 + `updateActionTimelineEvent` 가 `cache_hit/miss/advise` 를 카운트. render 가 stage 5줄 아래에 캐시 요약 1줄 (0건 종류는 자동 생략). reset() 도 카운터 클리어. |
| `src/cli/tui/panels/result-summary.ts` | `RagContextSummary` import + sourceType/skipReason 한국어 매핑 + `formatRagSummaryLine` / `formatRagItemLine` helper. token metrics 섹션 다음에 RAG 섹션 합성, top 3 items 노출. |
| 테스트 4 추가 + 4 추가 | cache 4 (no-event 시 비표시 / 누적 / 0 자동 생략 / reset) + RAG 4 (full 렌더 / 부재 시 생략 / found=0 시 생략 / top 3 cap) |

## Reviewer Notes

- **PR3 (#285) 의 글리프 토큰을 활용**: cacheHit `▣` / cacheMiss `▢` / cacheAdvise `⚠` / ragInjected `ⓘ` / ragSkipped `○` 가 PR3 에서 미리 추가됨. 본 PR 은 base 가 PR3 branch (stacked) — PR3 머지 후 자동으로 base 가 dev 로 전환되며 본 PR diff 는 4 파일만 보일 것.
- **캐시 요약은 stage 다음 1줄만 차지**: panel 이 8행이라 (0~7), 5 stage + (조건부) 작업 진행/ALL BLUE/work state 1행 + 캐시 요약 1행. 첫 행 + 캐시 요약 둘 다 있는 worst case 도 8행 안에 정확히 맞음.
- **RAG section 위치**: token metrics 다음. 의도적 — RAG 가 토큰 영향을 주므로 토큰 지표와 인접 배치.
- **skipReason 매핑**: orchestrator 가 emit 가능한 4개(`budget`/`empty_content`/`disabled`/`error`) 모두 한국어로 매핑됨. 새 reason 추가 시 TS 컴파일러가 비어있는 매핑을 잡아줌.
- **session ID 8자 truncate**: 보통 16자 이상. 화면 폭 절약 + 사용자가 `/session show <prefix>` 로 매칭 시 충분.
- **non-fatal 호환**: ragContextSummary 가 undefined 거나 found=0 이면 섹션 자체 미노출. 기존 result 표시는 그대로.

## Dependency

**Stacked PR**: base = `refactor/tui-pr3-visual-polish` (PR #285).

PR3 가 추가한 글리프 토큰 (cacheHit/cacheMiss/cacheAdvise/ragInjected/ragSkipped) 을 사용. **PR3 머지 후** PR base 가 자동으로 dev 로 옮겨가며 본 PR diff 가 4 파일로 정리됨. PR3 가 revision 필요 시 본 PR 도 rebase 필요.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- --run tests/ts/unit/cli/tui/` — 18 files, 200 tests 통과
- [x] 신규 8개 테스트 추가 통과 (cache 4 + RAG 4)
- [ ] PR3 머지 후 base 전환 + diff 검증
- [ ] 실 터미널 수동 검증:
  - 같은 prompt 두 번 실행 → 두 번째 실행 시 pipeline-status 에 `▣ N hit` 표시 확인
  - RAG 가 트리거된 task 실행 → result panel 의 RAG 섹션에 sourceType/sessionId/preview 노출 확인
  - 큰 RAG snippet 으로 budget gate 트리거 → "스킵 사유: 토큰 예산 초과" 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)