### PR TITLE
feat(tui): 캐시 라이브 스트림 + RAG 컨텍스트 요약 표시 (P1-1, P1-2) — replay

### DIFF
--- a/src/cli/tui/panels/pipeline-status.ts
+++ b/src/cli/tui/panels/pipeline-status.ts
@@ -15,10 +15,19 @@ interface StageStatus {
   endedAt?: number;
 }
 
+interface CacheCounters {
+  hit: number;
+  miss: number;
+  advise: number;
+}
+
 const formatStageDuration = (durationMs: number): string => {
   if (durationMs < 1000) return `${durationMs}ms`;
   return `${(durationMs / 1000).toFixed(1)}s`;
 };
+
+const isZeroCacheCounters = (c: CacheCounters): boolean =>
+  c.hit === 0 && c.miss === 0 && c.advise === 0;
 
 const STATUS_ICONS: Record<PipelineProgressStatus, string> = {
   end: glyph.done,
@@ -49,6 +58,8 @@ export class PipelineStatusPanel {
   private latestWorkState: string | null = null;
   private latestWorkStateDetail: string | null = null;
   private executionStartedAt: number | null = null;
+  private cacheCounters: CacheCounters = { hit: 0, miss: 0, advise: 0 };
+  private latestCacheEvent: { kind: "hit" | "miss" | "advise"; summary: string } | null = null;
 
   constructor() {
     for (const stageName of STAGE_ORDER) {
@@ -80,6 +91,18 @@ export class PipelineStatusPanel {
   }
 
   updateActionTimelineEvent(event: ActionTimelineEvent): void {
+    // Track cache lifecycle events for the cache summary line.
+    if (event.kind === "cache_hit") {
+      this.cacheCounters.hit += 1;
+      this.latestCacheEvent = { kind: "hit", summary: event.summary };
+    } else if (event.kind === "cache_miss") {
+      this.cacheCounters.miss += 1;
+      this.latestCacheEvent = { kind: "miss", summary: event.summary };
+    } else if (event.kind === "cache_advise") {
+      this.cacheCounters.advise += 1;
+      this.latestCacheEvent = { kind: "advise", summary: event.summary };
+    }
+
     const workState = deriveActionWorkState(event);
     if (!workState) {
       return;
@@ -105,6 +128,8 @@ export class PipelineStatusPanel {
     this.latestWorkState = null;
     this.latestWorkStateDetail = null;
     this.executionStartedAt = null;
+    this.cacheCounters = { hit: 0, miss: 0, advise: 0 };
+    this.latestCacheEvent = null;
   }
 
   render(ctx: RenderContext, region: PanelRegion): void {
@@ -170,6 +195,18 @@ export class PipelineStatusPanel {
         usableWidth,
         STATUS_STYLES[stageStatus.status],
       );
+      currentRow += 1;
+    }
+
+    // Cache summary line — only render when at least one cache event was seen.
+    if (currentRow < region.endRow && !isZeroCacheCounters(this.cacheCounters)) {
+      const c = this.cacheCounters;
+      const parts: string[] = [];
+      if (c.hit > 0) parts.push(`${glyph.cacheHit} ${c.hit} hit`);
+      if (c.miss > 0) parts.push(`${glyph.cacheMiss} ${c.miss} miss`);
+      if (c.advise > 0) parts.push(`${glyph.cacheAdvise} ${c.advise} advise`);
+      const summary = `캐시  ${parts.join("  ")}`;
+      writePaddedLine(ctx, currentRow, summary, usableWidth, statusColor.muted);
       currentRow += 1;
     }
 

--- a/src/cli/tui/panels/result-summary.ts
+++ b/src/cli/tui/panels/result-summary.ts
@@ -1,11 +1,48 @@
 import type { RenderContext } from "../renderer.js";
 import type { PanelRegion } from "../layout-manager.js";
-import type { PipelineExecutionResult } from "../../../core/pipeline/types.js";
+import type {
+  PipelineExecutionResult,
+  RagContextDisplayItem,
+  RagContextSummary,
+} from "../../../core/pipeline/types.js";
 import type { TokenReductionSnapshot } from "../../../core/utils/tokenMetrics.js";
 import { getTurnRecapLines } from "../../../core/timeline/action-timeline.js";
 import { getContentArea } from "../layout-manager.js";
 import { fillRemaining, truncateByLength, writePaddedLine } from "./base.js";
 import { glyph, statusColor } from "../design/tokens.js";
+
+const RAG_SOURCE_LABEL: Record<RagContextDisplayItem["sourceType"], string> = {
+  previous_request: "이전 요청",
+  previous_task: "이전 task",
+  previous_output: "이전 결과",
+};
+
+const RAG_SKIP_REASON_LABEL: Record<NonNullable<RagContextSummary["skipReason"]>, string> = {
+  budget: "토큰 예산 초과",
+  empty_content: "본문 비어있음",
+  disabled: "비활성화",
+  error: "오류",
+};
+
+const formatRagSummaryLine = (summary: RagContextSummary): string => {
+  const parts = [`${glyph.ragInjected} ${summary.injected}개 주입`];
+  if (summary.skipped > 0) {
+    parts.push(`${glyph.ragSkipped} ${summary.skipped}개 스킵`);
+  }
+  const tail = summary.skipReason
+    ? `  (스킵 사유: ${RAG_SKIP_REASON_LABEL[summary.skipReason]})`
+    : "";
+  return `RAG  ${summary.found}개 발견 · ${parts.join(" · ")}${tail}`;
+};
+
+const formatRagItemLine = (item: RagContextDisplayItem): string => {
+  const marker = item.injected ? glyph.ragInjected : glyph.ragSkipped;
+  const label = RAG_SOURCE_LABEL[item.sourceType];
+  const sessionShort = item.sessionId.slice(0, 8);
+  const taskFragment = item.taskId ? ` ${item.taskId}` : "";
+  const preview = item.preview.replace(/\s+/g, " ").trim();
+  return `  ${marker} [${item.relevance}] ${label} (${sessionShort}${taskFragment}) — ${preview}`;
+};
 
 const EMPTY_RESULT_LINES = [
   "실행 결과가 아직 없습니다.",
@@ -90,6 +127,16 @@ export class ResultSummaryPanel {
         lines.push(`  결과 요약 압축: ${this.formatTokenReduction(this.result.tokenMetrics.output)}`);
       } else if (this.result.promptTokenSavings) {
         lines.push(`  프롬프트 압축: ${this.formatTokenReduction(this.result.promptTokenSavings)}`);
+      }
+    }
+
+    const rag = this.result.ragContextSummary;
+    if (rag && rag.found > 0) {
+      lines.push("");
+      lines.push(formatRagSummaryLine(rag));
+      // Show top 3 items so users can see which past sessions were pulled in.
+      for (const item of rag.items.slice(0, 3)) {
+        lines.push(formatRagItemLine(item));
       }
     }
 

--- a/tests/ts/unit/cli/tui/panels/pipeline-status.test.ts
+++ b/tests/ts/unit/cli/tui/panels/pipeline-status.test.ts
@@ -336,4 +336,49 @@ describe("PipelineStatusPanel", () => {
       expect(executorLine).not.toMatch(/\d+ms/);
     });
   });
+
+  describe("cache event live stream", () => {
+    const cacheEvent = (kind: "cache_hit" | "cache_miss" | "cache_advise", summary: string): ActionTimelineEvent => ({
+      kind,
+      source: "pipeline",
+      summary,
+      timestamp: Date.now(),
+    });
+
+    it("does not render cache summary line when no cache events have arrived", () => {
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("\n");
+      expect(output).not.toContain("캐시");
+    });
+
+    it("renders accumulated counters with hit/miss/advise glyphs", () => {
+      panel.updateActionTimelineEvent(cacheEvent("cache_hit", "F1 hit"));
+      panel.updateActionTimelineEvent(cacheEvent("cache_hit", "F2 hit"));
+      panel.updateActionTimelineEvent(cacheEvent("cache_miss", "F2 miss"));
+      panel.updateActionTimelineEvent(cacheEvent("cache_advise", "F1 advise"));
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("\n");
+      expect(output).toContain("캐시");
+      expect(output).toContain("▣ 2 hit");
+      expect(output).toContain("▢ 1 miss");
+      expect(output).toContain("⚠ 1 advise");
+    });
+
+    it("omits zero-count categories from the summary", () => {
+      panel.updateActionTimelineEvent(cacheEvent("cache_hit", "F1 hit"));
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("\n");
+      expect(output).toContain("▣ 1 hit");
+      expect(output).not.toContain("0 miss");
+      expect(output).not.toContain("0 advise");
+    });
+
+    it("clears cache counters on reset", () => {
+      panel.updateActionTimelineEvent(cacheEvent("cache_hit", "F1 hit"));
+      panel.reset();
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("\n");
+      expect(output).not.toContain("캐시");
+    });
+  });
 });

--- a/tests/ts/unit/cli/tui/panels/result-summary.test.ts
+++ b/tests/ts/unit/cli/tui/panels/result-summary.test.ts
@@ -384,4 +384,86 @@ describe("ResultSummaryPanel", () => {
       expect(calls.length).toBeLessThanOrEqual(regionHeight);
     });
   });
+
+  describe("RAG context summary section", () => {
+    it("renders summary line + top items when found > 0", () => {
+      const result = mockResult({
+        ragContextSummary: {
+          found: 3,
+          injected: 1,
+          skipped: 2,
+          skipReason: "budget",
+          items: [
+            {
+              sourceType: "previous_task",
+              sessionId: "abcdef1234567890",
+              taskId: "t2",
+              preview: "Refactor user-service to extract auth middleware",
+              relevance: "high",
+              injected: true,
+            },
+            {
+              sourceType: "previous_request",
+              sessionId: "fedcba9876543210",
+              preview: "Update README with new API examples",
+              relevance: "medium",
+              injected: false,
+            },
+          ],
+        },
+      });
+      panel.setResult(result);
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toContain("RAG");
+      expect(output).toContain("3개 발견");
+      expect(output).toContain("1개 주입");
+      expect(output).toContain("2개 스킵");
+      expect(output).toContain("토큰 예산 초과");
+      expect(output).toContain("이전 task");
+      expect(output).toContain("abcdef12");
+      expect(output).toContain("Refactor user-service");
+    });
+
+    it("omits the section entirely when ragContextSummary is absent", () => {
+      panel.setResult(mockResult());
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).not.toContain("RAG");
+    });
+
+    it("omits the section when found is zero (no past matches)", () => {
+      panel.setResult(
+        mockResult({
+          ragContextSummary: { found: 0, injected: 0, skipped: 0, items: [] },
+        }),
+      );
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).not.toContain("RAG");
+    });
+
+    it("limits item rendering to top 3", () => {
+      const items = Array.from({ length: 5 }, (_, i) => ({
+        sourceType: "previous_task" as const,
+        sessionId: `session-${i.toString().padStart(8, "0")}`,
+        taskId: `t${i}`,
+        preview: `preview ${i}`,
+        relevance: "low" as const,
+        injected: i < 1,
+      }));
+      panel.setResult(
+        mockResult({
+          ragContextSummary: { found: 5, injected: 1, skipped: 4, items },
+        }),
+      );
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toContain("preview 0");
+      expect(output).toContain("preview 1");
+      expect(output).toContain("preview 2");
+      expect(output).not.toContain("preview 3");
+      expect(output).not.toContain("preview 4");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

원본 PR #286 의 변경을 dev 에 적용하기 위한 **재제출 PR**.

## 배경

PR #286 은 stacked PR (base = `refactor/tui-pr3-visual-polish`) 로 만들어졌고, PR #285 (PR3) 가 먼저 dev 에 머지된 후 GitHub 가 PR #286 의 base 를 자동으로 dev 로 갱신하지 않은 상태에서 머지됨. 결과적으로 PR #286 의 commit 이 PR3 branch (이미 stale) 안으로만 들어가고 origin/dev 에는 도달하지 못함.

본 PR 은 PR #286 의 단일 commit (`20344aa`) 을 dev 위에 직접 cherry-pick 한 결과로, **변경 내용은 PR #286 과 동일**.

## Changes

PR #286 와 동일:

| 파일 | 변경 |
|---|---|
| `src/cli/tui/panels/pipeline-status.ts` | 캐시 이벤트 카운터 (`▣ N hit  ▢ N miss  ⚠ N advise`) |
| `src/cli/tui/panels/result-summary.ts` | RAG 컨텍스트 요약 섹션 + top 3 items |
| `tests/...pipeline-status.test.ts` | 캐시 카운터 4 tests |
| `tests/...result-summary.test.ts` | RAG 섹션 4 tests |

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- --run tests/ts/unit/cli/tui/` — 18 files, 200 tests 통과 (192 baseline + 8 PR4 tests)

자세한 설계/리뷰 노트는 원본 [PR #286](https://github.com/tok-it/detoks/pull/286) 참조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)