### PR TITLE
feat(tui): result panel 에 Resume / Task grid / Verbose cost 노출 (P1-3, P1-4, P1-5)

### DIFF
--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -235,6 +235,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     const pipelinePanel = new PipelineStatusPanel();
     const transcriptPanel = new TranscriptPanel();
     const resultPanel = new ResultSummaryPanel();
+    resultPanel.setVerbose(currentVerbose);
     let embeddedTerminalPane = new EmbeddedTerminalPane();
     const eventRouter = new TuiEventRouter({
       pipelinePanel,
@@ -1453,6 +1454,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
             cacheDisabled: currentCacheDisabled,
             onVerboseToggle: (enabled) => {
               currentVerbose = enabled;
+              resultPanel.setVerbose(enabled);
             },
             onCacheDisableToggle: (disabled) => {
               currentCacheDisabled = disabled;

--- a/src/cli/tui/panels/result-summary.ts
+++ b/src/cli/tui/panels/result-summary.ts
@@ -4,12 +4,15 @@ import type {
   PipelineExecutionResult,
   RagContextDisplayItem,
   RagContextSummary,
+  ResumeHintInfo,
+  TaskExecutionRecord,
 } from "../../../core/pipeline/types.js";
 import type { TokenReductionSnapshot } from "../../../core/utils/tokenMetrics.js";
+import type { CostAccounting } from "../../../core/utils/tokenAccounting.js";
 import { getTurnRecapLines } from "../../../core/timeline/action-timeline.js";
 import { getContentArea } from "../layout-manager.js";
 import { fillRemaining, truncateByLength, writePaddedLine } from "./base.js";
-import { glyph, statusColor } from "../design/tokens.js";
+import { glyph, statusColor, type Style } from "../design/tokens.js";
 
 const RAG_SOURCE_LABEL: Record<RagContextDisplayItem["sourceType"], string> = {
   previous_request: "이전 요청",
@@ -44,6 +47,81 @@ const formatRagItemLine = (item: RagContextDisplayItem): string => {
   return `  ${marker} [${item.relevance}] ${label} (${sessionShort}${taskFragment}) — ${preview}`;
 };
 
+const formatRelativeAge = (updatedAt: string, now: number = Date.now()): string => {
+  const ts = Date.parse(updatedAt);
+  if (isNaN(ts)) return "방금";
+  const diffMs = Math.max(0, now - ts);
+  const min = Math.floor(diffMs / 60_000);
+  if (min < 1) return "방금";
+  if (min < 60) return `${min}분 전`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}시간 전`;
+  const day = Math.floor(hr / 24);
+  return `${day}일 전`;
+};
+
+const formatResumeBannerLines = (resumeHint: ResumeHintInfo): string[] => {
+  const sessionShort = resumeHint.sessionId.slice(0, 8);
+  const completedCount = resumeHint.completedTaskIds.length;
+  const ago = formatRelativeAge(resumeHint.updatedAt);
+  return [
+    `↩ Resume  미완성 세션 ${sessionShort} — 완료 ${completedCount}개, 중단 ${resumeHint.currentTaskId} (${ago})`,
+    `   이어가기: /session continue ${sessionShort}`,
+  ];
+};
+
+const TASK_STATUS_GLYPHS: Record<TaskExecutionRecord["status"], string> = {
+  completed: glyph.success,
+  failed: glyph.failure,
+  skipped: glyph.skipped,
+};
+
+const TASK_STATUS_STYLES: Record<TaskExecutionRecord["status"], Style> = {
+  completed: statusColor.success,
+  failed: statusColor.error,
+  skipped: statusColor.muted,
+};
+
+const TASK_STATUS_LABELS: Record<TaskExecutionRecord["status"], string> = {
+  completed: "완료",
+  failed: "실패",
+  skipped: "스킵",
+};
+
+interface StyledLine {
+  text: string;
+  style?: Style;
+}
+
+const formatTaskGridLines = (records: readonly TaskExecutionRecord[]): StyledLine[] => {
+  const lines: StyledLine[] = [];
+  lines.push({ text: "" });
+  lines.push({ text: "작업 결과" });
+  for (const record of records) {
+    const marker = TASK_STATUS_GLYPHS[record.status];
+    const label = TASK_STATUS_LABELS[record.status];
+    const blocked = record.blockedBy ? `  (blocked by ${record.blockedBy})` : "";
+    lines.push({
+      text: `  ${marker} ${record.taskId}  ${label}${blocked}`,
+      style: TASK_STATUS_STYLES[record.status],
+    });
+  }
+  return lines;
+};
+
+const formatUsd = (value: number): string => {
+  const sign = value >= 0 ? "" : "-";
+  const abs = Math.abs(value);
+  if (abs < 0.01) return `${sign}$${abs.toFixed(4)}`;
+  return `${sign}$${abs.toFixed(2)}`;
+};
+
+const formatCostAccountingLines = (cost: CostAccounting): string[] => [
+  "",
+  "비용 정산 (verbose)",
+  `  캐시로 절약: ${formatUsd(cost.costSavedUsd)}  ·  RAG 추가: ${formatUsd(cost.costAddedUsd)}  ·  순절감: ${formatUsd(cost.netCostSavedUsd)}`,
+];
+
 const EMPTY_RESULT_LINES = [
   "실행 결과가 아직 없습니다.",
   "첫 실행 이후 작업 타임라인 · 다음 작업 · 사용량/압축 지표가 이 영역에 표시됩니다.",
@@ -54,6 +132,7 @@ const EMPTY_RESULT_LINES = [
 export class ResultSummaryPanel {
   private result: PipelineExecutionResult | null = null;
   private executing = false;
+  private verbose = false;
 
   setResult(result: PipelineExecutionResult): void {
     this.result = result;
@@ -62,6 +141,10 @@ export class ResultSummaryPanel {
 
   setExecuting(active: boolean): void {
     this.executing = active;
+  }
+
+  setVerbose(verbose: boolean): void {
+    this.verbose = verbose;
   }
 
   clear(): void {
@@ -83,60 +166,89 @@ export class ResultSummaryPanel {
   }
 
   getLines(): string[] {
+    return this.buildStyledLines().map((line) => line.text);
+  }
+
+  private buildStyledLines(): StyledLine[] {
     if (this.executing) {
-      return ["", "  Waiting for adapter CLI to finish…"];
+      return [{ text: "" }, { text: "  Waiting for adapter CLI to finish…" }];
     }
 
     if (!this.result) {
       return [];
     }
 
-    const lines: string[] = [];
+    const lines: StyledLine[] = [];
+
+    // P1-3: Resume hint banner — top of result, prominent accent color.
+    if (this.result.resumeHint) {
+      for (const text of formatResumeBannerLines(this.result.resumeHint)) {
+        lines.push({ text, style: statusColor.accent });
+      }
+      lines.push({ text: "" });
+    }
 
     const statusIcon = this.result.ok ? glyph.success : glyph.failure;
     const statusText = this.result.ok ? "완료" : "실패";
-    lines.push(`${statusIcon} ${statusText}  어댑터: ${this.result.adapter}  세션: ${this.result.sessionId}`);
+    lines.push({
+      text: `${statusIcon} ${statusText}  어댑터: ${this.result.adapter}  세션: ${this.result.sessionId}`,
+      style: this.result.ok ? statusColor.success : statusColor.error,
+    });
 
-    lines.push(`요약: ${this.result.summary}`);
-    lines.push(`다음 작업: ${this.result.nextAction}`);
+    lines.push({ text: `요약: ${this.result.summary}` });
+    lines.push({ text: `다음 작업: ${this.result.nextAction}` });
 
     const turnRecap = [...(this.result.actionTimeline ?? [])]
       .reverse()
       .find((event) => event.kind === "turn_recap");
 
     if (turnRecap) {
-      lines.push("");
-      lines.push("작업 타임라인");
+      lines.push({ text: "" });
+      lines.push({ text: "작업 타임라인" });
       for (const line of getTurnRecapLines(turnRecap)) {
-        lines.push(`  ${line}`);
+        lines.push({ text: `  ${line}` });
       }
     }
 
     const actualUsage = this.extractActualTokenUsage(this.result.rawOutput);
     if (actualUsage !== null) {
-      lines.push("");
-      lines.push("사용량");
-      lines.push(`  실제 ${this.result.adapter} 사용량: ${actualUsage} tokens`);
+      lines.push({ text: "" });
+      lines.push({ text: "사용량" });
+      lines.push({ text: `  실제 ${this.result.adapter} 사용량: ${actualUsage} tokens` });
     }
 
     if (this.result.tokenMetrics || this.result.promptTokenSavings) {
-      lines.push("");
-      lines.push("detoks 압축 지표");
+      lines.push({ text: "" });
+      lines.push({ text: "detoks 압축 지표" });
       if (this.result.tokenMetrics) {
-        lines.push(`  프롬프트 압축: ${this.formatTokenReduction(this.result.tokenMetrics.input)}`);
-        lines.push(`  결과 요약 압축: ${this.formatTokenReduction(this.result.tokenMetrics.output)}`);
+        lines.push({ text: `  프롬프트 압축: ${this.formatTokenReduction(this.result.tokenMetrics.input)}` });
+        lines.push({ text: `  결과 요약 압축: ${this.formatTokenReduction(this.result.tokenMetrics.output)}` });
       } else if (this.result.promptTokenSavings) {
-        lines.push(`  프롬프트 압축: ${this.formatTokenReduction(this.result.promptTokenSavings)}`);
+        lines.push({ text: `  프롬프트 압축: ${this.formatTokenReduction(this.result.promptTokenSavings)}` });
+      }
+    }
+
+    // P1-4: Per-task status grid — styled per record status.
+    if (this.result.taskRecords && this.result.taskRecords.length > 0) {
+      for (const styled of formatTaskGridLines(this.result.taskRecords)) {
+        lines.push(styled);
       }
     }
 
     const rag = this.result.ragContextSummary;
     if (rag && rag.found > 0) {
-      lines.push("");
-      lines.push(formatRagSummaryLine(rag));
+      lines.push({ text: "" });
+      lines.push({ text: formatRagSummaryLine(rag) });
       // Show top 3 items so users can see which past sessions were pulled in.
       for (const item of rag.items.slice(0, 3)) {
-        lines.push(formatRagItemLine(item));
+        lines.push({ text: formatRagItemLine(item) });
+      }
+    }
+
+    // P1-5: Verbose-only — cost accounting.
+    if (this.verbose && this.result.costAccounting) {
+      for (const text of formatCostAccountingLines(this.result.costAccounting)) {
+        lines.push({ text, style: statusColor.muted });
       }
     }
 
@@ -147,18 +259,16 @@ export class ResultSummaryPanel {
     const { usableWidth } = getContentArea(region);
 
     const isEmptyState = this.result === null && !this.executing;
-    const lines = isEmptyState ? [...EMPTY_RESULT_LINES] : this.getLines();
+    const styledLines: StyledLine[] = isEmptyState
+      ? EMPTY_RESULT_LINES.map((text) => ({ text, style: statusColor.muted }))
+      : this.buildStyledLines();
     let currentRow = region.startRow;
 
-    for (const line of lines) {
+    for (const line of styledLines) {
       if (currentRow >= region.endRow) break;
 
-      const truncated = truncateByLength(line, usableWidth);
-      if (isEmptyState) {
-        writePaddedLine(ctx, currentRow, truncated, usableWidth, statusColor.muted);
-      } else {
-        writePaddedLine(ctx, currentRow, truncated, usableWidth);
-      }
+      const truncated = truncateByLength(line.text, usableWidth);
+      writePaddedLine(ctx, currentRow, truncated, usableWidth, line.style);
       currentRow += 1;
     }
 

--- a/tests/ts/unit/cli/tui/panels/result-summary.test.ts
+++ b/tests/ts/unit/cli/tui/panels/result-summary.test.ts
@@ -466,4 +466,98 @@ describe("ResultSummaryPanel", () => {
       expect(output).not.toContain("preview 4");
     });
   });
+
+  describe("resume hint banner (P1-3)", () => {
+    it("renders banner at top with sessionId, completed count, currentTaskId, ago, and continue command", () => {
+      const fiveMinAgo = new Date(Date.now() - 5 * 60_000).toISOString();
+      panel.setResult(
+        mockResult({
+          resumeHint: {
+            sessionId: "abc123def4567890",
+            completedTaskIds: ["t1", "t2"],
+            currentTaskId: "t3",
+            updatedAt: fiveMinAgo,
+          },
+        }),
+      );
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toContain("↩ Resume");
+      expect(output).toContain("abc123de");
+      expect(output).toContain("완료 2개");
+      expect(output).toContain("중단 t3");
+      expect(output).toMatch(/\d+분 전/);
+      expect(output).toContain("/session continue abc123de");
+    });
+
+    it("omits banner when resumeHint is undefined", () => {
+      panel.setResult(mockResult());
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).not.toContain("Resume");
+    });
+  });
+
+  describe("per-task status grid (P1-4)", () => {
+    it("renders a section with one styled line per task record", () => {
+      panel.setResult(
+        mockResult({
+          taskRecords: [
+            { taskId: "t1", status: "completed", rawOutput: "" },
+            { taskId: "t2", status: "failed", rawOutput: "" },
+            { taskId: "t3", status: "skipped", rawOutput: "", blockedBy: "t2" },
+          ],
+        }),
+      );
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toContain("작업 결과");
+      expect(output).toContain("✓ t1");
+      expect(output).toContain("✗ t2");
+      expect(output).toContain("○ t3");
+      expect(output).toContain("blocked by t2");
+    });
+
+    it("omits the section when taskRecords is empty", () => {
+      panel.setResult(mockResult({ taskRecords: [] }));
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).not.toContain("작업 결과");
+    });
+  });
+
+  describe("verbose mode (P1-5)", () => {
+    const cost = {
+      costSavedUsd: 0.0123,
+      costAddedUsd: 0.0034,
+      compressionCostUsd: 0,
+      netCostSavedUsd: 0.0089,
+    };
+
+    it("hides cost accounting section by default", () => {
+      panel.setResult(mockResult({ costAccounting: cost }));
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).not.toContain("비용 정산");
+    });
+
+    it("shows cost accounting section when verbose enabled", () => {
+      panel.setVerbose(true);
+      panel.setResult(mockResult({ costAccounting: cost }));
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toContain("비용 정산");
+      expect(output).toContain("캐시로 절약");
+      expect(output).toContain("RAG 추가");
+      expect(output).toContain("순절감");
+    });
+
+    it("omits cost accounting even when verbose if costAccounting is missing", () => {
+      panel.setVerbose(true);
+      panel.setResult(mockResult());
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).not.toContain("비용 정산");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

TUI UI/UX 개선 로드맵의 **PR5 / 6** — 두 번째 P1 묶음. 파이프라인이 이미 `result` 에 담아 보내고 있던 세 가지 데이터 (`resumeHint`, `taskRecords`, `costAccounting`) 를 result-summary panel 이 모두 무시하고 있었음. 본 PR 로 셋 다 사용자에게 가시화.

## What changes

### P1-3 Resume hint banner (panel 최상단)

미완성 prior session 이 발견되면 result panel 최상단에 강조 색 (`statusColor.accent`) 으로:
```
↩ Resume  미완성 세션 abc123de — 완료 2개, 중단 t3 (5분 전)
   이어가기: /session continue abc123de
```
- `formatRelativeAge` 헬퍼로 분/시간/일 단위 자동 포맷 (1분 미만은 "방금")
- `sessionId` 8자 truncate — `/session continue` prefix 매칭 충분
- `result.resumeHint` 부재 시 섹션 자체 미노출

### P1-4 Per-task status grid

token metrics 다음 위치에 "작업 결과" 섹션:
```
작업 결과
  ✓ t1  완료              (success, 녹색)
  ✗ t2  실패              (error, 빨강)
  ○ t3  스킵  (blocked by t2)  (muted, 회색)
```
- `result.taskRecords[]` 의 status 별 글리프·색 매핑 (`completed`/`failed`/`skipped`)
- `blockedBy` 가 있으면 우측에 안내
- `taskRecords` 비어있으면 섹션 자체 미노출

### P1-5 Verbose mode 실효화

`ResultSummaryPanel.setVerbose(boolean)` 추가. index.ts 의 verbose flag 가 panel 로 전달되고 `/verbose` 토글 시 갱신.

`verbose=true` 시에만 노출:
```
비용 정산 (verbose)
  캐시로 절약: $0.0123  ·  RAG 추가: $0.0034  ·  순절감: $0.0089
```
- `result.costAccounting` 부재 시 verbose 라도 섹션 미노출
- 추후 verbose 가 추가 정보 (전체 transcript path, stage messages) 노출하는 hub 으로 활용 가능

## Why

[orchestrator.ts:744-757](https://github.com/tok-it/detoks/blob/dev/src/core/pipeline/orchestrator.ts#L744-L757) 가 `resumeHint` 채우고, [:1546-1559](https://github.com/tok-it/detoks/blob/dev/src/core/pipeline/orchestrator.ts#L1546-L1559) 가 `costAccounting` 계산하는데도 TUI 가 무시. resumeHint 는 비-TUI 경로 (`format.ts:250-258`) 에서만 출력됐음.

이로써 사용자가:
- 세션 중단 후 재실행 시 어떻게 이어갈지 즉시 알 수 있음 (Resume banner)
- 어떤 task 가 성공/실패/skipped 됐는지 한눈에 (Task grid)
- 캐시·RAG 가 실제 얼마의 비용을 절약·추가했는지 검증 가능 (Verbose cost)

## Internal refactor

`getLines(): string[]` 의 caller (storage 의 `summaryLines` 저장 등) 호환성 유지를 위해:
- `buildStyledLines(): StyledLine[]` private helper 도입 — 모든 섹션 한 곳에서 styled tuple 로 빌드
- `getLines()` 는 buildStyledLines() 결과의 text 만 추출
- `render()` 는 buildStyledLines() 결과의 style 을 line 별로 적용

이전엔 render() 가 모든 line 에 동일 style 적용 (empty 면 muted, 아니면 plain). 이제 Resume banner / 상태 line / Task grid 가 각자 의미 색을 가짐.

## Changes

| 파일 | 변경 |
|---|---|
| `src/cli/tui/panels/result-summary.ts` | `formatResumeBannerLines` / `formatTaskGridLines` / `formatCostAccountingLines` / `formatRelativeAge` 헬퍼 + `setVerbose` + `buildStyledLines` |
| `src/cli/tui/index.ts` | panel 생성 직후 `setVerbose(currentVerbose)` 호출, `onVerboseToggle` 콜백에 panel 갱신 추가 |
| `tests/.../result-summary.test.ts` | 7 신규 tests (Resume banner 2 + Task grid 2 + Verbose toggle 3) |

## Reviewer Notes

- **시각 변화는 의도된 것**: Resume banner / Task grid / verbose-only cost section 모두 사용자 가시.
- **buildStyledLines 가 새 contract**: getLines() 는 plain text 보존하므로 `currentRunBlock.summaryLines = resultPanel.getLines()` 같은 storage caller 영향 0. style 은 render() 시점에만 적용.
- **panel-내 색 사용**: PR1·P2-1 의 토큰만 사용 (`statusColor.accent/success/error/muted`). 새 색 추가 0.
- **8자 sessionId truncate**: 일관 — RAG item 표시도 같은 8자 사용 (PR4 와 동일).
- **Resume hint 의 ago 계산은 client-side**: `Date.parse(updatedAt)` + `Date.now()`. 서버 시간 동기 필요 없음.
- **verbose flag 흐름**: 기존 `currentVerbose` flow 그대로 활용. /verbose 토글 시 panel.setVerbose 호출만 추가. 추후 P3 의 추가 verbose 섹션 (transcript 분류 색·stage messages 등) 도 panel.setVerbose 한 곳만 거치면 됨.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- --run tests/ts/unit/cli/tui/` — 18 files, 207 tests 통과 (200 → +7)
- [x] 신규 7 tests: Resume banner 2 + Task grid 2 + Verbose toggle 3
- [ ] 실 터미널 수동 검증:
  - 세션 중단 후 같은 prompt 재실행 → Resume banner 노출 확인
  - task graph 가 있는 multi-task 실행 → task grid 색·blockedBy 표시 확인
  - `/verbose` 토글 → cost accounting 섹션 토글 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)