### PR TITLE
[codex] chunk long rag outputs

### DIFF
--- a/src/core/rag/embedding-indexer.ts
+++ b/src/core/rag/embedding-indexer.ts
@@ -5,6 +5,54 @@ interface Embedder {
   embed(text: string): Promise<Float32Array>;
 }
 
+const MAX_EMBED_CHARS = 1200;
+
+function chunkTextForEmbedding(text: string): string[] {
+  const normalized = text.trim();
+  if (!normalized) return [];
+  if (normalized.length <= MAX_EMBED_CHARS) return [normalized];
+
+  const paragraphs = normalized.split(/\n\s*\n/g);
+  const chunks: string[] = [];
+  let current = "";
+
+  const flush = (): void => {
+    const trimmed = current.trim();
+    if (trimmed) chunks.push(trimmed);
+    current = "";
+  };
+
+  const append = (part: string): void => {
+    const trimmed = part.trim();
+    if (!trimmed) return;
+
+    if (trimmed.length > MAX_EMBED_CHARS) {
+      flush();
+      for (let i = 0; i < trimmed.length; i += MAX_EMBED_CHARS) {
+        const slice = trimmed.slice(i, i + MAX_EMBED_CHARS).trim();
+        if (slice) chunks.push(slice);
+      }
+      return;
+    }
+
+    const next = current ? `${current}\n\n${trimmed}` : trimmed;
+    if (next.length <= MAX_EMBED_CHARS) {
+      current = next;
+      return;
+    }
+
+    flush();
+    current = trimmed;
+  };
+
+  for (const paragraph of paragraphs) {
+    append(paragraph);
+  }
+
+  flush();
+  return chunks;
+}
+
 export class EmbeddingIndexer {
   constructor(
     private readonly store: VectorStore,
@@ -14,9 +62,13 @@ export class EmbeddingIndexer {
   async indexSession(session: SessionState): Promise<void> {
     const sessionId = session.shared_context.session_id;
 
-    if (session.shared_context.raw_input) {
-      const vec = await this.embedder.embed(session.shared_context.raw_input);
-      this.store.upsert(`prompt::${sessionId}`, vec, { kind: "prompt", session_id: sessionId });
+    for (const [index, chunk] of chunkTextForEmbedding(session.shared_context.raw_input ?? "").entries()) {
+      const vec = await this.embedder.embed(chunk);
+      this.store.upsert(
+        index === 0 ? `prompt::${sessionId}` : `prompt::${sessionId}::chunk${index + 1}`,
+        vec,
+        { kind: "prompt", session_id: sessionId },
+      );
     }
 
     for (const [taskId, rawResult] of Object.entries(session.task_results ?? {})) {
@@ -24,20 +76,30 @@ export class EmbeddingIndexer {
       if (!result.success) continue;
 
       const taskText = result.summary ?? result.raw_output ?? taskId;
-      const taskVec = await this.embedder.embed(taskText);
-      this.store.upsert(`task::${sessionId}::${taskId}`, taskVec, {
-        kind: "task",
-        session_id: sessionId,
-        task_id: taskId,
-      });
+      for (const [index, chunk] of chunkTextForEmbedding(taskText).entries()) {
+        const taskVec = await this.embedder.embed(chunk);
+        this.store.upsert(
+          index === 0 ? `task::${sessionId}::${taskId}` : `task::${sessionId}::${taskId}::chunk${index + 1}`,
+          taskVec,
+          {
+            kind: "task",
+            session_id: sessionId,
+            task_id: taskId,
+          },
+        );
+      }
 
-      if (result.raw_output) {
-        const outVec = await this.embedder.embed(result.raw_output);
-        this.store.upsert(`output::${sessionId}::${taskId}`, outVec, {
-          kind: "output",
-          session_id: sessionId,
-          task_id: taskId,
-        });
+      for (const [index, chunk] of chunkTextForEmbedding(result.raw_output ?? "").entries()) {
+        const outVec = await this.embedder.embed(chunk);
+        this.store.upsert(
+          index === 0 ? `output::${sessionId}::${taskId}` : `output::${sessionId}::${taskId}::chunk${index + 1}`,
+          outVec,
+          {
+            kind: "output",
+            session_id: sessionId,
+            task_id: taskId,
+          },
+        );
       }
     }
   }

--- a/tests/ts/unit/core/rag/embedding-indexer.test.ts
+++ b/tests/ts/unit/core/rag/embedding-indexer.test.ts
@@ -84,6 +84,27 @@ describe("EmbeddingIndexer", () => {
     );
   });
 
+  it("긴 raw_output은 여러 output 청크로 나눠 인덱싱한다", async () => {
+    const session = makeSession({
+      task_results: {
+        t1: {
+          task_id: "t1",
+          success: true,
+          summary: "Found auth module",
+          raw_output: "긴 출력 ".repeat(400),
+          input_hash: "taskhash001",
+        },
+      },
+    });
+
+    await indexer.indexSession(session as any);
+
+    const outputCalls = (store.upsert as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c) => typeof c[0] === "string" && c[0].startsWith("output::sess-abc::t1"),
+    );
+    expect(outputCalls.length).toBeGreaterThan(1);
+  });
+
   it("raw_input이 없는 세션은 prompt 인덱싱을 건너뛴다", async () => {
     const session = makeSession({
       shared_context: { session_id: "sess-no-input", raw_input: "" },


### PR DESCRIPTION
## 변경 내용
- 긴 `raw_input`, `task summary`, `raw_output`을 임베딩 전에 청크로 나누도록 수정했습니다.
- 임베딩 컨텍스트 크기 초과로 RAG 인덱싱이 실패하던 문제를 해결했습니다.
- 첫 청크는 기존 `prompt::...`, `task::...`, `output::...` ID를 유지하고, 이후 청크는 `::chunkN`을 붙이도록 했습니다.
- 긴 `raw_output`이 여러 청크로 인덱싱되는 단위 테스트를 추가했습니다.

## 변경 이유
- 데모용 RAG 세션에서 긴 출력이 임베딩 모델의 context size를 넘어서 인덱싱이 끊기는 문제가 있었습니다.
- 긴 세션 로그도 안정적으로 검색 가능하게 만들기 위해 청크 분할이 필요했습니다.

## 검증
- `npx vitest run tests/ts/unit/core/rag/embedding-indexer.test.ts tests/ts/unit/core/rag/embedding-service.test.ts tests/ts/unit/core/rag/vector-store.test.ts`
- `npm run build`
- 데모 `vectors.db` 재생성 및 검색 확인 완료

## 비고
- 워크트리에 있던 별도 로컬 변경사항(`package.json` 등)은 PR에 포함하지 않았습니다.