### PR TITLE
feat(tui): in-line cursor editing — Ctrl+A/E, ←/→, Home/End, 위치 기반 backspace (P3-3 2단계)

### DIFF
--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -44,6 +44,16 @@ import {
   saveHistoryToDisk,
 } from "./input-history.js";
 import {
+  backspaceAt,
+  deleteAt,
+  insertAt,
+  moveCursorEnd,
+  moveCursorHome,
+  moveCursorLeft,
+  moveCursorRight,
+  setInput,
+} from "./input-cursor.js";
+import {
   createEmbeddedTerminalFocusManager,
   isEmbeddedTerminalInterruptKey,
   isEmbeddedTerminalNativeFocusToggleKey,
@@ -240,6 +250,8 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     }
 
     let input = "";
+    // P3-3 2단계: code-point index of cursor in `input`. 0 ≤ cursor ≤ input length.
+    let cursor = 0;
     let running = true;
     let isExecuting = false;
 
@@ -762,7 +774,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     const renderInputOnly = (): void => {
       const dims = screen.getDimensions();
       const ctx = { screen, dims };
-      const inputLayout = renderInputArea(ctx, input);
+      const inputLayout = renderInputArea(ctx, input, cursor);
       lastInputSeparatorRow = inputLayout.separatorRow;
       screen.flush();
     };
@@ -804,7 +816,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     const renderInteractiveInput = (): void => {
       const dims = screen.getDimensions();
       const ctx = { screen, dims };
-      const inputLayout = measureInputLayout(dims, input);
+      const inputLayout = measureInputLayout(dims, input, cursor);
       lastInputSeparatorRow = inputLayout.separatorRow;
 
       const slashAutocompleteQuery = getSlashAutocompleteQuery(input);
@@ -830,7 +842,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           formatEmbeddedTerminalFocusHint(embeddedTerminalFocus.focus, currentAdapter),
         );
       } else {
-        renderInputArea(ctx, input);
+        renderInputArea(ctx, input, cursor);
       }
 
       if (slashAutocompleteQuery !== null) {
@@ -866,7 +878,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         screen.cursorMoveTo(0, 0);
         forceFullRender = false;
       }
-      const inputLayout = measureInputLayout(dims, input);
+      const inputLayout = measureInputLayout(dims, input, cursor);
       const viewportStatusText = getEmbeddedViewportStatusText(dims.columns, inputLayout);
       const bannerRows = Math.min(3, Math.max(0, inputLayout.separatorRow));
       const statusRegionStart = bannerRows;
@@ -1039,7 +1051,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
             render();
           } else if (text === "\x1b[H" || text === "\x1b[1~") {
             const dims = screen.getDimensions();
-            const inputLayout = measureInputLayout(dims, input);
+            const inputLayout = measureInputLayout(dims, input, cursor);
             embeddedTerminalPane.scrollToTop(dims.columns, getEmbeddedTranscriptHeight(inputLayout));
             render();
           } else if (text === "\x1b[F" || text === "\x1b[4~") {
@@ -1117,7 +1129,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               activeRunBlock.summaryLines = ["실행이 취소되었습니다."];
               setStickyPromptFromRun(activeRunBlock);
             }
-            input = pendingApprovalPrompt;
+            ({ input, cursor } = setInput(pendingApprovalPrompt));
             pendingApprovalPrompt = null;
             skipApprovalLineFeed = false;
             render();
@@ -1157,7 +1169,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               scrollEmbeddedViewportBy(Math.max(1, Math.floor(screen.getDimensions().rows / 3)));
             } else if (matchedScrollSequence === "\x1b[H" || matchedScrollSequence === "\x1b[1~") {
               const dims = screen.getDimensions();
-              const inputLayout = measureInputLayout(dims, input);
+              const inputLayout = measureInputLayout(dims, input, cursor);
               embeddedTerminalPane.scrollToTop(dims.columns, getEmbeddedTranscriptHeight(inputLayout));
             } else {
               embeddedTerminalPane.scrollToBottom();
@@ -1166,6 +1178,24 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
             i += matchedScrollSequence.length;
             handled = true;
             continue;
+          }
+
+          // P3-3 2단계: Home/End → cursor home/end in non-embedded mode.
+          if (!embeddedPaneMode) {
+            if (matchedScrollSequence === "\x1b[H" || matchedScrollSequence === "\x1b[1~") {
+              ({ input, cursor } = moveCursorHome({ input, cursor }));
+              renderInputOnly();
+              i += matchedScrollSequence.length;
+              handled = true;
+              continue;
+            }
+            if (matchedScrollSequence === "\x1b[F" || matchedScrollSequence === "\x1b[4~") {
+              ({ input, cursor } = moveCursorEnd({ input, cursor }));
+              renderInputOnly();
+              i += matchedScrollSequence.length;
+              handled = true;
+              continue;
+            }
           }
 
           const sequence = text.substring(i, i + 3);
@@ -1195,7 +1225,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               // PageUp still scrolls the viewport.
               const recalled = inputHistory.recallOlder(input);
               if (recalled !== null) {
-                input = recalled;
+                ({ input, cursor } = setInput(recalled));
                 renderInteractiveInput();
               }
             }
@@ -1214,10 +1244,22 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               // P3-3: ↓ recalls newer history (or exits recall and restores draft).
               const recalled = inputHistory.recallNewer();
               if (recalled !== null) {
-                input = recalled;
+                ({ input, cursor } = setInput(recalled));
                 renderInteractiveInput();
               }
             }
+            i += 3;
+            handled = true;
+          } else if (sequence === "\x1b[D") {
+            // P3-3 2단계: ← moves cursor left within input.
+            ({ input, cursor } = moveCursorLeft({ input, cursor }));
+            renderInputOnly();
+            i += 3;
+            handled = true;
+          } else if (sequence === "\x1b[C") {
+            // P3-3 2단계: → moves cursor right within input.
+            ({ input, cursor } = moveCursorRight({ input, cursor }));
+            renderInputOnly();
             i += 3;
             handled = true;
           }
@@ -1355,7 +1397,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
             if (isPasting) {
               // During bracketed paste, newlines are part of the pasted content
               if (char === "\n") {
-                input += "\n";
+                ({ input, cursor } = insertAt({ input, cursor }, "\n"));
                 needsFullRender = true;
               }
             } else if (input.trim()) {
@@ -1388,7 +1430,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               void saveHistoryToDisk(historyPath, inputHistory.toArray()).catch(
                 () => undefined,
               );
-              input = ""; // Clear input for next prompt
+              ({ input, cursor } = setInput("")); // Clear input for next prompt
               slashAutocompleteSelectedIndex = 0;
             }
           } else if (embeddedPaneMode && isEmbeddedTerminalNativeFocusToggleKey(char)) {
@@ -1399,17 +1441,12 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               renderInteractiveInput();
             }
           } else if (char === "\x7f" || char === "\b") {
-            // Backspace (DEL: 0x7f or Backspace: 0x08)
-            // Remove last character by code point, not by byte
+            // Backspace — delete code point BEFORE cursor (P3-3 2단계).
             const wasSlashAutocompleteActive = getSlashAutocompleteQuery(input) !== null;
-            const charArray = Array.from(input);
-            if (charArray.length > 0) {
-              charArray.pop();
-              input = charArray.join("");
-            }
+            ({ input, cursor } = backspaceAt({ input, cursor }));
             inputHistory.resetRecall();
             slashAutocompleteSelectedIndex = 0;
-            const nextInputLayout = measureInputLayout(screen.getDimensions(), input);
+            const nextInputLayout = measureInputLayout(screen.getDimensions(), input, cursor);
             const isSlashAutocompleteActive = getSlashAutocompleteQuery(input) !== null;
             if (
               wasSlashAutocompleteActive ||
@@ -1423,15 +1460,36 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
             }
             i++;
             continue;
+          } else if (char === "\x01") {
+            // Ctrl+A — move cursor to start (P3-3 2단계, readline)
+            ({ input, cursor } = moveCursorHome({ input, cursor }));
+            renderInputOnly();
+            i++;
+            continue;
+          } else if (char === "\x05") {
+            // Ctrl+E — move cursor to end (P3-3 2단계, readline)
+            ({ input, cursor } = moveCursorEnd({ input, cursor }));
+            renderInputOnly();
+            i++;
+            continue;
+          } else if (char === "\x04" && input.length > 0) {
+            // Ctrl+D — forward-delete (only on non-empty input; empty-input
+            // Ctrl+D continues to mean "exit" per shell convention, handled
+            // by the earlier Ctrl+C/D exit branch).
+            ({ input, cursor } = deleteAt({ input, cursor }));
+            inputHistory.resetRecall();
+            renderInputOnly();
+            i++;
+            continue;
           } else if (char.charCodeAt(0) >= 32 || /[\p{L}\p{N}\p{P}\p{Z}]/u.test(char)) {
-            // Append committed printable characters directly.
-            // Terminal IME input arrives as committed characters, so rewriting prior input
-            // would erase already-entered Hangul syllables.
+            // Insert committed printable character at cursor (P3-3 2단계).
+            // Terminal IME input arrives as committed characters; insertAt is
+            // code-point safe so Korean syllables aren't split.
             const wasSlashAutocompleteActive = getSlashAutocompleteQuery(input) !== null;
-            input += char;
+            ({ input, cursor } = insertAt({ input, cursor }, char));
             inputHistory.resetRecall();
             slashAutocompleteSelectedIndex = 0;
-            const nextInputLayout = measureInputLayout(screen.getDimensions(), input);
+            const nextInputLayout = measureInputLayout(screen.getDimensions(), input, cursor);
             const isSlashAutocompleteActive = getSlashAutocompleteQuery(input) !== null;
             if (
               wasSlashAutocompleteActive ||

--- a/src/cli/tui/input-cursor.ts
+++ b/src/cli/tui/input-cursor.ts
@@ -1,0 +1,83 @@
+/**
+ * Cursor-aware input mutation helpers. All operations are code-point safe
+ * (use Array.from to split, never byte indexing) so Korean/emoji input is not
+ * corrupted by editing operations.
+ *
+ * Cursor positions are code-point indices into the input string, ranging
+ * from 0 (before first char) to length (after last char). Out-of-range values
+ * are clamped silently.
+ */
+
+export interface CursorState {
+  input: string;
+  cursor: number; // code-point index
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+const chars = (input: string): string[] => Array.from(input);
+
+export const codepointLength = (input: string): number => chars(input).length;
+
+/** Insert text at the cursor position. Cursor advances past inserted text. */
+export const insertAt = (state: CursorState, text: string): CursorState => {
+  const all = chars(state.input);
+  const safeCursor = clamp(state.cursor, 0, all.length);
+  const inserted = chars(text);
+  const next = [...all.slice(0, safeCursor), ...inserted, ...all.slice(safeCursor)];
+  return {
+    input: next.join(""),
+    cursor: safeCursor + inserted.length,
+  };
+};
+
+/** Backspace — delete the char BEFORE the cursor. No-op at start. */
+export const backspaceAt = (state: CursorState): CursorState => {
+  const all = chars(state.input);
+  const safeCursor = clamp(state.cursor, 0, all.length);
+  if (safeCursor === 0) return { input: state.input, cursor: 0 };
+  const next = [...all.slice(0, safeCursor - 1), ...all.slice(safeCursor)];
+  return {
+    input: next.join(""),
+    cursor: safeCursor - 1,
+  };
+};
+
+/** Forward delete — delete the char AT the cursor. No-op at end. */
+export const deleteAt = (state: CursorState): CursorState => {
+  const all = chars(state.input);
+  const safeCursor = clamp(state.cursor, 0, all.length);
+  if (safeCursor >= all.length) return { input: state.input, cursor: safeCursor };
+  const next = [...all.slice(0, safeCursor), ...all.slice(safeCursor + 1)];
+  return {
+    input: next.join(""),
+    cursor: safeCursor,
+  };
+};
+
+export const moveCursorLeft = (state: CursorState): CursorState => ({
+  input: state.input,
+  cursor: clamp(state.cursor - 1, 0, codepointLength(state.input)),
+});
+
+export const moveCursorRight = (state: CursorState): CursorState => ({
+  input: state.input,
+  cursor: clamp(state.cursor + 1, 0, codepointLength(state.input)),
+});
+
+export const moveCursorHome = (state: CursorState): CursorState => ({
+  input: state.input,
+  cursor: 0,
+});
+
+export const moveCursorEnd = (state: CursorState): CursorState => ({
+  input: state.input,
+  cursor: codepointLength(state.input),
+});
+
+/** Replace input string entirely (e.g. history recall). Cursor goes to end. */
+export const setInput = (next: string): CursorState => ({
+  input: next,
+  cursor: codepointLength(next),
+});

--- a/src/cli/tui/renderer.ts
+++ b/src/cli/tui/renderer.ts
@@ -266,7 +266,11 @@ export const buildFooterText = (columns: number, footer: FooterContext): string 
   return finalizeFooter(shortened);
 };
 
-export const measureInputLayout = (dims: ScreenDimensions, input: string): InputLayout => {
+export const measureInputLayout = (
+  dims: ScreenDimensions,
+  input: string,
+  cursorPos?: number,
+): InputLayout => {
   const firstLineWidth = Math.max(0, dims.columns - 2);
   const continuationWidth = Math.max(0, dims.columns);
   const allLines = wrapInputLines(input, firstLineWidth, continuationWidth);
@@ -279,9 +283,32 @@ export const measureInputLayout = (dims: ScreenDimensions, input: string): Input
   const inputStartRow = separatorRow + 1;
   const bottomSeparatorRow = dims.rows - 2;
   const inputEndRow = dims.rows - 1;
+
+  // Default — cursor at end of last visible line.
   const lastVisibleLine = visibleLines[visibleLines.length - 1] ?? { text: "", width: 0 };
-  const cursorRow = inputStartRow + visibleLines.length - 1;
-  const cursorCol = lastVisibleLine.width + (visibleStartIndex === 0 && visibleLines.length === 1 ? 2 : 0);
+  let cursorRow = inputStartRow + Math.max(0, visibleLines.length - 1);
+  let cursorCol = lastVisibleLine.width + (visibleStartIndex === 0 && visibleLines.length === 1 ? 2 : 0);
+
+  if (cursorPos !== undefined) {
+    const chars = Array.from(input);
+    const clamped = Math.max(0, Math.min(cursorPos, chars.length));
+    const prefix = chars.slice(0, clamped).join("");
+    const prefixLines = wrapInputLines(prefix, firstLineWidth, continuationWidth);
+    const prefixLastLineIdx = prefixLines.length - 1;
+    const prefixLastLine = prefixLines[prefixLastLineIdx] ?? { text: "", width: 0 };
+    // Map prefixLastLineIdx (in the full allLines space) to the visible window.
+    const visibleCursorLineIdx = Math.max(0, prefixLastLineIdx - visibleStartIndex);
+    if (prefixLastLineIdx >= visibleStartIndex) {
+      cursorRow = inputStartRow + visibleCursorLineIdx;
+      // Prompt offset applies only on the very first visible line ("> " prefix).
+      const promptOffset = visibleStartIndex === 0 && prefixLastLineIdx === 0 ? 2 : 0;
+      cursorCol = prefixLastLine.width + promptOffset;
+    } else {
+      // Cursor is above the visible window — pin to the first visible row, col 0.
+      cursorRow = inputStartRow;
+      cursorCol = visibleStartIndex === 0 ? 2 : 0;
+    }
+  }
 
   return {
     separatorRow,
@@ -351,9 +378,13 @@ export const renderStatusPanel = (
   return currentRow;
 };
 
-export const renderInputArea = (ctx: RenderContext, input: string): InputLayout => {
+export const renderInputArea = (
+  ctx: RenderContext,
+  input: string,
+  cursorPos?: number,
+): InputLayout => {
   const { screen, dims } = ctx;
-  const layout = measureInputLayout(dims, input);
+  const layout = measureInputLayout(dims, input, cursorPos);
 
   // Render colored separator line before input area
   for (let row = layout.separatorRow; row <= layout.bottomSeparatorRow; row++) {

--- a/tests/ts/unit/cli/tui/input-cursor.test.ts
+++ b/tests/ts/unit/cli/tui/input-cursor.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import {
+  backspaceAt,
+  codepointLength,
+  deleteAt,
+  insertAt,
+  moveCursorEnd,
+  moveCursorHome,
+  moveCursorLeft,
+  moveCursorRight,
+  setInput,
+} from "../../../../../src/cli/tui/input-cursor.js";
+
+describe("input-cursor", () => {
+  describe("codepointLength", () => {
+    it("counts ASCII characters", () => {
+      expect(codepointLength("hello")).toBe(5);
+    });
+
+    it("counts Korean code points (not UTF-16 units)", () => {
+      // "한글" is 2 code points
+      expect(codepointLength("한글")).toBe(2);
+    });
+
+    it("counts emoji as a single code point (when not surrogate-paired)", () => {
+      // Surrogate-paired emoji counts as 2 if naive; Array.from yields 1
+      expect(codepointLength("😀")).toBe(1);
+    });
+  });
+
+  describe("insertAt", () => {
+    it("appends at end when cursor is at length", () => {
+      const r = insertAt({ input: "abc", cursor: 3 }, "d");
+      expect(r).toEqual({ input: "abcd", cursor: 4 });
+    });
+
+    it("inserts at beginning when cursor is 0", () => {
+      const r = insertAt({ input: "abc", cursor: 0 }, "z");
+      expect(r).toEqual({ input: "zabc", cursor: 1 });
+    });
+
+    it("inserts in middle and advances cursor by inserted length", () => {
+      const r = insertAt({ input: "abc", cursor: 1 }, "XYZ");
+      expect(r).toEqual({ input: "aXYZbc", cursor: 4 });
+    });
+
+    it("is code-point safe with Korean characters", () => {
+      const r = insertAt({ input: "안녕", cursor: 1 }, "한");
+      expect(r).toEqual({ input: "안한녕", cursor: 2 });
+    });
+
+    it("clamps out-of-range cursor to bounds", () => {
+      const tooHigh = insertAt({ input: "abc", cursor: 99 }, "z");
+      expect(tooHigh).toEqual({ input: "abcz", cursor: 4 });
+      const tooLow = insertAt({ input: "abc", cursor: -5 }, "z");
+      expect(tooLow).toEqual({ input: "zabc", cursor: 1 });
+    });
+  });
+
+  describe("backspaceAt", () => {
+    it("removes char before cursor", () => {
+      const r = backspaceAt({ input: "abcd", cursor: 3 });
+      expect(r).toEqual({ input: "abd", cursor: 2 });
+    });
+
+    it("is no-op at cursor 0", () => {
+      const r = backspaceAt({ input: "abc", cursor: 0 });
+      expect(r).toEqual({ input: "abc", cursor: 0 });
+    });
+
+    it("removes whole Korean syllable, not a UTF-16 unit", () => {
+      const r = backspaceAt({ input: "안녕", cursor: 2 });
+      expect(r).toEqual({ input: "안", cursor: 1 });
+    });
+
+    it("removes emoji as single code point", () => {
+      const r = backspaceAt({ input: "x😀y", cursor: 2 });
+      expect(r).toEqual({ input: "xy", cursor: 1 });
+    });
+
+    it("removes char before cursor in middle of string", () => {
+      const r = backspaceAt({ input: "abcdef", cursor: 3 });
+      expect(r).toEqual({ input: "abdef", cursor: 2 });
+    });
+  });
+
+  describe("deleteAt", () => {
+    it("removes char AT cursor (forward delete)", () => {
+      const r = deleteAt({ input: "abc", cursor: 1 });
+      expect(r).toEqual({ input: "ac", cursor: 1 });
+    });
+
+    it("is no-op at end of input", () => {
+      const r = deleteAt({ input: "abc", cursor: 3 });
+      expect(r).toEqual({ input: "abc", cursor: 3 });
+    });
+
+    it("removes whole Korean syllable at cursor", () => {
+      const r = deleteAt({ input: "안녕하세요", cursor: 1 });
+      expect(r).toEqual({ input: "안하세요", cursor: 1 });
+    });
+  });
+
+  describe("cursor movement", () => {
+    it("moveCursorLeft decrements but stops at 0", () => {
+      expect(moveCursorLeft({ input: "abc", cursor: 2 })).toEqual({ input: "abc", cursor: 1 });
+      expect(moveCursorLeft({ input: "abc", cursor: 0 })).toEqual({ input: "abc", cursor: 0 });
+    });
+
+    it("moveCursorRight increments but stops at length", () => {
+      expect(moveCursorRight({ input: "abc", cursor: 1 })).toEqual({ input: "abc", cursor: 2 });
+      expect(moveCursorRight({ input: "abc", cursor: 3 })).toEqual({ input: "abc", cursor: 3 });
+    });
+
+    it("moveCursorHome jumps to 0", () => {
+      expect(moveCursorHome({ input: "abc", cursor: 2 })).toEqual({ input: "abc", cursor: 0 });
+    });
+
+    it("moveCursorEnd jumps to code-point length (not UTF-16 length) for Korean", () => {
+      expect(moveCursorEnd({ input: "안녕하세요", cursor: 0 })).toEqual({ input: "안녕하세요", cursor: 5 });
+    });
+  });
+
+  describe("setInput", () => {
+    it("replaces input and places cursor at end", () => {
+      expect(setInput("recalled prompt")).toEqual({ input: "recalled prompt", cursor: 15 });
+    });
+
+    it("handles empty string", () => {
+      expect(setInput("")).toEqual({ input: "", cursor: 0 });
+    });
+
+    it("places cursor past Korean syllables at end", () => {
+      expect(setInput("안녕")).toEqual({ input: "안녕", cursor: 2 });
+    });
+  });
+
+  describe("composed scenarios", () => {
+    it("type → move left → backspace → type again", () => {
+      let state = { input: "", cursor: 0 };
+      state = insertAt(state, "h");
+      state = insertAt(state, "e");
+      state = insertAt(state, "l");
+      state = insertAt(state, "l");
+      state = insertAt(state, "o");
+      expect(state).toEqual({ input: "hello", cursor: 5 });
+
+      state = moveCursorLeft(state); // cursor=4 (between 'l' and 'o')
+      state = moveCursorLeft(state); // cursor=3 (between 'l' and 'l')
+      state = backspaceAt(state); // removes second 'l' before cursor
+      expect(state).toEqual({ input: "helo", cursor: 2 });
+
+      state = insertAt(state, "X");
+      expect(state).toEqual({ input: "heXlo", cursor: 3 });
+    });
+
+    it("Ctrl+A then type prepends to input", () => {
+      let state = { input: "world", cursor: 5 };
+      state = moveCursorHome(state);
+      state = insertAt(state, "hello ");
+      expect(state).toEqual({ input: "hello world", cursor: 6 });
+    });
+
+    it("Ctrl+E from middle then backspace removes last char", () => {
+      let state = { input: "abcdef", cursor: 2 };
+      state = moveCursorEnd(state);
+      expect(state.cursor).toBe(6);
+      state = backspaceAt(state);
+      expect(state).toEqual({ input: "abcde", cursor: 5 });
+    });
+  });
+});

--- a/tests/ts/unit/cli/tui/renderer-cursor.test.ts
+++ b/tests/ts/unit/cli/tui/renderer-cursor.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { measureInputLayout } from "../../../../../src/cli/tui/renderer.js";
+
+const dims = (rows: number, columns: number) => ({ rows, columns });
+
+describe("measureInputLayout cursor positioning (P3-3 2단계)", () => {
+  it("defaults cursor to end of last visible line when cursorPos is omitted", () => {
+    const layout = measureInputLayout(dims(24, 80), "hello");
+    // First-line prompt offset is "> " (2 cols). "hello" width = 5.
+    expect(layout.cursorCol).toBe(2 + 5);
+    expect(layout.cursorRow).toBe(layout.inputStartRow);
+  });
+
+  it("places cursor on first line with prompt offset when cursorPos = 0", () => {
+    const layout = measureInputLayout(dims(24, 80), "hello world", 0);
+    expect(layout.cursorRow).toBe(layout.inputStartRow);
+    // Cursor at start → just the "> " prompt offset, no input width consumed.
+    expect(layout.cursorCol).toBe(2);
+  });
+
+  it("places cursor in middle of first line", () => {
+    const layout = measureInputLayout(dims(24, 80), "hello world", 5);
+    expect(layout.cursorRow).toBe(layout.inputStartRow);
+    // "hello" width = 5, plus "> " prompt = 7
+    expect(layout.cursorCol).toBe(2 + 5);
+  });
+
+  it("places cursor at end when cursorPos equals input length", () => {
+    const layout = measureInputLayout(dims(24, 80), "hello", 5);
+    expect(layout.cursorRow).toBe(layout.inputStartRow);
+    expect(layout.cursorCol).toBe(2 + 5);
+  });
+
+  it("handles cursorPos beyond input length by clamping to end", () => {
+    const layout = measureInputLayout(dims(24, 80), "hi", 99);
+    expect(layout.cursorCol).toBe(2 + 2);
+  });
+
+  it("counts CJK display width (2 cells per Korean syllable)", () => {
+    // "한" is 2 display cells; with cursor after it, col = 2 (prompt) + 2 (한)
+    const layout = measureInputLayout(dims(24, 80), "한", 1);
+    expect(layout.cursorCol).toBe(2 + 2);
+  });
+
+  it("moves cursor to second wrapped line when input exceeds first-line width", () => {
+    // dims.columns = 10 → first-line width = 8 (after "> " prompt). Continuation width = 10.
+    // input "1234567890ab" should wrap: line0 = "12345678", line1 = "90ab"
+    const layout = measureInputLayout(dims(24, 10), "1234567890ab", 12);
+    expect(layout.cursorRow).toBeGreaterThan(layout.inputStartRow);
+    // Cursor at end of line1, which is "90ab" (4 chars). No prompt offset on continuation.
+    expect(layout.cursorCol).toBe(4);
+  });
+
+  it("places cursor at line break boundary correctly", () => {
+    // cursor=8 means after "12345678" → start of next continuation line.
+    const layout = measureInputLayout(dims(24, 10), "1234567890ab", 8);
+    // 8 chars + prompt offset 2 = 10 col, which is end-of-line on a 10-col window.
+    // wrapInputLines keeps the chars on line 0 until they exceed width.
+    expect(layout.cursorRow).toBe(layout.inputStartRow);
+    expect(layout.cursorCol).toBe(2 + 8);
+  });
+
+  it("handles multi-line input via explicit \\n", () => {
+    // input.slice(0, 5) = "abc\nd" → wrap into ["abc", "d"]
+    const layout = measureInputLayout(dims(24, 80), "abc\ndef", 5);
+    // Cursor on line 1 (continuation), at end of "d" (col 1, no prompt offset).
+    expect(layout.cursorRow).toBe(layout.inputStartRow + 1);
+    expect(layout.cursorCol).toBe(1);
+  });
+
+  it("returns identical layout (besides cursor) regardless of cursorPos for plain input", () => {
+    const withCursor = measureInputLayout(dims(24, 80), "hello world", 3);
+    const withoutCursor = measureInputLayout(dims(24, 80), "hello world");
+    expect(withCursor.visibleLines).toEqual(withoutCursor.visibleLines);
+    expect(withCursor.separatorRow).toBe(withoutCursor.separatorRow);
+    expect(withCursor.inputStartRow).toBe(withoutCursor.inputStartRow);
+    expect(withCursor.totalLineCount).toBe(withoutCursor.totalLineCount);
+  });
+});


### PR DESCRIPTION
## Summary

TUI UI/UX 개선 로드맵의 **P3-3 2단계** — 입력 영역에 in-line 커서 편집 추가. P3-3 1단계 (히스토리) 위에 자연 확장.

기존엔 input 이 단순 append-only string 이라 한 번 친 내용 중간을 고치려면 다 지우고 다시 타이핑해야 했음. 이번 PR 로 readline 수준의 편집 가능:

| 키 | 동작 |
|---|---|
| ← / → | 커서 좌/우 이동 |
| Ctrl+A / Home | 입력 시작으로 |
| Ctrl+E / End | 입력 끝으로 |
| Ctrl+D | 커서 위치 글자 forward-delete (empty input 일 땐 기존 exit 유지) |
| Backspace | 커서 **앞** 글자 삭제 (예전엔 항상 마지막 글자) |
| 일반 글자 | 커서 위치에 **삽입** (예전엔 항상 끝에 append) |

embedded pane 모드에서 Home/End 는 기존 viewport scroll 동작 유지 (긴 output 읽을 때 필요). non-embedded 모드에서만 cursor home/end.

## Internal model change

```ts
// Before
let input = "";

// After
let input = "";
let cursor = 0;  // code-point index, 0 ≤ cursor ≤ codepointLength(input)
```

모든 input mutation 이 새 `src/cli/tui/input-cursor.ts` 모듈의 pure 함수를 거침. 한글·이모지가 깨지지 않도록 `Array.from()` 기반 code-point 단위 처리.

## Render

`renderer.measureInputLayout(dims, input, cursorPos?)` 에 optional cursorPos 추가:
- cursorPos 가 전달되면 input.slice(0, cursorPos) 를 다시 wrap 해서 정확한 (row, col) 계산
- `> ` prompt offset 은 첫 visible 라인에만 적용
- CJK display width 보존 (한글 2-cell)
- cursorPos 가 visible window 위에 있으면 첫 visible row 로 pin

## Changes

| 파일 | 변경 |
|---|---|
| `src/cli/tui/input-cursor.ts` | 신규 — CursorState + 8개 pure mutation/movement 함수 |
| `src/cli/tui/renderer.ts` | measureInputLayout / renderInputArea 가 optional cursorPos 받아 정확한 cursor (row, col) 계산 |
| `src/cli/tui/index.ts` | cursor state 추가 · 모든 input mutation 을 cursor-aware 헬퍼로 교체 · Ctrl+A/E/D + ←/→ + Home/End 핸들러 추가 |
| `tests/.../input-cursor.test.ts` | 26 신규 tests |
| `tests/.../renderer-cursor.test.ts` | 10 신규 tests |

## Reviewer Notes

- **시각 변화 1 가지**: 커서가 항상 입력 끝에 있던 것 → 이제 사용자가 이동한 위치에 표시됨. 이게 P3-3 2단계의 핵심 효과.
- **breaking 변경 없음**: 기존 키 동작 (Enter, Backspace, Ctrl+C, ↑/↓ 히스토리, /autocomplete) 모두 그대로. 새 키만 추가 + Backspace 의미만 "마지막" → "커서 앞" 으로 살짝 바뀜 (사용자가 cursor 안 옮기면 동일 효과).
- **embedded pane Home/End 충돌**: embedded 모드에선 기존 scroll 동작 유지. 이유: 긴 codex/gemini output 읽을 때 시작/끝으로 빠르게 점프하는 게 더 자주 필요. cursor home/end 가 필요하면 Ctrl+A/E 사용.
- **Ctrl+D 정책**: empty input 일 땐 기존 exit (shell 컨벤션). non-empty 일 땐 forward-delete. 분기 조건: `char === "\x04" && input.length > 0`.
- **한글 IME 호환**: insertAt 가 Array.from 기반 → 한글 syllable (BMP 코드 포인트) 단위 안전. 기존 committed-character append 경로 무수정.
- **clamp 정책**: cursor 가 out-of-range 면 자동으로 [0, length] 로. 외부 caller 가 잘못된 값 넣어도 절대 throw 안 함.
- **history recall 시 cursor 위치**: setInput(recalled) → 커서가 recall 된 문자열 끝. bash 와 일치.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- --run tests/ts/unit/cli/tui/` — 22 files, 290 tests 통과 (254 → +36)
- [x] input-cursor 26 tests + renderer-cursor 10 tests
- [ ] 실 터미널 수동 검증:
  - "hello world" 입력 후 ← 5번 → 커서가 'o' 와 ' ' 사이
  - Ctrl+A → 커서 맨 앞 / Ctrl+E → 맨 끝
  - 중간 위치에서 backspace → 앞 글자 삭제
  - 한글 "안녕하세요" 입력 후 ← 2번 → "하" 글자 앞 / backspace → "안녕세요"
  - 히스토리 ↑ recall 후 Ctrl+A → recall 된 prompt 의 맨 앞
  - embedded 모드에서 Home/End → embedded pane scroll (cursor 이동 X)

## Roadmap progress

| | |
|---|---|
| ✅ 머지 | PR1~5, P2-1, P3-2, P3-3 (1단계), P3-4 (9개) |
| 🟡 본 PR | **P3-3 (2단계) cursor editing** |
| 남음 | P3-1 Resizable panel (가장 복잡, 8~12h) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)