### PR TITLE
[codex] embedded PTY 렌더링 최적화 및 승인 smoke 안정화

### DIFF
--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -306,6 +306,14 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     let executionClockStartedAt: number | null = null;
     let executionClockTimer: NodeJS.Timeout | undefined;
     let forceFullRender = false;
+    let scheduledRenderTimer: NodeJS.Timeout | undefined;
+    let scheduledRenderReason: string | undefined;
+    let lastEmbeddedNativeResize: { columns: number; rows: number } | null = null;
+    let renderPerfWindowStartedAt = Date.now();
+    let renderPerfCount = 0;
+    let coalescedRenderCount = 0;
+    let ptyEventPerfCount = 0;
+    let render: () => void = () => {};
     let localLlmBuildHint: string | null = null;
     let buildSpinnerTimer: NodeJS.Timeout | undefined;
     let buildSpinnerFrame = 0;
@@ -708,6 +716,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         embeddedNativeCliSession?.close();
       }
       embeddedNativeCliSession = null;
+      lastEmbeddedNativeResize = null;
     };
 
     const closeActiveAdapterController = (signal?: NodeJS.Signals): void => {
@@ -737,6 +746,74 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       forceFullRender = true;
     };
 
+    const maybeFocusEmbeddedInteraction = (): boolean => {
+      if (!embeddedPaneMode) {
+        return false;
+      }
+
+      const interactionState = embeddedTerminalPane.getInteractionState();
+      if (
+        interactionState?.kind === "approval" &&
+        embeddedTerminalFocus.focus !== "adapter-terminal"
+      ) {
+        embeddedTerminalFocus.focusNative();
+        return true;
+      }
+
+      return false;
+    };
+
+    const emitRenderPerfIfNeeded = (): void => {
+      if (process.env.DETOKS_TUI_PERF !== "1") {
+        return;
+      }
+
+      const now = Date.now();
+      const elapsed = now - renderPerfWindowStartedAt;
+      if (elapsed < 1000) {
+        return;
+      }
+
+      process.stderr.write(
+        `[detoks:tui-perf] render=${renderPerfCount}/s pty=${ptyEventPerfCount}/s coalesced=${coalescedRenderCount}/s reason=${scheduledRenderReason ?? "none"}\n`,
+      );
+      renderPerfWindowStartedAt = now;
+      renderPerfCount = 0;
+      coalescedRenderCount = 0;
+      ptyEventPerfCount = 0;
+    };
+
+    const renderNow = (_reason: string): void => {
+      if (scheduledRenderTimer !== undefined) {
+        clearTimeout(scheduledRenderTimer);
+        scheduledRenderTimer = undefined;
+      }
+      render();
+      renderPerfCount += 1;
+      emitRenderPerfIfNeeded();
+    };
+
+    const requestRender = (reason: string): void => {
+      scheduledRenderReason = reason;
+      if (!embeddedPaneMode) {
+        renderNow(reason);
+        return;
+      }
+
+      if (scheduledRenderTimer !== undefined) {
+        coalescedRenderCount += 1;
+        return;
+      }
+
+      scheduledRenderTimer = setTimeout(() => {
+        scheduledRenderTimer = undefined;
+        maybeFocusEmbeddedInteraction();
+        render();
+        renderPerfCount += 1;
+        emitRenderPerfIfNeeded();
+      }, 16);
+    };
+
     const startExecutionClock = (): void => {
       if (!embeddedPaneMode || executionClockStartedAt !== null) {
         return;
@@ -746,7 +823,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       pipelinePanel.setExecutionClock(executionClockStartedAt);
       executionClockTimer = setInterval(() => {
         if (isExecuting) {
-          render();
+          requestRender("execution-clock");
         }
       }, 1000);
     };
@@ -764,7 +841,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         ...(options.sessionId !== undefined ? { sessionId: options.sessionId } : {}),
         onEvent: (event) => {
           eventRouter.routeAdapterEvent(event, "embedded");
-          render();
+          if (event.type === "chunk") {
+            ptyEventPerfCount += 1;
+          }
+          requestRender("embedded-native-event");
         },
       });
     };
@@ -889,7 +969,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       screen.flush();
     };
 
-    const render = (): void => {
+    render = (): void => {
       const dims = screen.getDimensions();
       const ctx = { screen, dims };
       if (forceFullRender) {
@@ -963,7 +1043,17 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         );
         embeddedTerminalPane.resize(transcriptRegion.columns, transcriptPtyRows);
         if (embeddedNativeCliSession !== null) {
-          embeddedNativeCliSession?.resize(transcriptRegion.columns, transcriptPtyRows);
+          if (
+            lastEmbeddedNativeResize === null ||
+            lastEmbeddedNativeResize.columns !== transcriptRegion.columns ||
+            lastEmbeddedNativeResize.rows !== transcriptPtyRows
+          ) {
+            lastEmbeddedNativeResize = {
+              columns: transcriptRegion.columns,
+              rows: transcriptPtyRows,
+            };
+            embeddedNativeCliSession?.resize(transcriptRegion.columns, transcriptPtyRows);
+          }
         }
         embeddedTerminalPane.render(ctx, transcriptRegion);
       } else {
@@ -1017,6 +1107,8 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           return;
         }
         lastProgressRenderAt = now;
+        requestRender("pipeline-progress");
+        return;
       }
       render();
     };
@@ -1708,13 +1800,11 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
 
             if (embeddedPaneMode) {
               eventRouter.routeAdapterEvent(event, "embedded");
-              const interactionState = embeddedTerminalPane.getInteractionState();
-              if (
-                interactionState?.kind === "approval" &&
-                embeddedTerminalFocus.focus !== "adapter-terminal"
-              ) {
-                embeddedTerminalFocus.focusNative();
+              if (event.type === "chunk") {
+                ptyEventPerfCount += 1;
               }
+              requestRender("adapter-event");
+              return;
             } else {
               eventRouter.routeAdapterEvent(event, "transcript");
             }
@@ -1722,7 +1812,12 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           },
           onActionTimelineEvent: (event) => {
             eventRouter.routeActionTimeline(event);
-            if (!nativePassthroughMode || !isExecuting) {
+            if (nativePassthroughMode && isExecuting) {
+              return;
+            }
+            if (embeddedPaneMode && isExecuting) {
+              requestRender("action-timeline");
+            } else {
               render();
             }
           },
@@ -1863,6 +1958,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     stdin.on("data", onData);
     stdin.on("end", () => {
       clearNativeEscapeTimer();
+      if (scheduledRenderTimer !== undefined) {
+        clearTimeout(scheduledRenderTimer);
+        scheduledRenderTimer = undefined;
+      }
       closeExecutionControllers();
       running = false;
     });
@@ -1876,6 +1975,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     }
 
     stdin.removeListener("data", onData);
+    if (scheduledRenderTimer !== undefined) {
+      clearTimeout(scheduledRenderTimer);
+      scheduledRenderTimer = undefined;
+    }
     unsubBuildEvents();
     if (buildSpinnerTimer !== undefined) {
       clearInterval(buildSpinnerTimer);

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -634,11 +634,24 @@ export interface EmbeddedTerminalViewportTrackingInfo {
 export class EmbeddedTerminalPane {
   private readonly buffer = new TerminalEmulatorBuffer(80, 24, EMBEDDED_PANE_SCROLLBACK_LIMIT);
   private scrollOffset = 0;
-  // Cached total renderable line count (after compact summaries are applied) —
-  // updated on every write to avoid rebuilding the combined array on every scrollUp() keypress.
+  // Cached total renderable line count (after compact summaries are applied).
+  // Mark dirty on writes and rebuild lazily during render/scroll queries so
+  // high-frequency PTY chunks do not repeatedly compact the whole scrollback.
   private cachedTotalRows = 0;
   private currentColumns = 80;
   private currentRows = 24;
+  private renderCacheDirty = true;
+  private renderCache:
+    | {
+        width: number;
+        rows: RenderedRowInfo[];
+        cursorColumn: number;
+        cursorVisible: boolean;
+        cursorGlobalRow: number;
+        compactLines: EmbeddedTerminalRenderableLine[];
+      }
+    | null = null;
+  private renderCacheRebuildCount = 0;
 
   clear(): void {
     this.buffer.reset();
@@ -646,6 +659,8 @@ export class EmbeddedTerminalPane {
     this.cachedTotalRows = 0;
     this.currentColumns = 80;
     this.currentRows = 24;
+    this.renderCacheDirty = true;
+    this.renderCache = null;
   }
 
   resize(columns: number, rows: number): void {
@@ -659,10 +674,11 @@ export class EmbeddedTerminalPane {
     this.currentColumns = nextColumns;
     this.currentRows = nextRows;
     this.buffer.resize(nextColumns, nextRows);
-    this.updateCachedTotalRows();
+    this.markRenderCacheDirty();
   }
 
   scrollUp(): void {
+    this.ensureCachedTotalRows();
     this.scrollOffset = Math.min(this.scrollOffset + 1, Math.max(0, this.cachedTotalRows - 1));
   }
 
@@ -675,6 +691,7 @@ export class EmbeddedTerminalPane {
   }
 
   scrollBy(deltaRows: number): void {
+    this.ensureCachedTotalRows();
     if (deltaRows < 0) {
       this.scrollOffset = Math.min(this.scrollOffset + Math.abs(deltaRows), Math.max(0, this.cachedTotalRows - 1));
       return;
@@ -684,12 +701,12 @@ export class EmbeddedTerminalPane {
   }
 
   scrollToTop(maxWidth: number, viewportHeight: number): void {
-    const totalLines = this.getRenderableLines(Math.max(1, maxWidth)).length;
+    const totalLines = this.getTotalRenderableLineCount(Math.max(1, maxWidth));
     this.scrollOffset = Math.max(0, totalLines - Math.max(0, viewportHeight));
   }
 
   getViewportTrackingInfo(maxWidth: number, viewportHeight: number): EmbeddedTerminalViewportTrackingInfo {
-    const totalLines = this.getRenderableLines(Math.max(1, maxWidth)).length;
+    const totalLines = this.getTotalRenderableLineCount(Math.max(1, maxWidth));
     const maxTopRow = Math.max(0, totalLines - Math.max(0, viewportHeight));
     const distanceFromBottom = Math.min(this.scrollOffset, maxTopRow);
 
@@ -700,8 +717,28 @@ export class EmbeddedTerminalPane {
     };
   }
 
-  private updateCachedTotalRows(): void {
-    this.cachedTotalRows = this.getRenderableLines(this.currentColumns).length;
+  private markRenderCacheDirty(): void {
+    this.renderCacheDirty = true;
+    this.renderCache = null;
+  }
+
+  private ensureCachedTotalRows(): void {
+    this.cachedTotalRows = this.getTotalRenderableLineCount(this.currentColumns);
+  }
+
+  private getTotalRenderableLineCount(maxWidth: number): number {
+    if (maxWidth <= 0) {
+      return 0;
+    }
+
+    if (!this.buffer.hasContent()) {
+      this.cachedTotalRows = EMPTY_PANE_LINES.length;
+      return this.cachedTotalRows;
+    }
+
+    const cache = this.ensureRenderCache(maxWidth);
+    this.cachedTotalRows = cache.compactLines.length;
+    return this.cachedTotalRows;
   }
 
   addEvent(event: PtyEvent): void {
@@ -717,7 +754,7 @@ export class EmbeddedTerminalPane {
     }
 
     this.buffer.write(event.data);
-    this.updateCachedTotalRows();
+    this.markRenderCacheDirty();
     this.scrollOffset = 0;
   }
 
@@ -727,7 +764,7 @@ export class EmbeddedTerminalPane {
     }
 
     this.buffer.write(text.endsWith("\n") ? text : `${text}\n`);
-    this.updateCachedTotalRows();
+    this.markRenderCacheDirty();
     this.scrollOffset = 0;
   }
 
@@ -740,7 +777,7 @@ export class EmbeddedTerminalPane {
       return null;
     }
 
-    const { rows } = this.getRenderedRows(Math.max(1, maxWidth));
+    const { rows } = this.ensureRenderCache(Math.max(1, maxWidth));
     for (let index = rows.length - 1; index >= 0; index -= 1) {
       const row = rows[index];
       if (row === undefined) {
@@ -790,7 +827,7 @@ export class EmbeddedTerminalPane {
       return null;
     }
 
-    const { rows } = this.getRenderedRows(Math.max(1, maxWidth));
+    const { rows } = this.ensureRenderCache(Math.max(1, maxWidth));
     for (let index = rows.length - 1; index >= 0; index -= 1) {
       const row = rows[index];
       if (row === undefined || row.plainText.length === 0) {
@@ -849,6 +886,52 @@ export class EmbeddedTerminalPane {
     };
   }
 
+  private ensureRenderCache(maxWidth: number): NonNullable<EmbeddedTerminalPane["renderCache"]> {
+    const width = Math.max(1, maxWidth);
+    if (
+      this.renderCache !== null &&
+      !this.renderCacheDirty &&
+      this.renderCache.width === width
+    ) {
+      return this.renderCache;
+    }
+
+    const {
+      rows: renderedRows,
+      cursorColumn,
+      cursorVisible,
+      cursorGlobalRow,
+    } = this.getRenderedRows(width);
+
+    const compactLines = buildCompactRenderableLines(
+      renderedRows,
+      width,
+      cursorColumn,
+      cursorVisible,
+      cursorGlobalRow,
+    );
+
+    this.renderCache = {
+      width,
+      rows: renderedRows,
+      cursorColumn,
+      cursorVisible,
+      cursorGlobalRow,
+      compactLines,
+    };
+    this.renderCacheDirty = false;
+    this.cachedTotalRows = compactLines.length;
+    this.renderCacheRebuildCount += 1;
+    return this.renderCache;
+  }
+
+  getDebugStats(): { renderCacheRebuildCount: number; cachedTotalRows: number } {
+    return {
+      renderCacheRebuildCount: this.renderCacheRebuildCount,
+      cachedTotalRows: this.cachedTotalRows,
+    };
+  }
+
   getRenderableLines(maxWidth: number, maxRows?: number, scrollOffset = 0): EmbeddedTerminalRenderableLine[] {
     if (maxWidth <= 0) {
       return [];
@@ -860,20 +943,7 @@ export class EmbeddedTerminalPane {
       }));
     }
 
-    const {
-      rows: renderedRows,
-      cursorColumn,
-      cursorVisible,
-      cursorGlobalRow,
-    } = this.getRenderedRows(maxWidth);
-
-    const compactLines = buildCompactRenderableLines(
-      renderedRows,
-      maxWidth,
-      cursorColumn,
-      cursorVisible,
-      cursorGlobalRow,
-    );
+    const { compactLines } = this.ensureRenderCache(maxWidth);
 
     const endIndex = Math.max(0, compactLines.length - Math.max(0, scrollOffset));
     const startIndex = Math.max(0, maxRows === undefined ? 0 : endIndex - Math.max(0, maxRows));

--- a/src/integrations/subprocess/pty-session.ts
+++ b/src/integrations/subprocess/pty-session.ts
@@ -263,6 +263,18 @@ export const createInteractivePtySession = (
     });
   });
 
+  if (request.input !== undefined) {
+    emitEvent({ type: "prompt", data: request.input });
+    ptyProcess.write(request.input);
+    // Match the PTY runner behavior: stdin-driven commands like `codex exec -`
+    // need an explicit line terminator/EOF to start work, while the PTY stays
+    // interactive for later approval replies.
+    if (!request.input.endsWith("\r") && !request.input.endsWith("\n")) {
+      ptyProcess.write("\r");
+    }
+    ptyProcess.write("\x04");
+  }
+
   return {
     write: (data: string): void => {
       if (request.input !== undefined) {

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -850,8 +850,8 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       child.stdin.write("\n");
 
       await waitForOutput(stdoutState, "approval required (y/n)", 25_000);
-      await waitForOutput(stdoutState, "Codex 승인 대기", 25_000);
-      await waitForOutput(stdoutState, "Esc/Ctrl+G returns to detoks", 25_000);
+      await waitForOutput(stdoutState, "Codex 승인 대기", 30_000);
+      await waitForOutput(stdoutState, "Esc / Ctrl+G detoks 입력으로 복귀", 30_000);
       child.kill("SIGKILL");
       const exitCode = await new Promise<number>((resolve, reject) => {
         child.on("error", reject);
@@ -862,11 +862,11 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       expect(stderrState.value).not.toContain("ReferenceError");
       expect(stdoutState.value).toContain("approval required (y/n)");
       expect(stdoutState.value).toContain("Codex 승인 대기");
-      expect(stdoutState.value).toContain("Esc/Ctrl+G returns to detoks");
+      expect(stdoutState.value).toContain("Esc / Ctrl+G detoks 입력으로 복귀");
     } finally {
       rmSync(tempDir, { force: true, recursive: true });
     }
-  }, 30_000);
+  }, 45_000);
 
   it("cancels an embedded run with Ctrl+C without exiting the repl", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "detoks-cli-embedded-cancel-"));

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -276,6 +276,23 @@ describe("EmbeddedTerminalPane", () => {
     expect(output).toContain("line");
   });
 
+  it("rebuilds compact render lines lazily and reuses them for the same width", () => {
+    pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "line1\n" });
+    pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "line2\n" });
+
+    expect(pane.getDebugStats().renderCacheRebuildCount).toBe(0);
+
+    expect(pane.getRenderableLines(80).length).toBeGreaterThan(0);
+    expect(pane.getDebugStats().renderCacheRebuildCount).toBe(1);
+
+    pane.getRenderableLines(80);
+    pane.getViewportTrackingInfo(80, 10);
+    expect(pane.getDebugStats().renderCacheRebuildCount).toBe(1);
+
+    pane.getRenderableLines(100);
+    expect(pane.getDebugStats().renderCacheRebuildCount).toBe(2);
+  });
+
   it("scrollUp clamps at total row count and does not crash on empty buffer", () => {
     // Scrolling on empty pane must not throw
     expect(() => {

--- a/tests/ts/unit/integrations/subprocess/pty-session.test.ts
+++ b/tests/ts/unit/integrations/subprocess/pty-session.test.ts
@@ -93,7 +93,7 @@ describe("interactive PTY session", () => {
     });
   });
 
-  it("keeps request input writable and emits a prompt event for canned input", async () => {
+  it("submits initial PTY input immediately and emits a prompt event", async () => {
     const ptyProcess = new FakePtyProcess();
     ptyMocks.spawn.mockReturnValueOnce(ptyProcess as unknown as never);
     const onEvent = vi.fn();
@@ -107,9 +107,12 @@ describe("interactive PTY session", () => {
       { onEvent },
     );
 
-    session.write("hello detoks\n");
-    expect(ptyProcess.write).toHaveBeenCalledWith("hello detoks\n");
+    expect(ptyProcess.write).toHaveBeenNthCalledWith(1, "hello detoks\n");
+    expect(ptyProcess.write).toHaveBeenNthCalledWith(2, "\x04");
     expect(onEvent.mock.calls.some(([event]) => event.type === "prompt")).toBe(true);
+
+    session.write("y\r");
+    expect(ptyProcess.write).toHaveBeenNthCalledWith(3, "y\r");
 
     session.close();
     expect(ptyProcess.kill).toHaveBeenCalledWith("SIGTERM");
@@ -119,6 +122,31 @@ describe("interactive PTY session", () => {
       exitCode: 0,
       timedOut: false,
     });
+  });
+
+  it("adds a carriage return before EOF when the initial prompt has no trailing newline", async () => {
+    const ptyProcess = new FakePtyProcess();
+    ptyMocks.spawn.mockReturnValueOnce(ptyProcess as unknown as never);
+
+    const session = createInteractivePtySession(
+      {
+        command: process.execPath,
+        args: ["-e", "process.stdout.write('ok')"],
+        input: "hello detoks",
+        interactiveAfterInput: true,
+      },
+      { onEvent: vi.fn() },
+    );
+
+    expect(ptyProcess.write).toHaveBeenNthCalledWith(1, "hello detoks");
+    expect(ptyProcess.write).toHaveBeenNthCalledWith(2, "\r");
+    expect(ptyProcess.write).toHaveBeenNthCalledWith(3, "\x04");
+
+    session.write("y\r");
+    expect(ptyProcess.write).toHaveBeenNthCalledWith(4, "y\r");
+
+    ptyProcess.emitExit(0);
+    await expect(session.result).resolves.toMatchObject({ exitCode: 0, timedOut: false });
   });
 
   it("captures child output and emits resize events", async () => {


### PR DESCRIPTION
## 변경 내용
- embedded PTY/TUI의 고빈도 redraw를 프레임 스케줄러로 coalescing하도록 조정했습니다.
- embedded native PTY resize의 중복 호출을 억제했습니다.
- embedded terminal compact render line 재구성을 lazy + width-aware 캐시 방식으로 바꿨습니다.
- interactive PTY session이 초기 prompt 입력 후 EOF까지 올바르게 보내도록 runner 경로와 동작을 맞췄습니다.
- approval smoke 테스트 기대 문구와 timeout을 현재 embedded TUI 동작에 맞게 갱신했습니다.
- lazy render cache 재사용과 interactive PTY bootstrap 동작에 대한 unit coverage를 추가했습니다.

## 변경 이유
embedded real-mode 출력에서 PTY 이벤트가 몰릴 때 redraw가 과도하게 발생해 반응성이 떨어질 수 있었고,
approval 경로 smoke 테스트도 실제 런타임/UI 동작과 어긋나 flaky하게 실패할 수 있었습니다.

## 원인
- embedded pane 렌더링이 PTY/action/progress 이벤트를 너무 직접적으로 따라가고 있었습니다.
- compact render line이 필요 이상 자주 재계산되고 있었습니다.
- interactive PTY startup이 stdin 기반 `codex exec -` 흐름에서 runner 경로와 완전히 일치하지 않았습니다.
- approval smoke assertion이 현재 UI 문구와 소요 시간 변화를 반영하지 못하고 있었습니다.

## 영향
- embedded real-mode에서 bursty PTY 출력 시 화면 갱신 부담이 줄어듭니다.
- 불필요한 PTY resize 호출이 감소합니다.
- embedded approval 경로의 동작과 smoke 테스트 안정성이 개선됩니다.

## 검증
- `npx vitest run tests/ts/unit/integrations/subprocess/pty-session.test.ts tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts`
- `npx vitest run tests/ts/integration/cli-smoke.test.ts -t "shows the embedded approval prompt and switches focus to the native Codex pane|returns to detoks input after an embedded run so another prompt can be entered|does not auto-execute the approval prompt when the initial Enter arrives as CRLF"`