### PR TITLE
feat(tui): runtime resizable transcript/result split — /layout 명령 + Alt+↑/↓ (P3-1)

### DIFF
--- a/src/cli/repl-commands/index.ts
+++ b/src/cli/repl-commands/index.ts
@@ -96,6 +96,12 @@ const BASE_COMMANDS: SlashCommand[] = [
     usage: "/cache [stats|clear|disable|enable]",
   },
   {
+    name: "layout",
+    aliases: ["l"],
+    description: "transcript/result 패널 비율 조정 (reset / transcript=N result=N / + / -)",
+    usage: "/layout [reset|transcript=N|result=N|+|-]",
+  },
+  {
     name: "exit",
     aliases: ["quit", "q"],
     description: "REPL 종료",
@@ -454,6 +460,7 @@ export const handleSlashCommand = async (
     onMainScreenRestore?: () => void;
     onInteractiveStart?: () => void;
     onInteractiveEnd?: () => void;
+    onLayoutCommand?: (args: readonly string[]) => string;
   },
 ): Promise<boolean> => {
   const adapter = state.adapter as Adapter;
@@ -512,6 +519,17 @@ export const handleSlashCommand = async (
         ),
       );
       return true;
+
+    case "layout": {
+      const args = input.trim().split(/\s+/).slice(1);
+      if (state.onLayoutCommand) {
+        const message = state.onLayoutCommand(args);
+        if (message) output.write(colors.info(`\n${message}\n\n`));
+      } else {
+        output.write(colors.warning("\n레이아웃 변경이 비활성화된 컨텍스트입니다.\n\n"));
+      }
+      return true;
+    }
 
     case "codex-models": {
       const handled = await handleCodexModels(selectStreams);

--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -54,6 +54,16 @@ import {
   setInput,
 } from "./input-cursor.js";
 import {
+  computeShiftedOverrides,
+  getEffectiveWeights,
+  isEmptyOverrides,
+  loadLayoutOverrides,
+  parseLayoutCommand,
+  resolveLayoutOverridesPath,
+  saveLayoutOverrides,
+  type RuntimeLayoutOverrides,
+} from "./runtime-layout.js";
+import {
   createEmbeddedTerminalFocusManager,
   isEmbeddedTerminalInterruptKey,
   isEmbeddedTerminalNativeFocusToggleKey,
@@ -267,6 +277,15 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     void loadHistoryFromDisk(historyPath)
       .then((entries) => inputHistory.load(entries))
       .catch(() => undefined);
+
+    // P3-1: Runtime layout overrides — load applied below after render() is defined.
+    let layoutOverrides: RuntimeLayoutOverrides = {};
+    const layoutOverridesPath = resolveLayoutOverridesPath(executionCwd);
+    const getTranscriptRatio = (): number => {
+      const { transcriptWeight, resultWeight } = getEffectiveWeights(layoutOverrides);
+      const total = transcriptWeight + resultWeight;
+      return total > 0 ? transcriptWeight / total : 0.7;
+    };
     let embeddedTerminalPane = new EmbeddedTerminalPane();
     const eventRouter = new TuiEventRouter({
       pipelinePanel,
@@ -887,7 +906,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       const availableContentRows = Math.max(0, inputLayout.separatorRow - contentRegionStart);
       const transcriptRows =
         availableContentRows > 0
-          ? Math.max(1, Math.floor(availableContentRows * 0.7))
+          ? Math.max(1, Math.floor(availableContentRows * getTranscriptRatio()))
           : 0;
       const transcriptRegionEnd = Math.min(
         inputLayout.separatorRow,
@@ -940,7 +959,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         };
         const transcriptPtyRows = Math.max(
           1,
-          Math.ceil(Math.max(0, availableContentRows - stickyRows) * 0.7),
+          Math.ceil(Math.max(0, availableContentRows - stickyRows) * getTranscriptRatio()),
         );
         embeddedTerminalPane.resize(transcriptRegion.columns, transcriptPtyRows);
         if (embeddedNativeCliSession !== null) {
@@ -1196,6 +1215,21 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               handled = true;
               continue;
             }
+          }
+
+          // P3-1: Alt+↑/↓ (xterm SGR \x1b[1;3A / \x1b[1;3B) shifts transcript
+          // weight ±1. Detect BEFORE the 3-char arrow dispatch since these
+          // are 6-char sequences.
+          if (text.startsWith("\x1b[1;3A", i) || text.startsWith("\x1b[1;3B", i)) {
+            const delta = text.charAt(i + 5) === "A" ? 1 : -1;
+            layoutOverrides = computeShiftedOverrides(layoutOverrides, delta);
+            void saveLayoutOverrides(layoutOverridesPath, layoutOverrides).catch(
+              () => undefined,
+            );
+            needsFullRender = true;
+            i += 6;
+            handled = true;
+            continue;
           }
 
           const sequence = text.substring(i, i + 3);
@@ -1559,6 +1593,37 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
             onExit: async () => {
               running = false;
             },
+            onLayoutCommand: (args) => {
+              const action = parseLayoutCommand(args);
+              if (action.kind === "show") {
+                const w = getEffectiveWeights(layoutOverrides);
+                return `현재 transcript=${w.transcriptWeight}  result=${w.resultWeight} (기본값 7/3, 사용법: /layout reset | transcript=N result=N | + | -)`;
+              }
+              if (action.kind === "unknown") {
+                return `알 수 없는 인자: ${action.arg}. 사용법: /layout reset | transcript=N result=N | + | -`;
+              }
+              if (action.kind === "reset") {
+                layoutOverrides = {};
+              } else if (action.kind === "shift") {
+                layoutOverrides = computeShiftedOverrides(layoutOverrides, action.transcriptDelta);
+              } else {
+                layoutOverrides = {
+                  ...layoutOverrides,
+                  ...(action.transcriptWeight !== undefined
+                    ? { transcriptWeight: action.transcriptWeight }
+                    : {}),
+                  ...(action.resultWeight !== undefined
+                    ? { resultWeight: action.resultWeight }
+                    : {}),
+                };
+              }
+              void saveLayoutOverrides(layoutOverridesPath, layoutOverrides).catch(
+                () => undefined,
+              );
+              forceFullRender = true;
+              const w = getEffectiveWeights(layoutOverrides);
+              return `레이아웃 조정: transcript=${w.transcriptWeight} result=${w.resultWeight}`;
+            },
           });
 
           refreshRuntimeState();
@@ -1782,6 +1847,18 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         isExecuting = false;
       }
     };
+
+    // P3-1: kick off layout overrides load (non-fatal) — once it resolves,
+    // future renders pick up the new ratio.
+    void loadLayoutOverrides(layoutOverridesPath)
+      .then((loaded) => {
+        if (!isEmptyOverrides(loaded)) {
+          layoutOverrides = loaded;
+          forceFullRender = true;
+          render();
+        }
+      })
+      .catch(() => undefined);
 
     stdin.on("data", onData);
     stdin.on("end", () => {

--- a/src/cli/tui/layout-manager.ts
+++ b/src/cli/tui/layout-manager.ts
@@ -139,8 +139,11 @@ export const computeLayoutRegions = (
   return result;
 };
 
-export const computeLayout = (dims: ScreenDimensions): LayoutConfig => {
-  const regions = computeLayoutRegions(dims);
+export const computeLayout = (
+  dims: ScreenDimensions,
+  schema: readonly PanelDef[] = DEFAULT_LAYOUT_SCHEMA,
+): LayoutConfig => {
+  const regions = computeLayoutRegions(dims, schema);
   return {
     rows: dims.rows,
     columns: dims.columns,

--- a/src/cli/tui/runtime-layout.ts
+++ b/src/cli/tui/runtime-layout.ts
@@ -1,0 +1,155 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { DEFAULT_LAYOUT_SCHEMA, type PanelDef } from "./layout-manager.js";
+import { resolveProjectDataDir } from "../../core/state/storage-paths.js";
+
+const OVERRIDES_FILENAME = "layout-overrides.json";
+const MIN_FLEX_WEIGHT = 1;
+const MAX_FLEX_WEIGHT = 99;
+
+/** User-adjustable flex weights for the two main content panels. */
+export interface RuntimeLayoutOverrides {
+  transcriptWeight?: number;
+  resultWeight?: number;
+}
+
+export const isEmptyOverrides = (overrides: RuntimeLayoutOverrides): boolean =>
+  overrides.transcriptWeight === undefined && overrides.resultWeight === undefined;
+
+const clampWeight = (value: number): number => {
+  if (!Number.isFinite(value)) return MIN_FLEX_WEIGHT;
+  return Math.min(MAX_FLEX_WEIGHT, Math.max(MIN_FLEX_WEIGHT, Math.floor(value)));
+};
+
+/**
+ * Returns a new schema with transcript/result weights replaced when overrides
+ * specify them. Other panels are passed through untouched.
+ */
+export const applyLayoutOverrides = (
+  schema: readonly PanelDef[],
+  overrides: RuntimeLayoutOverrides,
+): readonly PanelDef[] => {
+  if (isEmptyOverrides(overrides)) return schema;
+  return schema.map((panel) => {
+    if (panel.id === "transcript" && overrides.transcriptWeight !== undefined) {
+      return { ...panel, weight: clampWeight(overrides.transcriptWeight) };
+    }
+    if (panel.id === "result" && overrides.resultWeight !== undefined) {
+      return { ...panel, weight: clampWeight(overrides.resultWeight) };
+    }
+    return panel;
+  });
+};
+
+export type LayoutCommandAction =
+  | { kind: "reset" }
+  | { kind: "set"; transcriptWeight?: number; resultWeight?: number }
+  | { kind: "shift"; transcriptDelta: number }
+  | { kind: "show" }
+  | { kind: "unknown"; arg: string };
+
+/**
+ * Parses /layout command args. Examples:
+ *   /layout                  → show current
+ *   /layout reset            → restore default 7/3 split
+ *   /layout transcript=8     → transcript=8 (result inferred from current)
+ *   /layout transcript=8 result=2
+ *   /layout result=4         → result=4 (transcript inferred)
+ *   /layout +                → transcript += 1, result -= 1 (shift toward transcript)
+ *   /layout -                → transcript -= 1, result += 1 (shift toward result)
+ */
+export const parseLayoutCommand = (args: readonly string[]): LayoutCommandAction => {
+  if (args.length === 0) return { kind: "show" };
+
+  const first = args[0]?.toLowerCase() ?? "";
+  if (first === "reset" || first === "default") return { kind: "reset" };
+  if (first === "+" || first === "up") return { kind: "shift", transcriptDelta: 1 };
+  if (first === "-" || first === "down") return { kind: "shift", transcriptDelta: -1 };
+
+  const result: { kind: "set"; transcriptWeight?: number; resultWeight?: number } = { kind: "set" };
+  let matched = false;
+  for (const arg of args) {
+    const [rawKey, rawValue] = arg.split("=");
+    if (!rawKey || rawValue === undefined) continue;
+    const key = rawKey.trim().toLowerCase();
+    const value = Number(rawValue.trim());
+    if (!Number.isFinite(value)) continue;
+    if (key === "transcript" || key === "t") {
+      result.transcriptWeight = clampWeight(value);
+      matched = true;
+    } else if (key === "result" || key === "r") {
+      result.resultWeight = clampWeight(value);
+      matched = true;
+    }
+  }
+  if (!matched) {
+    return { kind: "unknown", arg: args.join(" ") };
+  }
+  return result;
+};
+
+/** Convert a shift delta into next absolute overrides given current state. */
+export const computeShiftedOverrides = (
+  current: RuntimeLayoutOverrides,
+  transcriptDelta: number,
+  defaults: { transcriptWeight: number; resultWeight: number } = {
+    transcriptWeight: 7,
+    resultWeight: 3,
+  },
+): RuntimeLayoutOverrides => {
+  const baseT = current.transcriptWeight ?? defaults.transcriptWeight;
+  const baseR = current.resultWeight ?? defaults.resultWeight;
+  return {
+    transcriptWeight: clampWeight(baseT + transcriptDelta),
+    resultWeight: clampWeight(baseR - transcriptDelta),
+  };
+};
+
+/** Derives current effective weights from DEFAULT_LAYOUT_SCHEMA + overrides. */
+export const getEffectiveWeights = (
+  overrides: RuntimeLayoutOverrides,
+  schema: readonly PanelDef[] = DEFAULT_LAYOUT_SCHEMA,
+): { transcriptWeight: number; resultWeight: number } => {
+  const transcript = schema.find((p) => p.id === "transcript");
+  const result = schema.find((p) => p.id === "result");
+  return {
+    transcriptWeight: overrides.transcriptWeight ?? transcript?.weight ?? 7,
+    resultWeight: overrides.resultWeight ?? result?.weight ?? 3,
+  };
+};
+
+export const resolveLayoutOverridesPath = (
+  cwd: string = process.cwd(),
+): string => join(resolveProjectDataDir(cwd), OVERRIDES_FILENAME);
+
+export const loadLayoutOverrides = async (
+  filePath: string,
+): Promise<RuntimeLayoutOverrides> => {
+  let raw: string;
+  try {
+    raw = await readFile(filePath, "utf-8");
+  } catch {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<RuntimeLayoutOverrides>;
+    const overrides: RuntimeLayoutOverrides = {};
+    if (typeof parsed.transcriptWeight === "number") {
+      overrides.transcriptWeight = clampWeight(parsed.transcriptWeight);
+    }
+    if (typeof parsed.resultWeight === "number") {
+      overrides.resultWeight = clampWeight(parsed.resultWeight);
+    }
+    return overrides;
+  } catch {
+    return {};
+  }
+};
+
+export const saveLayoutOverrides = async (
+  filePath: string,
+  overrides: RuntimeLayoutOverrides,
+): Promise<void> => {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(overrides, null, 2) + "\n", "utf-8");
+};

--- a/tests/ts/unit/cli/tui/runtime-layout.test.ts
+++ b/tests/ts/unit/cli/tui/runtime-layout.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  applyLayoutOverrides,
+  computeShiftedOverrides,
+  getEffectiveWeights,
+  isEmptyOverrides,
+  loadLayoutOverrides,
+  parseLayoutCommand,
+  resolveLayoutOverridesPath,
+  saveLayoutOverrides,
+  type RuntimeLayoutOverrides,
+} from "../../../../../src/cli/tui/runtime-layout.js";
+import { DEFAULT_LAYOUT_SCHEMA } from "../../../../../src/cli/tui/layout-manager.js";
+
+describe("runtime-layout", () => {
+  describe("isEmptyOverrides", () => {
+    it("returns true when no weights set", () => {
+      expect(isEmptyOverrides({})).toBe(true);
+    });
+
+    it("returns false when transcriptWeight set", () => {
+      expect(isEmptyOverrides({ transcriptWeight: 5 })).toBe(false);
+    });
+
+    it("returns false when resultWeight set", () => {
+      expect(isEmptyOverrides({ resultWeight: 2 })).toBe(false);
+    });
+  });
+
+  describe("applyLayoutOverrides", () => {
+    it("returns the schema unchanged when overrides are empty", () => {
+      expect(applyLayoutOverrides(DEFAULT_LAYOUT_SCHEMA, {})).toBe(DEFAULT_LAYOUT_SCHEMA);
+    });
+
+    it("replaces transcript weight only", () => {
+      const result = applyLayoutOverrides(DEFAULT_LAYOUT_SCHEMA, { transcriptWeight: 8 });
+      const transcript = result.find((p) => p.id === "transcript");
+      const resultPanel = result.find((p) => p.id === "result");
+      expect(transcript?.weight).toBe(8);
+      expect(resultPanel?.weight).toBe(3);
+    });
+
+    it("replaces both weights", () => {
+      const result = applyLayoutOverrides(DEFAULT_LAYOUT_SCHEMA, {
+        transcriptWeight: 5,
+        resultWeight: 5,
+      });
+      expect(result.find((p) => p.id === "transcript")?.weight).toBe(5);
+      expect(result.find((p) => p.id === "result")?.weight).toBe(5);
+    });
+
+    it("clamps below MIN_FLEX_WEIGHT (1)", () => {
+      const result = applyLayoutOverrides(DEFAULT_LAYOUT_SCHEMA, {
+        transcriptWeight: 0,
+      });
+      expect(result.find((p) => p.id === "transcript")?.weight).toBe(1);
+    });
+
+    it("clamps above MAX_FLEX_WEIGHT (99)", () => {
+      const result = applyLayoutOverrides(DEFAULT_LAYOUT_SCHEMA, {
+        transcriptWeight: 1000,
+      });
+      expect(result.find((p) => p.id === "transcript")?.weight).toBe(99);
+    });
+
+    it("does not touch panels that are not transcript/result", () => {
+      const result = applyLayoutOverrides(DEFAULT_LAYOUT_SCHEMA, {
+        transcriptWeight: 9,
+      });
+      expect(result.find((p) => p.id === "header")).toEqual(
+        DEFAULT_LAYOUT_SCHEMA.find((p) => p.id === "header"),
+      );
+      expect(result.find((p) => p.id === "input")).toEqual(
+        DEFAULT_LAYOUT_SCHEMA.find((p) => p.id === "input"),
+      );
+    });
+  });
+
+  describe("parseLayoutCommand", () => {
+    it("returns show when no args", () => {
+      expect(parseLayoutCommand([])).toEqual({ kind: "show" });
+    });
+
+    it("returns reset for 'reset' or 'default'", () => {
+      expect(parseLayoutCommand(["reset"])).toEqual({ kind: "reset" });
+      expect(parseLayoutCommand(["default"])).toEqual({ kind: "reset" });
+      expect(parseLayoutCommand(["RESET"])).toEqual({ kind: "reset" });
+    });
+
+    it("returns shift +1 for '+' or 'up'", () => {
+      expect(parseLayoutCommand(["+"])).toEqual({ kind: "shift", transcriptDelta: 1 });
+      expect(parseLayoutCommand(["up"])).toEqual({ kind: "shift", transcriptDelta: 1 });
+    });
+
+    it("returns shift -1 for '-' or 'down'", () => {
+      expect(parseLayoutCommand(["-"])).toEqual({ kind: "shift", transcriptDelta: -1 });
+      expect(parseLayoutCommand(["down"])).toEqual({ kind: "shift", transcriptDelta: -1 });
+    });
+
+    it("parses transcript=N", () => {
+      expect(parseLayoutCommand(["transcript=8"])).toEqual({
+        kind: "set",
+        transcriptWeight: 8,
+      });
+    });
+
+    it("parses result=N", () => {
+      expect(parseLayoutCommand(["result=4"])).toEqual({
+        kind: "set",
+        resultWeight: 4,
+      });
+    });
+
+    it("parses combined transcript=N result=N", () => {
+      expect(parseLayoutCommand(["transcript=8", "result=2"])).toEqual({
+        kind: "set",
+        transcriptWeight: 8,
+        resultWeight: 2,
+      });
+    });
+
+    it("accepts t/r short forms", () => {
+      expect(parseLayoutCommand(["t=6", "r=4"])).toEqual({
+        kind: "set",
+        transcriptWeight: 6,
+        resultWeight: 4,
+      });
+    });
+
+    it("clamps invalid (negative/too large) values", () => {
+      const r = parseLayoutCommand(["transcript=-5", "result=500"]);
+      expect(r).toEqual({ kind: "set", transcriptWeight: 1, resultWeight: 99 });
+    });
+
+    it("returns unknown for unrecognized argument", () => {
+      expect(parseLayoutCommand(["foobar"])).toEqual({ kind: "unknown", arg: "foobar" });
+    });
+
+    it("returns unknown when no key=value pairs match", () => {
+      expect(parseLayoutCommand(["x=1"])).toEqual({ kind: "unknown", arg: "x=1" });
+    });
+  });
+
+  describe("computeShiftedOverrides", () => {
+    it("shifts toward transcript when delta is positive", () => {
+      const r = computeShiftedOverrides({}, 1);
+      expect(r).toEqual({ transcriptWeight: 8, resultWeight: 2 });
+    });
+
+    it("shifts toward result when delta is negative", () => {
+      const r = computeShiftedOverrides({}, -1);
+      expect(r).toEqual({ transcriptWeight: 6, resultWeight: 4 });
+    });
+
+    it("clamps to min (1)", () => {
+      const r = computeShiftedOverrides({ transcriptWeight: 1, resultWeight: 99 }, -5);
+      expect(r.transcriptWeight).toBe(1);
+    });
+
+    it("clamps to max (99)", () => {
+      const r = computeShiftedOverrides({ transcriptWeight: 99, resultWeight: 1 }, 5);
+      expect(r.transcriptWeight).toBe(99);
+    });
+
+    it("operates from current overrides, not defaults", () => {
+      const r = computeShiftedOverrides({ transcriptWeight: 5, resultWeight: 5 }, 1);
+      expect(r).toEqual({ transcriptWeight: 6, resultWeight: 4 });
+    });
+
+    it("accepts custom default fallback", () => {
+      const r = computeShiftedOverrides({}, 1, { transcriptWeight: 4, resultWeight: 6 });
+      expect(r).toEqual({ transcriptWeight: 5, resultWeight: 5 });
+    });
+  });
+
+  describe("getEffectiveWeights", () => {
+    it("falls back to default schema (7/3) when overrides empty", () => {
+      expect(getEffectiveWeights({})).toEqual({ transcriptWeight: 7, resultWeight: 3 });
+    });
+
+    it("uses overrides when provided", () => {
+      expect(getEffectiveWeights({ transcriptWeight: 8, resultWeight: 2 })).toEqual({
+        transcriptWeight: 8,
+        resultWeight: 2,
+      });
+    });
+
+    it("mixes overrides with schema defaults when partial", () => {
+      expect(getEffectiveWeights({ transcriptWeight: 9 })).toEqual({
+        transcriptWeight: 9,
+        resultWeight: 3,
+      });
+    });
+  });
+
+  describe("disk persistence", () => {
+    let tempDir: string;
+    let filePath: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), "detoks-layout-test-"));
+      filePath = join(tempDir, "layout-overrides.json");
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("loadLayoutOverrides returns empty object when file missing", async () => {
+      expect(await loadLayoutOverrides(filePath)).toEqual({});
+    });
+
+    it("save then load round-trips", async () => {
+      const overrides: RuntimeLayoutOverrides = { transcriptWeight: 6, resultWeight: 4 };
+      await saveLayoutOverrides(filePath, overrides);
+      expect(await loadLayoutOverrides(filePath)).toEqual(overrides);
+    });
+
+    it("clamps invalid stored values on load", async () => {
+      await saveLayoutOverrides(filePath, { transcriptWeight: 200, resultWeight: -3 });
+      const loaded = await loadLayoutOverrides(filePath);
+      expect(loaded).toEqual({ transcriptWeight: 99, resultWeight: 1 });
+    });
+
+    it("returns empty object on malformed JSON", async () => {
+      const { writeFile } = await import("node:fs/promises");
+      await writeFile(filePath, "not json {", "utf-8");
+      expect(await loadLayoutOverrides(filePath)).toEqual({});
+    });
+
+    it("ignores non-numeric fields", async () => {
+      const { writeFile } = await import("node:fs/promises");
+      await writeFile(
+        filePath,
+        JSON.stringify({ transcriptWeight: "eight", resultWeight: 5 }),
+        "utf-8",
+      );
+      expect(await loadLayoutOverrides(filePath)).toEqual({ resultWeight: 5 });
+    });
+
+    it("saveLayoutOverrides creates parent directories", async () => {
+      const nested = join(tempDir, "a/b/c/layout-overrides.json");
+      await saveLayoutOverrides(nested, { transcriptWeight: 5 });
+      expect(await loadLayoutOverrides(nested)).toEqual({ transcriptWeight: 5 });
+    });
+  });
+
+  describe("resolveLayoutOverridesPath", () => {
+    it("places file under projects/<workspace>/layout-overrides.json", () => {
+      const path = resolveLayoutOverridesPath("/tmp/sample-cwd");
+      expect(path).toMatch(/layout-overrides\.json$/);
+      expect(path).toContain(".detoks/projects/");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

TUI UI/UX 개선 로드맵의 **P3-1 (마지막 P3)** — transcript/result 비율 런타임 조정. 지금까지 70/30 으로 하드코딩됐던 split 을 사용자가 조정 가능 + 워크스페이스별 디스크 영속.

## Usage

```
/layout                       → 현재 비율 표시
/layout reset                 → 기본 7/3 복원
/layout transcript=8 result=2 → 명시
/layout +                     → transcript +1, result -1
/layout -                     → 반대 방향
Alt+↑ / Alt+↓                 → 라이브 ±1 shift (모달 없이)
```

비율은 매 변경 시 `~/.detoks/projects/<workspace>/layout-overrides.json` 에 저장 → 다음 세션 자동 적용.

## Why

지금까지:
- 짧은 작업 위주 (간단한 prompt → 짧은 결과) 사용자는 result 영역이 너무 작음
- 긴 transcript 로그를 자세히 보는 사용자는 transcript 가 너무 짧음
- 워크플로우 마다 선호 비율 다른데 조정 수단 없었음

이번 PR 로:
- 슬래시 명령으로 정확한 비율 설정
- Alt+화살표로 빠른 1-step shift (모달 없이)
- 워크스페이스별 저장 → 프로젝트 별로 다른 비율 가능

## Behavior

| 항목 | 동작 |
|---|---|
| 기본값 | transcript=7, result=3 (변경 없음) |
| 최소 weight | 1 (한쪽 panel 사라지지 않도록) |
| 최대 weight | 99 |
| invalid 인자 | clamp + 경고 (path 차단 0) |
| disk 저장 실패 | non-fatal (다음 세션엔 미반영, 그래도 진행) |
| embedded pane 모드 | PTY 버퍼 size 도 동일 비율로 (codex/gemini 출력 영역 함께 조정) |

## Changes

| 파일 | 변경 |
|---|---|
| `src/cli/tui/runtime-layout.ts` | 신규 — applyLayoutOverrides / parseLayoutCommand / computeShiftedOverrides / getEffectiveWeights / disk persistence |
| `src/cli/tui/layout-manager.ts` | computeLayout(dims, schema?) optional schema 받도록 |
| `src/cli/repl-commands/index.ts` | /layout (alias /l) command + onLayoutCommand 콜백 |
| `src/cli/tui/index.ts` | layoutOverrides state · 디스크 load · getTranscriptRatio() · 0.7 split 2 곳 교체 · onLayoutCommand 콜백 · Alt+↑/↓ 핸들러 |
| `tests/.../runtime-layout.test.ts` | 36 신규 tests |

## Reviewer Notes

- **default 동작 변화 0**: DEFAULT_LAYOUT_SCHEMA 가 7/3 이고 override 없는 사용자는 시각 동일.
- **`computeLayout` 실제 사용**: PR2 에서 도입한 schema-driven `computeLayout` 은 사실상 인덱스에서 미사용이었음. 이번 PR 도 같은 패턴 (index.ts 가 inlined region math 사용) — `getTranscriptRatio()` 만 끼워넣어 override 효과. 차후 PR 에서 인덱스가 `computeLayout` 직접 호출하도록 본격 정리 가능 (별 트랙).
- **Alt+arrow 호환성**: xterm SGR 시퀀스 (`\x1b[1;3A` / `\x1b[1;3B`) 만 처리. macOS Terminal·iTerm2·VS Code 터미널 호환. 일부 오래된 터미널(Linux console 등) 은 `\x1b\x1b[A` 형태로 보내는데 미처리 — 그런 환경에선 `/layout +` / `-` 명령 사용.
- **embedded pane PTY sizing**: codex/gemini 가 실행되는 가상 터미널 크기에도 같은 비율 적용 (line 943 의 transcriptPtyRows). PTY 크기 변경 → 어댑터에 SIGWINCH 전달 → 어댑터 자체 출력 폭 재조정.
- **disk 정책**: `forceFullRender = true` 후 render() 호출은 sync. 디스크 save 는 .catch fire-and-forget — race condition 시 마지막 write 가 이김. 사용자 평균 1초당 < 1 변경이라 무관.
- **clamp 정책 일관성**: load / save / parse / shift 모두 동일한 clampWeight(1..99). 잘못된 값 들어와도 throw 0, 항상 안전.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- --run tests/ts/unit/cli/tui/` — 23 files, 326 tests 통과 (290 → +36)
- [x] runtime-layout 36 신규 tests (모든 helper · disk persistence · clamp · malformed input)
- [ ] 실 터미널 수동 검증:
  - `/layout` → 현재 비율 표시
  - `/layout transcript=8 result=2` → 즉시 시각 변경 + 다음 세션 유지
  - `/layout reset` → 기본 7/3 복원
  - `/layout +` 5번 → transcript 가 점진적으로 커짐
  - Alt+↑/↓ → 라이브 shift (xterm SGR 호환 터미널)
  - 다른 프로젝트로 cd 후 detoks → 그 프로젝트의 별도 비율 적용

## Roadmap progress — P3 완료 🎉

| | |
|---|---|
| ✅ 머지 | PR1~5, P2-1, P3-2, P3-3 (1+2단계), P3-4 (10개) |
| 🟡 본 PR | **P3-1 Resizable panel** |

본 PR 머지 시 **TUI UI/UX 개선 로드맵 P0~P3 전체 완료**. P3-3 의 cursor editing 도 1+2 단계로 묶어 거의 모든 P3 항목 커버. 미커버 P3 (별 트랙 후보):
- 마우스 drag 으로 resize (P3-1 follow-up)
- Ctrl+R 히스토리 검색 (P3-3 follow-up)
- 사용자 정의 schema (전체 panel 추가/제거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)