### PR TITLE
feat(tui): adapter transcript auto-save + result panel 경로 노출 (P3-4)

### DIFF
--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -32,6 +32,12 @@ import { EmbeddedTerminalPane } from "./panels/embedded-terminal.js";
 import { renderSlashAutocompletePanel } from "./panels/slash-autocomplete.js";
 import { TuiEventRouter } from "./event-router.js";
 import {
+  formatTranscript,
+  isAutoSaveEnabled,
+  resolveTranscriptPath,
+  saveTranscript,
+} from "./transcript-export.js";
+import {
   createEmbeddedTerminalFocusManager,
   isEmbeddedTerminalInterruptKey,
   isEmbeddedTerminalNativeFocusToggleKey,
@@ -1609,6 +1615,37 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           ...(actionTimeline.length > 0 ? { actionTimeline } : {}),
         };
         resultPanel.setResult(completedResult);
+
+        // P3-4: Auto-save adapter transcript when DETOKS_SAVE_TRANSCRIPTS=1.
+        if (
+          isAutoSaveEnabled() &&
+          completedResult.adapterTranscript &&
+          completedResult.adapterTranscript.events.length > 0
+        ) {
+          const path = resolveTranscriptPath({
+            cwd: executionCwd,
+            sessionId: completedResult.sessionId,
+            runIndex: currentRunBlock.index,
+          });
+          const text = formatTranscript(completedResult.adapterTranscript, {
+            sessionId: completedResult.sessionId,
+            adapter: completedResult.adapter,
+            ...(completedResult.originalPrompt
+              ? { prompt: completedResult.originalPrompt }
+              : {}),
+          });
+          saveTranscript(path, text)
+            .then(() => {
+              resultPanel.setSavedTranscriptPath(path);
+              render();
+            })
+            .catch(() => {
+              // Non-fatal — transcript export must never break the pipeline.
+            });
+        } else {
+          resultPanel.setSavedTranscriptPath(null);
+        }
+
         currentRunBlock.summaryLines = resultPanel.getLines();
         currentRunBlock.status = completedResult.ok ? "completed" : "failed";
         currentRunBlock.completedAt = Date.now();

--- a/src/cli/tui/panels/result-summary.ts
+++ b/src/cli/tui/panels/result-summary.ts
@@ -133,6 +133,7 @@ export class ResultSummaryPanel {
   private result: PipelineExecutionResult | null = null;
   private executing = false;
   private verbose = false;
+  private savedTranscriptPath: string | null = null;
 
   setResult(result: PipelineExecutionResult): void {
     this.result = result;
@@ -147,9 +148,14 @@ export class ResultSummaryPanel {
     this.verbose = verbose;
   }
 
+  setSavedTranscriptPath(path: string | null): void {
+    this.savedTranscriptPath = path;
+  }
+
   clear(): void {
     this.result = null;
     this.executing = false;
+    this.savedTranscriptPath = null;
   }
 
   private formatTokenReduction(tokens: TokenReductionSnapshot): string {
@@ -250,6 +256,15 @@ export class ResultSummaryPanel {
       for (const text of formatCostAccountingLines(this.result.costAccounting)) {
         lines.push({ text, style: statusColor.muted });
       }
+    }
+
+    // P3-4: Saved transcript path (only when DETOKS_SAVE_TRANSCRIPTS=1 produced one).
+    if (this.savedTranscriptPath) {
+      lines.push({ text: "" });
+      lines.push({
+        text: `전사 저장: ${this.savedTranscriptPath}`,
+        style: statusColor.muted,
+      });
     }
 
     return lines;

--- a/src/cli/tui/transcript-export.ts
+++ b/src/cli/tui/transcript-export.ts
@@ -1,0 +1,144 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { PtyEvent, PtyTranscript } from "../../integrations/subprocess/types.js";
+import { resolveProjectDataDir } from "../../core/state/storage-paths.js";
+
+// ANSI CSI sequences (color codes etc.): ESC [ ... letter
+const ANSI_CSI = new RegExp("\\u001b\\[[0-?]*[ -/]*[@-~]", "g");
+// ANSI OSC sequences (window title etc.): ESC ] ... BEL or ESC \
+const ANSI_OSC = new RegExp("\\u001b\\][^\\u0007]*(?:\\u0007|\\u001b\\\\)", "g");
+// Bare control bytes except whitespace (TAB, LF, CR retained).
+const CONTROL_CHARS = new RegExp("[\\u0000-\\u0008\\u000B\\u000C\\u000E-\\u001F\\u007F]", "g");
+
+const stripAnsi = (value: string): string =>
+  value.replace(ANSI_CSI, "").replace(ANSI_OSC, "").replace(CONTROL_CHARS, "");
+
+const formatRelative = (timestampMs: number, baseMs: number): string => {
+  const deltaMs = Math.max(0, timestampMs - baseMs);
+  const totalSec = Math.floor(deltaMs / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  const ms = deltaMs % 1000;
+  return `${String(min).padStart(2, "0")}:${String(sec).padStart(2, "0")}.${String(ms).padStart(3, "0")}`;
+};
+
+const formatDuration = (totalMs: number): string => {
+  const totalSec = Math.floor(totalMs / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return min > 0 ? `${min}m ${sec}s` : `${sec}s`;
+};
+
+const formatEvent = (event: PtyEvent, baseMs: number): string | null => {
+  const ts = formatRelative(event.timestamp, baseMs);
+  switch (event.type) {
+    case "chunk": {
+      if (!event.data) return null;
+      const stream = event.stream ?? "stdout";
+      const text = stripAnsi(event.data).replace(/\r\n/g, "\n");
+      return text
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => `[${ts}] ${stream}: ${line}`)
+        .join("\n");
+    }
+    case "prompt":
+      return event.data ? `[${ts}] PROMPT: ${stripAnsi(event.data)}` : null;
+    case "reply":
+      return event.data ? `[${ts}] REPLY: ${stripAnsi(event.data)}` : null;
+    case "resize":
+      return `[${ts}] RESIZE: ${event.columns ?? "?"}x${event.rows ?? "?"}`;
+    case "exit":
+      return `[${ts}] EXIT: ${event.data ?? ""}`;
+    case "timeout":
+      return `[${ts}] TIMEOUT`;
+    case "error":
+      return `[${ts}] ERROR: ${event.data ?? ""}`;
+    default:
+      return null;
+  }
+};
+
+export interface FormatTranscriptOptions {
+  sessionId?: string;
+  adapter?: string;
+  prompt?: string;
+}
+
+export const formatTranscript = (
+  transcript: PtyTranscript,
+  options: FormatTranscriptOptions = {},
+): string => {
+  const lines: string[] = [];
+  lines.push("# detoks adapter transcript");
+  if (options.sessionId) lines.push(`# session: ${options.sessionId}`);
+  if (options.adapter) lines.push(`# adapter: ${options.adapter}`);
+  if (options.prompt) {
+    const oneLine = options.prompt.replace(/\s+/g, " ").trim();
+    lines.push(`# prompt: ${oneLine}`);
+  }
+  lines.push(`# started: ${new Date(transcript.startTime).toISOString()}`);
+  lines.push(`# ended: ${new Date(transcript.endTime).toISOString()}`);
+  lines.push(`# duration: ${formatDuration(transcript.totalDuration)}`);
+  if (transcript.exitCode !== undefined) {
+    lines.push(`# exit: ${transcript.exitCode}`);
+  }
+  if (transcript.timedOut) {
+    lines.push(`# timed_out: true`);
+  }
+  lines.push(`# events: ${transcript.events.length}`);
+  lines.push("# ---");
+
+  for (const event of transcript.events) {
+    const formatted = formatEvent(event, transcript.startTime);
+    if (formatted) lines.push(formatted);
+  }
+
+  return lines.join("\n") + "\n";
+};
+
+const sanitizeForFilename = (value: string): string =>
+  value.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 64);
+
+export interface ResolveTranscriptPathOptions {
+  cwd?: string;
+  sessionId?: string;
+  runIndex?: number;
+  /** Override timestamp for deterministic tests. */
+  now?: () => Date;
+}
+
+export const resolveTranscriptPath = (
+  options: ResolveTranscriptPathOptions = {},
+): string => {
+  const cwd = options.cwd ?? process.cwd();
+  const baseDir = join(resolveProjectDataDir(cwd), "transcripts");
+  const ts = (options.now ?? (() => new Date()))();
+  const stamp = [
+    ts.getUTCFullYear(),
+    String(ts.getUTCMonth() + 1).padStart(2, "0"),
+    String(ts.getUTCDate()).padStart(2, "0"),
+    "-",
+    String(ts.getUTCHours()).padStart(2, "0"),
+    String(ts.getUTCMinutes()).padStart(2, "0"),
+    String(ts.getUTCSeconds()).padStart(2, "0"),
+    "-",
+    String(ts.getUTCMilliseconds()).padStart(3, "0"),
+  ].join("");
+  const sessionPart = options.sessionId
+    ? `-${sanitizeForFilename(options.sessionId).slice(0, 12)}`
+    : "";
+  const runPart = options.runIndex !== undefined ? `-r${options.runIndex}` : "";
+  return join(baseDir, `${stamp}${sessionPart}${runPart}.txt`);
+};
+
+export const saveTranscript = async (
+  filePath: string,
+  contents: string,
+): Promise<void> => {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, contents, "utf-8");
+};
+
+export const isAutoSaveEnabled = (): boolean =>
+  process.env.DETOKS_SAVE_TRANSCRIPTS === "1";

--- a/tests/ts/unit/cli/tui/panels/result-summary.test.ts
+++ b/tests/ts/unit/cli/tui/panels/result-summary.test.ts
@@ -560,4 +560,32 @@ describe("ResultSummaryPanel", () => {
       expect(output).not.toContain("비용 정산");
     });
   });
+
+  describe("saved transcript path (P3-4)", () => {
+    it("renders path when set after a result", () => {
+      panel.setResult(mockResult());
+      panel.setSavedTranscriptPath("/tmp/.detoks/projects/x/transcripts/abc.txt");
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toContain("전사 저장");
+      expect(output).toContain("/tmp/.detoks/projects/x/transcripts/abc.txt");
+    });
+
+    it("omits path section when savedTranscriptPath is null", () => {
+      panel.setResult(mockResult());
+      panel.setSavedTranscriptPath(null);
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).not.toContain("전사 저장");
+    });
+
+    it("clears saved path when clear() is called", () => {
+      panel.setResult(mockResult());
+      panel.setSavedTranscriptPath("/tmp/x.txt");
+      panel.clear();
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).not.toContain("전사 저장");
+    });
+  });
 });

--- a/tests/ts/unit/cli/tui/transcript-export.test.ts
+++ b/tests/ts/unit/cli/tui/transcript-export.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  formatTranscript,
+  isAutoSaveEnabled,
+  resolveTranscriptPath,
+  saveTranscript,
+} from "../../../../../src/cli/tui/transcript-export.js";
+import type { PtyEvent, PtyTranscript } from "../../../../../src/integrations/subprocess/types.js";
+
+const buildTranscript = (overrides: Partial<PtyTranscript> = {}): PtyTranscript => {
+  const startTime = 1_000_000;
+  return {
+    events: [],
+    startTime,
+    endTime: startTime + 5_000,
+    totalDuration: 5_000,
+    timedOut: false,
+    ...overrides,
+  };
+};
+
+const event = (overrides: Partial<PtyEvent>): PtyEvent => ({
+  type: "chunk",
+  timestamp: 0,
+  ...overrides,
+});
+
+describe("transcript-export", () => {
+  describe("formatTranscript", () => {
+    it("emits a header block with session/adapter/prompt/duration metadata", () => {
+      const transcript = buildTranscript({ exitCode: 0 });
+      const output = formatTranscript(transcript, {
+        sessionId: "abc12345",
+        adapter: "codex",
+        prompt: "do the thing",
+      });
+      expect(output).toContain("# detoks adapter transcript");
+      expect(output).toContain("# session: abc12345");
+      expect(output).toContain("# adapter: codex");
+      expect(output).toContain("# prompt: do the thing");
+      expect(output).toContain("# duration: 5s");
+      expect(output).toContain("# exit: 0");
+      expect(output).toContain("# events: 0");
+      expect(output).toContain("# ---");
+    });
+
+    it("formats stdout/stderr chunks with relative MM:SS.mmm timestamps and stream label", () => {
+      const transcript = buildTranscript({
+        events: [
+          event({ timestamp: 1_000_000 + 1234, stream: "stdout", data: "hello\n" }),
+          event({ timestamp: 1_000_000 + 2456, stream: "stderr", data: "warn message" }),
+        ],
+      });
+      const output = formatTranscript(transcript, { sessionId: "x" });
+      expect(output).toMatch(/\[00:01\.234\] stdout: hello/);
+      expect(output).toMatch(/\[00:02\.456\] stderr: warn message/);
+    });
+
+    it("strips ANSI escape sequences from chunk payload", () => {
+      const transcript = buildTranscript({
+        events: [
+          event({
+            timestamp: 1_000_000,
+            stream: "stdout",
+            data: "[32mgreen[0m text",
+          }),
+        ],
+      });
+      const output = formatTranscript(transcript);
+      expect(output).toContain("stdout: green text");
+      expect(output).not.toContain("");
+    });
+
+    it("formats prompt/reply/exit/timeout/error event types", () => {
+      const transcript = buildTranscript({
+        events: [
+          event({ type: "prompt", timestamp: 1_000_000, data: "Continue?" }),
+          event({ type: "reply", timestamp: 1_000_100, data: "y" }),
+          event({ type: "resize", timestamp: 1_000_200, columns: 80, rows: 24 }),
+          event({ type: "exit", timestamp: 1_000_300, data: "0" }),
+          event({ type: "timeout", timestamp: 1_000_400 }),
+          event({ type: "error", timestamp: 1_000_500, data: "boom" }),
+        ],
+      });
+      const output = formatTranscript(transcript);
+      expect(output).toContain("PROMPT: Continue?");
+      expect(output).toContain("REPLY: y");
+      expect(output).toContain("RESIZE: 80x24");
+      expect(output).toContain("EXIT: 0");
+      expect(output).toContain("TIMEOUT");
+      expect(output).toContain("ERROR: boom");
+    });
+
+    it("uses minutes-and-seconds format when duration exceeds 60s", () => {
+      const transcript = buildTranscript({
+        startTime: 0,
+        endTime: 125_000,
+        totalDuration: 125_000,
+      });
+      const output = formatTranscript(transcript);
+      expect(output).toContain("# duration: 2m 5s");
+    });
+
+    it("includes timed_out marker when transcript timed out", () => {
+      const transcript = buildTranscript({ timedOut: true });
+      const output = formatTranscript(transcript);
+      expect(output).toContain("# timed_out: true");
+    });
+  });
+
+  describe("resolveTranscriptPath", () => {
+    it("places file under projects/<workspace>/transcripts/ with sortable timestamp", () => {
+      const fixedNow = () => new Date("2026-05-16T01:23:45.678Z");
+      const path = resolveTranscriptPath({
+        cwd: "/tmp/sample-cwd",
+        sessionId: "abcdef1234567890",
+        runIndex: 2,
+        now: fixedNow,
+      });
+      expect(path).toMatch(/transcripts\/20260516-012345-678-abcdef123456-r2\.txt$/);
+      expect(path).toContain(".detoks/projects/");
+    });
+
+    it("works without sessionId or runIndex", () => {
+      const fixedNow = () => new Date("2026-05-16T00:00:00.000Z");
+      const path = resolveTranscriptPath({ cwd: "/tmp", now: fixedNow });
+      expect(path).toMatch(/transcripts\/20260516-000000-000\.txt$/);
+    });
+
+    it("sanitizes sessionId for safe filename usage", () => {
+      const fixedNow = () => new Date("2026-05-16T00:00:00.000Z");
+      const path = resolveTranscriptPath({
+        cwd: "/tmp",
+        sessionId: "weird/sess id*123",
+        now: fixedNow,
+      });
+      // After sanitization, slash/space/star become "-".
+      expect(path).toMatch(/-weird-sess/);
+      expect(path).not.toContain("/weird/sess");
+    });
+  });
+
+  describe("saveTranscript", () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), "detoks-transcript-test-"));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("creates parent directory and writes file content", async () => {
+      const filePath = join(tempDir, "nested/dir/transcript.txt");
+      await saveTranscript(filePath, "hello world\n");
+      const written = await readFile(filePath, "utf-8");
+      expect(written).toBe("hello world\n");
+    });
+
+    it("overwrites existing file on subsequent saves", async () => {
+      const filePath = join(tempDir, "transcript.txt");
+      await saveTranscript(filePath, "first");
+      await saveTranscript(filePath, "second");
+      expect(await readFile(filePath, "utf-8")).toBe("second");
+    });
+
+    it("creates nested directories as needed", async () => {
+      const filePath = join(tempDir, "a/b/c/d/file.txt");
+      await saveTranscript(filePath, "x");
+      expect(dirname(filePath)).toContain("a/b/c/d");
+      expect(await readFile(filePath, "utf-8")).toBe("x");
+    });
+  });
+
+  describe("isAutoSaveEnabled", () => {
+    let originalEnv: string | undefined;
+
+    beforeEach(() => {
+      originalEnv = process.env.DETOKS_SAVE_TRANSCRIPTS;
+    });
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.DETOKS_SAVE_TRANSCRIPTS;
+      } else {
+        process.env.DETOKS_SAVE_TRANSCRIPTS = originalEnv;
+      }
+    });
+
+    it("returns true only when env is exactly '1'", () => {
+      process.env.DETOKS_SAVE_TRANSCRIPTS = "1";
+      expect(isAutoSaveEnabled()).toBe(true);
+
+      process.env.DETOKS_SAVE_TRANSCRIPTS = "true";
+      expect(isAutoSaveEnabled()).toBe(false);
+
+      process.env.DETOKS_SAVE_TRANSCRIPTS = "0";
+      expect(isAutoSaveEnabled()).toBe(false);
+
+      delete process.env.DETOKS_SAVE_TRANSCRIPTS;
+      expect(isAutoSaveEnabled()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

TUI UI/UX 개선 로드맵의 **P3-4** — 두 번째 P3 항목. embedded pane 의 500-line scrollback cap 때문에 화면에서 잘려나가는 adapter transcript 를 디스크에 **전체 보존**.

`result.adapterTranscript` 가 항상 모든 `PtyEvent` 를 들고 있는데 (in-memory display 만 cap 됨) 디스크에는 저장 안 되고 있었음. `DETOKS_SAVE_TRANSCRIPTS=1` 옵트인으로 매 실행 후 자동 저장 + result panel 에 경로 노출.

## Usage

```bash
DETOKS_SAVE_TRANSCRIPTS=1 detoks "..."
```

→ 매 실행 종료 후:
- `~/.detoks/projects/<workspace>/transcripts/20260516-014523-678-abc12345-r0.txt` 에 저장
- result panel 하단에 `전사 저장: <path>` muted 텍스트로 표시

## Transcript format

```
# detoks adapter transcript
# session: abc12345
# adapter: codex
# prompt: refactor the auth middleware...
# started: 2026-05-16T01:23:45.000Z
# ended: 2026-05-16T01:25:08.234Z
# duration: 1m 23s
# exit: 0
# events: 147
# ---
[00:00.123] stdout: Reading file...
[00:00.567] stderr: warning: ...
[00:23.890] PROMPT: Continue? [y/n]
[00:24.012] REPLY: y
[01:23.234] EXIT: 0
```

- ANSI CSI / OSC / 제어 바이트 제거
- `[MM:SS.mmm]` 상대 timestamp
- 이벤트 종류별 라벨 (stdout / stderr / PROMPT / REPLY / RESIZE / EXIT / TIMEOUT / ERROR)
- 헤더 블록에 메타데이터 (session, adapter, prompt, 시간, 종료 코드, 이벤트 수)

## Why

PR4 의 cache live · PR5 의 task grid 와 함께 **"파이프라인 데이터가 있는데 사용자가 못 보는" 갭** 해소의 마무리. 특히:
- 어댑터 디버깅 시 화면에서 사라진 옛 출력을 재확인 가능
- 세션 공유·이슈 보고 시 transcript 파일 첨부 가능
- 자동화 스크립트가 transcript 를 후처리 (예: 매 실행마다 git commit, 외부 분석)

## Why opt-in via env var (not always-on)

- 모든 실행마다 디스크 쓰기 → 비용 0 아님 (큰 transcript 는 수 MB)
- 사용자가 명시적 의지 표명한 경우만 저장 → 의도치 않은 디스크 점유 방지
- 향후 `/save-transcript` slash command 추가 시 명시적 단발 저장도 가능 (별 PR 후보)

## Changes

| 파일 | 변경 |
|---|---|
| `src/cli/tui/transcript-export.ts` | 신규 — `formatTranscript` / `resolveTranscriptPath` / `saveTranscript` / `isAutoSaveEnabled` |
| `src/cli/tui/index.ts` | `resultPanel.setResult` 직후 auto-save 비동기 실행 + setSavedTranscriptPath → render |
| `src/cli/tui/panels/result-summary.ts` | `setSavedTranscriptPath` 추가, buildStyledLines 가 cost accounting 다음에 muted 라인 합성, clear() 가 경로도 초기화 |
| `tests/.../transcript-export.test.ts` | 신규 — 13 tests (포맷 헤더 · 타임스탬프 · ANSI strip · 이벤트 종류 · duration 포맷 · path resolver · save 동작 · env var) |
| `tests/.../result-summary.test.ts` | +3 tests (saved path 노출 · null 시 생략 · clear 후 제거) |

## Reviewer Notes

- **opt-in 기본값 OFF**: env var 미설정 시 동작 변경 0. 기존 사용자 영향 없음.
- **비동기 save 가 render 막지 않음**: `.then()/.catch()` 처리 — save 완료 후에야 setSavedTranscriptPath 호출되므로 path 가 늦게 나타나지만 결과 표시는 즉시.
- **non-fatal 원칙**: 저장 실패 (디스크 풀, 권한 등) 시 silent skip. 파이프라인 절대 차단 안 함.
- **경로 충돌 방지**: 파일명에 `YYYYMMDD-HHMMSS-mmm` (ms 정밀도) 포함 → 같은 세션의 여러 run 도 충돌 안 함. `-r<index>` 도 추가 식별.
- **sessionId truncate**: 12자로 (filename 길이 절약). 같은 세션의 여러 run 은 `-r<index>` 로 구분.
- **ANSI strip 의 regex 3개**: CSI (color codes), OSC (window title), control chars. `transcript.ts` 의 기존 패턴과 일치.
- **`resolveProjectDataDir` 재사용**: PR1 era 의 path resolver — sessions/checkpoints/rag 와 같은 워크스페이스 root 아래 `transcripts/` 디렉터리.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- --run tests/ts/unit/cli/tui/` — 19 files, 231 tests 통과 (215 → +16 신규)
- [x] 신규 16 tests: transcript-export 13 + result-summary 3
- [ ] 실 터미널 수동 검증:
  - `DETOKS_SAVE_TRANSCRIPTS=1 detoks ...` → 파일 생성·경로 표시 확인
  - env var 미설정 → 동작 변경 없음 확인
  - 큰 transcript (수백 라인) → 파일 정합성 확인

## Roadmap progress

| 항목 | 상태 |
|---|---|
| P0~P2 | ✅ 완료 (PR #283~#287, #290) |
| P1-1~P1-5 | ✅ 완료 (PR #288, #289) |
| **P3-2 Theme** | ✅ 머지 (#290) |
| **P3-4 Transcript export** | 🟡 본 PR |
| P3-3 Input editing | 다음 (히스토리·Ctrl+A/E/R) |
| P3-1 Resizable panel | 마지막 (가장 복잡) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)