### PR TITLE
feat(tui): Nerd Font 아이콘 옵션 + TUI 구조 개선

### DIFF
--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -116,6 +116,45 @@ function formatRagSkipReason(reason: NonNullable<CliExecutionResult["ragContextS
   return null;
 }
 
+function buildRagIndexingLines(result: CliExecutionResult): string[] {
+  const summary = result.ragIndexingSummary;
+  if (!summary || summary.status === "skipped") return [];
+
+  const dbStats = summary.dbRowCount !== undefined && summary.dbSessionCount !== undefined
+    ? ` · DB ${summary.dbRowCount} rows / ${summary.dbSessionCount} sessions`
+    : "";
+
+  if (summary.status === "completed") {
+    return [
+      "",
+      colors.header("RAG 인덱싱"),
+      `  ${colors.muted("·")} 완료 · 이번 세션 ${summary.indexed}/${summary.attempted}${dbStats}`,
+    ];
+  }
+
+  if (summary.status === "partial") {
+    const lines = [
+      "",
+      colors.header("RAG 인덱싱"),
+      `  ${colors.muted("·")} 부분 완료 · ${summary.indexed}/${summary.attempted} 반영 · ${summary.skipped}개 스킵${dbStats}`,
+    ];
+    for (const failure of (summary.failures ?? []).slice(0, 2)) {
+      lines.push(`    ${colors.warning("!")} ${failure.kind}${failure.taskId ? ` ${failure.taskId}` : ""}: ${translateVisibleText(failure.reason)}`);
+    }
+    if ((summary.failures?.length ?? 0) > 2) {
+      lines.push(`    ${colors.muted(`외 ${(summary.failures?.length ?? 0) - 2}개 실패`)}`);
+    }
+    return lines;
+  }
+
+  const firstFailure = summary.failures?.[0];
+  return [
+    "",
+    colors.header("RAG 인덱싱"),
+    `  ${colors.warning("!")} 실패 (non-fatal)${firstFailure ? ` · ${translateVisibleText(firstFailure.reason)}` : ""}`,
+  ];
+}
+
 function buildRagContextLines(result: CliExecutionResult): string[] {
   const summary = result.ragContextSummary;
   if (!summary || summary.items.length === 0) {
@@ -257,6 +296,8 @@ function formatResultHuman(result: CliExecutionResult, ok: boolean): string {
       `  ${colors.muted("이어서 진행:")} detoks session continue ${sessionId}`,
     );
   }
+
+  lines.push(...buildRagIndexingLines(result));
 
   const ragContextLines = buildRagContextLines(result);
   if (ragContextLines.length > 0) {

--- a/src/cli/repl-commands/index.ts
+++ b/src/cli/repl-commands/index.ts
@@ -3,6 +3,7 @@ import { createInterface } from "node:readline/promises";
 import { spawnSync } from "node:child_process";
 import type { Adapter } from "../../core/pipeline/types.js";
 import { colors } from "../colors.js";
+import { isNerdFontEnabled, setNerdFont } from "../tui/design/tokens.js";
 import {
   claudeLogout,
   getAdapterStatus,
@@ -100,6 +101,12 @@ const BASE_COMMANDS: SlashCommand[] = [
     aliases: ["l"],
     description: "transcript/result 패널 비율 조정 (reset / transcript=N result=N / + / -)",
     usage: "/layout [reset|transcript=N|result=N|+|-]",
+  },
+  {
+    name: "nerd",
+    aliases: ["nf"],
+    description: "Nerd Font 아이콘 토글 (DETOKS_NERD_FONT=1 로 시작 시 자동 활성화)",
+    usage: "/nerd [on|off]",
   },
   {
     name: "exit",
@@ -461,6 +468,7 @@ export const handleSlashCommand = async (
     onInteractiveStart?: () => void;
     onInteractiveEnd?: () => void;
     onLayoutCommand?: (args: readonly string[]) => string;
+    onNerdFontToggle?: (enabled: boolean) => void;
   },
 ): Promise<boolean> => {
   const adapter = state.adapter as Adapter;
@@ -528,6 +536,22 @@ export const handleSlashCommand = async (
       } else {
         output.write(colors.warning("\n레이아웃 변경이 비활성화된 컨텍스트입니다.\n\n"));
       }
+      return true;
+    }
+
+    case "nerd": {
+      const sub = input.trim().split(/\s+/)[1]?.toLowerCase();
+      const enabled =
+        sub === "on" ? true :
+        sub === "off" ? false :
+        !isNerdFontEnabled();
+      setNerdFont(enabled);
+      state.onNerdFontToggle?.(enabled);
+      output.write(
+        colors.info(
+          `\nNerd Font 아이콘: ${enabled ? colors.success("ON") : colors.warning("OFF")}\n\n`,
+        ),
+      );
       return true;
     }
 

--- a/src/cli/tui/design/tokens.ts
+++ b/src/cli/tui/design/tokens.ts
@@ -127,7 +127,45 @@ export const statusColor = {
 
 export type StatusColorKey = keyof typeof statusColor;
 
-export const glyph = {
+export interface GlyphSet {
+  active: string;
+  done: string;
+  skipped: string;
+  error: string;
+  pending: string;
+  info: string;
+  warn: string;
+  success: string;
+  failure: string;
+  selected: string;
+  arrow: string;
+  bullet: string;
+  separator: string;
+  ellipsisOneChar: string;
+  ellipsisThreeDot: string;
+  spinner: readonly string[];
+  changeAdd: string;
+  changeDelete: string;
+  changeRename: string;
+  changeUpdate: string;
+  cacheHit: string;
+  cacheMiss: string;
+  cacheAdvise: string;
+  ragInjected: string;
+  ragSkipped: string;
+  gutter: string;
+  spinnerBraille: readonly string[];
+  toolWeb: string;
+  toolMcp: string;
+  toolTodo: string;
+  execRunning: string;
+  execDone: string;
+  execFailed: string;
+  adapterBadge: string;
+  scrollIndicator: string;
+}
+
+const _defaultGlyph: GlyphSet = {
   active: "●",
   done: "●",
   skipped: "○",
@@ -143,7 +181,7 @@ export const glyph = {
   separator: "━",
   ellipsisOneChar: "…",
   ellipsisThreeDot: "...",
-  spinner: ["|", "/", "-", "\\"] as const,
+  spinner: ["|", "/", "-", "\\"],
   changeAdd: "+",
   changeDelete: "-",
   changeRename: "→",
@@ -154,7 +192,7 @@ export const glyph = {
   ragInjected: "ⓘ",
   ragSkipped: "○",
   gutter: "▎",
-  spinnerBraille: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const,
+  spinnerBraille: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
   toolWeb: "◐",
   toolMcp: "▢",
   toolTodo: "☐",
@@ -163,7 +201,57 @@ export const glyph = {
   execFailed: "✗",
   adapterBadge: "▣",
   scrollIndicator: "▒",
-} as const;
+};
+
+// Nerd Fonts v3 — FontAwesome + Codicon PUA codepoints
+const _nerdGlyph: GlyphSet = {
+  active:          "",  // nf-fa-circle
+  done:            "",  // nf-fa-check_circle
+  skipped:         "",  // nf-fa-ban
+  error:           "",  // nf-fa-times_circle
+  pending:         "",  // nf-fa-clock_o
+  info:            "",  // nf-fa-info_circle
+  warn:            "",  // nf-fa-warning
+  success:         "",  // nf-fa-check
+  failure:         "",  // nf-fa-times
+  selected:        "",  // nf-fa-chevron_right
+  arrow:           "",  // nf-fa-arrow_right
+  bullet:          "",  // nf-fa-circle
+  separator:       "━",
+  ellipsisOneChar: "…",
+  ellipsisThreeDot: "...",
+  spinner: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+  changeAdd:    "+",
+  changeDelete: "-",
+  changeRename: "",  // nf-fa-arrow_right
+  changeUpdate: "~",
+  cacheHit:    "",  // nf-fa-database
+  cacheMiss:   "",  // nf-fa-database
+  cacheAdvise: "",  // nf-fa-warning
+  ragInjected: "",  // nf-fa-file_text
+  ragSkipped:  "",  // nf-fa-file_text_o
+  gutter:        "▎",
+  spinnerBraille: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+  toolWeb:       "",  // nf-fa-globe
+  toolMcp:       "",  // nf-fa-plug
+  toolTodo:      "",  // nf-fa-tasks
+  execRunning:   "",  // nf-fa-play
+  execDone:      "",  // nf-fa-check
+  execFailed:    "",  // nf-fa-times
+  adapterBadge:  "",  // nf-fa-database
+  scrollIndicator: "▒",
+};
+
+let _nerdFontEnabled: boolean = process.env.DETOKS_NERD_FONT === "1";
+
+export const isNerdFontEnabled = (): boolean => _nerdFontEnabled;
+
+export const setNerdFont = (enabled: boolean): void => {
+  _nerdFontEnabled = enabled;
+  Object.assign(glyph, enabled ? _nerdGlyph : _defaultGlyph);
+};
+
+export const glyph: GlyphSet = { ...(_nerdFontEnabled ? _nerdGlyph : _defaultGlyph) };
 
 export const spacing = {
   panelPaddingX: 0,

--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -165,15 +165,17 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
   const screen = createScreenManager(stdout, stdin);
   const decoder = new StringDecoder("utf8");
   const executionCwd = options.cwd ?? process.cwd();
-  let currentAdapter = options.adapter;
-  let currentAdapterModel = options.adapterModel ?? getAdapterModel(currentAdapter);
-    let currentTranslationModel = options.translationModel ?? getTranslationModel();
-    let currentVerbose = options.verbose;
-  let currentCacheDisabled = false;
-  let currentInferenceStrength =
-    currentAdapter === "codex"
+  const state = {
+    adapter: options.adapter,
+    adapterModel: options.adapterModel ?? getAdapterModel(options.adapter),
+    translationModel: options.translationModel ?? getTranslationModel(),
+    verbose: options.verbose,
+    cacheDisabled: false,
+    inferenceStrength: options.adapter === "codex"
       ? options.inferenceStrength ?? getCodexReasoningEffortOverride() ?? "medium"
-      : undefined;
+      : undefined as string | undefined,
+    tokenSavingsLabel: undefined as string | undefined,
+  };
   const nativePassthroughMode = options.presentationMode === "passthrough";
   const embeddedPaneMode = options.presentationMode === "embedded-pane";
 
@@ -201,10 +203,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
   };
 
   const refreshRuntimeState = (): void => {
-    currentAdapterModel = getAdapterModel(currentAdapter);
-    currentTranslationModel = getTranslationModel();
-    currentInferenceStrength =
-      currentAdapter === "codex"
+    state.adapterModel = getAdapterModel(state.adapter);
+    state.translationModel = getTranslationModel();
+    state.inferenceStrength =
+      state.adapter === "codex"
         ? getCodexReasoningEffortOverride() ?? "medium"
         : undefined;
   };
@@ -237,8 +239,8 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       refreshRuntimeState();
 
       if (!hasInitialConfig) {
-        await handleAdapterSwitch(currentAdapter, async (newAdapter) => {
-          currentAdapter = newAdapter;
+        await handleAdapterSwitch(state.adapter, async (newAdapter) => {
+          state.adapter = newAdapter;
           loadAndApplyConfig(newAdapter);
           updateSelectedAdapter(newAdapter);
           refreshRuntimeState();
@@ -269,7 +271,14 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     const pipelinePanel = new PipelineStatusPanel();
     const transcriptPanel = new TranscriptPanel();
     const resultPanel = new ResultSummaryPanel();
-    resultPanel.setVerbose(currentVerbose);
+    resultPanel.setVerbose(state.verbose);
+
+    const dirtyPanels = { pipeline: true, transcript: true, result: true };
+    const markAllDirty = (): void => {
+      dirtyPanels.pipeline = true;
+      dirtyPanels.transcript = true;
+      dirtyPanels.result = true;
+    };
 
     // P3-3: Input history — load existing on init, persist on each submit.
     const inputHistory = new InputHistory();
@@ -296,7 +305,6 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     let hasExecuted = false;
     let lastInputSeparatorRow = -1;
     let slashAutocompleteSelectedIndex = 0;
-    let currentTokenSavingsLabel: string | undefined;
     let isInputSuspended = false;
     let isPasting = false;
     let embeddedNativeCliSession: EmbeddedNativeCliSession | null = null;
@@ -834,10 +842,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       }
 
       embeddedNativeCliSession = createEmbeddedNativeCliSession({
-        adapter: currentAdapter,
+        adapter: state.adapter,
         cwd: executionCwd,
-        verbose: currentVerbose,
-        ...(currentAdapterModel !== undefined ? { model: currentAdapterModel } : {}),
+        verbose: state.verbose,
+        ...(state.adapterModel !== undefined ? { model: state.adapterModel } : {}),
         ...(options.sessionId !== undefined ? { sessionId: options.sessionId } : {}),
         onEvent: (event) => {
           eventRouter.routeAdapterEvent(event, "embedded");
@@ -893,7 +901,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               ? viewportStatusText ?? "첫 프롬프트를 입력하면 아래 패널이 채워집니다 · /... 자동완성 · q 종료"
               : "첫 프롬프트를 입력하면 아래 패널이 채워집니다 · /... 자동완성 · q 종료");
       const bannerLines = [
-        `adapter: ${currentAdapter} | model: ${currentAdapterModel ?? "미설정"} | translate: ${currentTranslationModel ?? "미설정"}`,
+        `adapter: ${state.adapter} | model: ${state.adapterModel ?? "미설정"} | translate: ${state.translationModel ?? "미설정"}`,
         `mode: ${options.executionMode} | session: ${options.sessionId ?? "new"}`,
         browsingHistoryHint,
       ];
@@ -938,7 +946,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       if (embeddedPaneMode && embeddedTerminalFocus.focus !== "detoks-input") {
         renderFocusArea(
           ctx,
-          formatEmbeddedTerminalFocusHint(embeddedTerminalFocus.focus, currentAdapter),
+          formatEmbeddedTerminalFocusHint(embeddedTerminalFocus.focus, state.adapter),
         );
       } else {
         renderInputArea(ctx, input, cursor);
@@ -949,20 +957,21 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           ctx,
           resultRegion,
           slashAutocompleteQuery,
-          getSlashAutocompleteCommands(currentAdapter, slashAutocompleteQuery),
+          getSlashAutocompleteCommands(state.adapter, slashAutocompleteQuery),
           slashAutocompleteSelectedIndex,
         );
-      } else if (!embeddedPaneMode) {
+      } else if (!embeddedPaneMode && dirtyPanels.result) {
         resultPanel.render(ctx, resultRegion);
+        dirtyPanels.result = false;
       }
 
       renderFooter(
         ctx,
         buildFooterText(dims.columns, {
-          adapter: currentAdapter,
-          adapterModel: currentAdapterModel,
-          inferenceStrength: currentInferenceStrength,
-          tokenSavings: currentTokenSavingsLabel,
+          adapter: state.adapter,
+          adapterModel: state.adapterModel,
+          inferenceStrength: state.inferenceStrength,
+          tokenSavings: state.tokenSavingsLabel,
           cwd: executionCwd,
         }),
       );
@@ -976,6 +985,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         screen.clear();
         screen.cursorMoveTo(0, 0);
         forceFullRender = false;
+        markAllDirty();
       }
       const inputLayout = measureInputLayout(dims, input, cursor);
       const viewportStatusText = getEmbeddedViewportStatusText(dims.columns, inputLayout);
@@ -1005,7 +1015,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         endRow: statusRegionEnd,
         columns: dims.columns,
       };
-      pipelinePanel.render(ctx, statusRegion);
+      if (dirtyPanels.pipeline) {
+        pipelinePanel.render(ctx, statusRegion);
+        dirtyPanels.pipeline = false;
+      }
 
       if (embeddedPaneMode) {
         const stickyRegion = {
@@ -1087,7 +1100,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           endRow: transcriptRegionEnd,
           columns: dims.columns,
         };
-        transcriptPanel.render(ctx, transcriptRegion);
+        if (dirtyPanels.transcript) {
+          transcriptPanel.render(ctx, transcriptRegion);
+          dirtyPanels.transcript = false;
+        }
       }
 
       renderInteractiveInput();
@@ -1123,6 +1139,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
     const PROGRESS_RENDER_INTERVAL_MS = 200;
     const onProgress = (event: PipelineProgressEvent): void => {
       eventRouter.routePipelineProgress(event);
+      dirtyPanels.pipeline = true;
       if (nativePassthroughMode && isExecuting) {
         return;
       }
@@ -1368,7 +1385,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               slashAutocompleteSelectedIndex = getNextSlashAutocompleteIndex(
                 slashAutocompleteSelectedIndex,
                 "up",
-                getSlashAutocompleteCommands(currentAdapter, slashAutocompleteQuery).length,
+                getSlashAutocompleteCommands(state.adapter, slashAutocompleteQuery).length,
               );
               renderInteractiveInput();
             } else {
@@ -1388,7 +1405,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               slashAutocompleteSelectedIndex = getNextSlashAutocompleteIndex(
                 slashAutocompleteSelectedIndex,
                 "down",
-                getSlashAutocompleteCommands(currentAdapter, slashAutocompleteQuery).length,
+                getSlashAutocompleteCommands(state.adapter, slashAutocompleteQuery).length,
               );
               renderInteractiveInput();
             } else {
@@ -1556,7 +1573,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               const resolvedPrompt =
                 slashAutocompleteActive && (slashAutocompleteQuery?.length ?? 0) > 0
                   ? getSlashAutocompleteSelection(
-                      getSlashAutocompleteCommands(currentAdapter, slashAutocompleteQuery),
+                      getSlashAutocompleteCommands(state.adapter, slashAutocompleteQuery),
                       slashAutocompleteSelectedIndex,
                     )?.usage ?? input
                   : input;
@@ -1679,30 +1696,30 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         if (normalizedPrompt.startsWith("/")) {
           let shouldRestoreMainScreen = false;
           const previousState = {
-            adapter: currentAdapter,
-            adapterModel: currentAdapterModel,
-            translationModel: currentTranslationModel,
-            inferenceStrength: currentInferenceStrength,
+            adapter: state.adapter,
+            adapterModel: state.adapterModel,
+            translationModel: state.translationModel,
+            inferenceStrength: state.inferenceStrength,
           };
           const handled = await handleSlashCommand(normalizedPrompt, {
-            adapter: currentAdapter,
+            adapter: state.adapter,
             executionMode: options.executionMode,
-            modelName: currentTranslationModel,
-            verbose: currentVerbose,
-            cacheDisabled: currentCacheDisabled,
+            modelName: state.translationModel,
+            verbose: state.verbose,
+            cacheDisabled: state.cacheDisabled,
             onVerboseToggle: (enabled) => {
-              currentVerbose = enabled;
+              state.verbose = enabled;
               resultPanel.setVerbose(enabled);
             },
             onCacheDisableToggle: (disabled) => {
-              currentCacheDisabled = disabled;
+              state.cacheDisabled = disabled;
             },
             onMainScreenRestore: () => {
               shouldRestoreMainScreen = true;
             },
             onAdapterChange: async (newAdapter) => {
               closeExecutionControllers();
-              currentAdapter = newAdapter;
+              state.adapter = newAdapter;
               loadAndApplyConfig(newAdapter);
               updateSelectedAdapter(newAdapter);
               refreshRuntimeState();
@@ -1741,16 +1758,20 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               const w = getEffectiveWeights(layoutOverrides);
               return `레이아웃 조정: transcript=${w.transcriptWeight} result=${w.resultWeight}`;
             },
+            onNerdFontToggle: () => {
+              dirtyPanels.pipeline = true;
+              dirtyPanels.result = true;
+            },
           });
 
           refreshRuntimeState();
 
           if (handled) {
             const stateChanged =
-              previousState.adapter !== currentAdapter ||
-              previousState.adapterModel !== currentAdapterModel ||
-              previousState.translationModel !== currentTranslationModel ||
-              previousState.inferenceStrength !== currentInferenceStrength;
+              previousState.adapter !== state.adapter ||
+              previousState.adapterModel !== state.adapterModel ||
+              previousState.translationModel !== state.translationModel ||
+              previousState.inferenceStrength !== state.inferenceStrength;
             if (stateChanged || shouldRestoreMainScreen) {
               render();
             }
@@ -1781,7 +1802,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           resultPanel.setExecuting(true);
         }
         pipelinePanel.reset();
-        currentTokenSavingsLabel = undefined;
+        dirtyPanels.pipeline = true;
+        dirtyPanels.transcript = true;
+        dirtyPanels.result = true;
+        state.tokenSavingsLabel = undefined;
         if (nativePassthroughMode) {
           suspendInput();
           leaveTuiDisplay();
@@ -1795,10 +1819,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           {
             mode: "repl",
             prompt,
-            adapter: currentAdapter,
+            adapter: state.adapter,
             executionMode: options.executionMode,
-            verbose: currentVerbose,
-            noCache: currentCacheDisabled,
+            verbose: state.verbose,
+            noCache: state.cacheDisabled,
             trace: false,
             showHelp: false,
             helpTopic: "repl",
@@ -1832,11 +1856,14 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
               return;
             } else {
               eventRouter.routeAdapterEvent(event, "transcript");
+              dirtyPanels.transcript = true;
             }
             render();
           },
           onActionTimelineEvent: (event) => {
             eventRouter.routeActionTimeline(event);
+dirtyPanels.pipeline = true;
+            dirtyPanels.transcript = true;
             if (nativePassthroughMode && isExecuting) {
               return;
             }
@@ -1881,6 +1908,8 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           ...(actionTimeline.length > 0 ? { actionTimeline } : {}),
         };
         resultPanel.setResult(completedResult);
+        dirtyPanels.result = true;
+        dirtyPanels.transcript = true;
 
         // P3-4: Auto-save adapter transcript when DETOKS_SAVE_TRANSCRIPTS=1.
         if (
@@ -1920,7 +1949,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           closeExecutionControllers();
           embeddedTerminalFocus.focusDetoks();
         }
-        currentTokenSavingsLabel = result.cacheHit
+        state.tokenSavingsLabel = result.cacheHit
           ? formatCacheHitBadge(result.cacheHit)
           : formatTokenSavingsBadge(
               result.promptTokenSavings ?? result.tokenMetrics?.input ?? result.tokenMetrics?.output,
@@ -1939,13 +1968,13 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           enterTuiDisplay();
         }
         // Display error
-        const errorMsg = formatError(error, currentVerbose);
+        const errorMsg = formatError(error, state.verbose);
         resultPanel.clear();
         if (currentRunBlock !== null) {
           currentRunBlock.status = "failed";
           currentRunBlock.completedAt = Date.now();
           currentRunBlock.summaryLines = [
-            `✗ 실패  어댑터: ${currentAdapter}  세션: ${options.sessionId ?? "new"}`,
+            `✗ 실패  어댑터: ${state.adapter}  세션: ${options.sessionId ?? "new"}`,
             `요약: ${errorMsg}`,
             "다음 작업: 입력을 수정한 뒤 다시 시도하세요.",
           ];

--- a/src/cli/tui/panels/pipeline-status.ts
+++ b/src/cli/tui/panels/pipeline-status.ts
@@ -29,12 +29,14 @@ const formatStageDuration = (durationMs: number): string => {
 const isZeroCacheCounters = (c: CacheCounters): boolean =>
   c.hit === 0 && c.miss === 0 && c.advise === 0;
 
-const STATUS_ICONS: Record<PipelineProgressStatus, string> = {
-  end: glyph.done,
-  error: glyph.error,
-  skip: glyph.skipped,
-  start: glyph.active,
-  info: glyph.info,
+const getStatusIcon = (status: PipelineProgressStatus): string => {
+  switch (status) {
+    case "end":   return glyph.done;
+    case "error": return glyph.error;
+    case "skip":  return glyph.skipped;
+    case "start": return glyph.active;
+    case "info":  return glyph.info;
+  }
 };
 
 const STATUS_STYLES: Record<PipelineProgressStatus, Style> = {
@@ -184,7 +186,7 @@ export class PipelineStatusPanel {
       const stageStatus = this.stages.get(stageName);
       if (!stageStatus) continue;
 
-      const icon = STATUS_ICONS[stageStatus.status];
+      const icon = getStatusIcon(stageStatus.status);
       const durationLabel = stageStatus.startedAt !== undefined && stageStatus.endedAt !== undefined
         ? `  ${formatStageDuration(stageStatus.endedAt - stageStatus.startedAt)}`
         : "";

--- a/src/cli/tui/panels/result-summary.ts
+++ b/src/cli/tui/panels/result-summary.ts
@@ -47,6 +47,47 @@ const formatRagItemLine = (item: RagContextDisplayItem): string => {
   return `  ${marker} [${item.relevance}] ${label} (${sessionShort}${taskFragment}) — ${preview}`;
 };
 
+const formatRagIndexingLines = (result: PipelineExecutionResult): StyledLine[] => {
+  const summary = result.ragIndexingSummary;
+  if (!summary || summary.status === "skipped") return [];
+
+  const dbStats = summary.dbRowCount !== undefined && summary.dbSessionCount !== undefined
+    ? `  · DB ${summary.dbRowCount} rows/${summary.dbSessionCount} sessions`
+    : "";
+
+  if (summary.status === "completed") {
+    return [
+      { text: "" },
+      { text: `RAG 인덱싱  완료 · ${summary.indexed}/${summary.attempted}${dbStats}` },
+    ];
+  }
+
+  if (summary.status === "partial") {
+    const lines: StyledLine[] = [
+      { text: "" },
+      { text: `RAG 인덱싱  부분 완료 · ${summary.indexed}/${summary.attempted} · ${summary.skipped}개 스킵${dbStats}`, style: statusColor.warn },
+    ];
+    for (const failure of (summary.failures ?? []).slice(0, 2)) {
+      lines.push({
+        text: `  ${glyph.warn} ${failure.kind}${failure.taskId ? ` ${failure.taskId}` : ""} — ${failure.reason}`,
+        style: statusColor.warn,
+      });
+    }
+    if ((summary.failures?.length ?? 0) > 2) {
+      lines.push({ text: `  외 ${(summary.failures?.length ?? 0) - 2}개 실패`, style: statusColor.muted });
+    }
+    return lines;
+  }
+
+  return [
+    { text: "" },
+    { text: `RAG 인덱싱  실패 (non-fatal)`, style: statusColor.error },
+    ...(summary.failures?.[0]
+      ? [{ text: `  ${glyph.error} ${summary.failures[0].reason}`, style: statusColor.error } satisfies StyledLine]
+      : []),
+  ];
+};
+
 const formatRelativeAge = (updatedAt: string, now: number = Date.now()): string => {
   const ts = Date.parse(updatedAt);
   if (isNaN(ts)) return "방금";
@@ -70,11 +111,11 @@ const formatResumeBannerLines = (resumeHint: ResumeHintInfo): string[] => {
   ];
 };
 
-const TASK_STATUS_GLYPHS: Record<TaskExecutionRecord["status"], string> = {
+const getTaskStatusGlyph = (status: TaskExecutionRecord["status"]): string => ({
   completed: glyph.success,
   failed: glyph.failure,
   skipped: glyph.skipped,
-};
+}[status]);
 
 const TASK_STATUS_STYLES: Record<TaskExecutionRecord["status"], Style> = {
   completed: statusColor.success,
@@ -98,7 +139,7 @@ const formatTaskGridLines = (records: readonly TaskExecutionRecord[]): StyledLin
   lines.push({ text: "" });
   lines.push({ text: "작업 결과" });
   for (const record of records) {
-    const marker = TASK_STATUS_GLYPHS[record.status];
+    const marker = getTaskStatusGlyph(record.status);
     const label = TASK_STATUS_LABELS[record.status];
     const blocked = record.blockedBy ? `  (blocked by ${record.blockedBy})` : "";
     lines.push({
@@ -239,6 +280,10 @@ export class ResultSummaryPanel {
       for (const styled of formatTaskGridLines(this.result.taskRecords)) {
         lines.push(styled);
       }
+    }
+
+    for (const styled of formatRagIndexingLines(this.result)) {
+      lines.push(styled);
     }
 
     const rag = this.result.ragContextSummary;

--- a/src/cli/tui/panels/result-summary.ts
+++ b/src/cli/tui/panels/result-summary.ts
@@ -111,11 +111,13 @@ const formatResumeBannerLines = (resumeHint: ResumeHintInfo): string[] => {
   ];
 };
 
-const getTaskStatusGlyph = (status: TaskExecutionRecord["status"]): string => ({
-  completed: glyph.success,
-  failed: glyph.failure,
-  skipped: glyph.skipped,
-}[status]);
+const getTaskStatusGlyph = (status: TaskExecutionRecord["status"]): string => {
+  switch (status) {
+    case "completed": return glyph.success;
+    case "failed":    return glyph.failure;
+    case "skipped":   return glyph.skipped;
+  }
+};
 
 const TASK_STATUS_STYLES: Record<TaskExecutionRecord["status"], Style> = {
   completed: statusColor.success,

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -60,6 +60,7 @@ import type {
   SemanticContextResult,
   RagContextDisplayItem,
   RagContextSummary,
+  RagIndexingSummary,
 } from "./types.js";
 import { createActionTimelineEvent } from "../timeline/types.js";
 import type { ActionTimelineEvent } from "../timeline/types.js";
@@ -771,6 +772,7 @@ export const orchestratePipeline = async (
   const perTaskSnippets = new Map<string, RagSnippet[]>();
   const ragDisplayItemsByTask = new Map<string, RagContextDisplayItem[]>();
   let ragSkipReason: RagContextSummary["skipReason"] | undefined;
+  let ragIndexingSummary: RagIndexingSummary | undefined;
 
   // ── Step 1: Prompt compile + Role 2.1 handoff 생성 (Role 1) ──────────────
   let compiledPrompt;
@@ -1539,11 +1541,52 @@ export const orchestratePipeline = async (
 
   // ── RAG indexing: 완료된 세션을 벡터 DB에 인덱싱 ─────────────────────────
   if (ragEmbedder && ragStore && !memoryDisabled) {
+    await emitProgressWithLogging({
+      stage: "RAG Indexer",
+      status: "start",
+      message: "RAG Indexer 시작",
+    });
     try {
       const indexer = new EmbeddingIndexer(ragStore, ragEmbedder);
-      await indexer.indexSession(state as any);
+      const indexing = await indexer.indexSession(state as any);
+      const stats = ragStore.getStats();
+      ragIndexingSummary = {
+        status: indexing.failures.length === 0 ? "completed" : "partial",
+        attempted: indexing.attempted,
+        indexed: indexing.indexed,
+        skipped: indexing.skipped,
+        dbRowCount: stats.rowCount,
+        dbSessionCount: stats.sessionCount,
+        ...(indexing.failures.length > 0 ? { failures: indexing.failures } : {}),
+      };
+      await emitProgressWithLogging({
+        stage: "RAG Indexer",
+        status: "end",
+        message:
+          indexing.failures.length === 0
+            ? `RAG Indexer 완료 (${indexing.indexed}/${indexing.attempted}, DB ${stats.rowCount} rows/${stats.sessionCount} sessions)`
+            : `RAG Indexer 부분 완료 (${indexing.indexed}/${indexing.attempted}, ${indexing.skipped}개 스킵, DB ${stats.rowCount} rows/${stats.sessionCount} sessions)`,
+      });
     } catch (idxErr) {
-      logger.warn(`RAG indexing 실패 (non-fatal): ${toErrorMessage(idxErr)}`);
+      const reason = toErrorMessage(idxErr);
+      ragIndexingSummary = {
+        status: "failed",
+        attempted: 0,
+        indexed: 0,
+        skipped: 0,
+        failures: [{
+          id: `session::${sessionId}`,
+          kind: "output",
+          sessionId,
+          reason,
+        }],
+      };
+      logger.warn(`RAG indexing 실패 (non-fatal): ${reason}`);
+      await emitProgressWithLogging({
+        stage: "RAG Indexer",
+        status: "error",
+        message: `RAG Indexer 실패 (non-fatal): ${reason}`,
+      });
     } finally {
       await ragEmbedder.dispose().catch(() => {});
       ragStore.close();
@@ -1607,6 +1650,7 @@ export const orchestratePipeline = async (
     ...(resumeHint ? { resumeHint } : {}),
     ...(semanticContext ? { semanticContext } : {}),
     ...(ragContextSummary ? { ragContextSummary } : {}),
+    ...(ragIndexingSummary ? { ragIndexingSummary } : {}),
     tokenAccounting,
     costAccounting,
     lightQuality,

--- a/src/core/pipeline/types.ts
+++ b/src/core/pipeline/types.ts
@@ -107,6 +107,24 @@ export interface RagContextSummary {
   items: RagContextDisplayItem[];
 }
 
+export interface RagIndexingFailure {
+  id: string;
+  kind: "prompt" | "task" | "output";
+  sessionId: string;
+  taskId?: string;
+  reason: string;
+}
+
+export interface RagIndexingSummary {
+  status: "completed" | "partial" | "failed" | "skipped";
+  attempted: number;
+  indexed: number;
+  skipped: number;
+  dbRowCount?: number;
+  dbSessionCount?: number;
+  failures?: RagIndexingFailure[];
+}
+
 export interface PipelineExecutionResult {
   ok: boolean;
   mode: InteractionMode;
@@ -137,6 +155,7 @@ export interface PipelineExecutionResult {
   resumeHint?: ResumeHintInfo;
   semanticContext?: SemanticContextResult[];
   ragContextSummary?: RagContextSummary;
+  ragIndexingSummary?: RagIndexingSummary;
   tokenAccounting?: TokenAccounting;
   costAccounting?: CostAccounting;
   lightQuality?: LightQualityCounters;

--- a/src/core/rag/embedding-indexer.ts
+++ b/src/core/rag/embedding-indexer.ts
@@ -5,6 +5,21 @@ interface Embedder {
   embed(text: string): Promise<Float32Array>;
 }
 
+export interface RagIndexingFailure {
+  id: string;
+  kind: "prompt" | "task" | "output";
+  sessionId: string;
+  taskId?: string;
+  reason: string;
+}
+
+export interface RagIndexingResult {
+  attempted: number;
+  indexed: number;
+  skipped: number;
+  failures: RagIndexingFailure[];
+}
+
 const MAX_EMBED_CHARS = 1200;
 
 function chunkTextForEmbedding(text: string): string[] {
@@ -59,48 +74,72 @@ export class EmbeddingIndexer {
     private readonly embedder: Embedder,
   ) {}
 
-  async indexSession(session: SessionState): Promise<void> {
+  async indexSession(session: SessionState): Promise<RagIndexingResult> {
     const sessionId = session.shared_context.session_id;
+    const result: RagIndexingResult = {
+      attempted: 0,
+      indexed: 0,
+      skipped: 0,
+      failures: [],
+    };
 
-    for (const [index, chunk] of chunkTextForEmbedding(session.shared_context.raw_input ?? "").entries()) {
-      const vec = await this.embedder.embed(chunk);
-      this.store.upsert(
-        index === 0 ? `prompt::${sessionId}` : `prompt::${sessionId}::chunk${index + 1}`,
-        vec,
-        { kind: "prompt", session_id: sessionId },
+    const indexChunks = async (
+      kind: "prompt" | "task" | "output",
+      taskId: string | undefined,
+      chunks: string[],
+      idForIndex: (index: number) => string,
+    ): Promise<void> => {
+      for (const [index, chunk] of chunks.entries()) {
+        const id = idForIndex(index);
+        result.attempted += 1;
+        try {
+          const vec = await this.embedder.embed(chunk);
+          this.store.upsert(id, vec, {
+            kind,
+            session_id: sessionId,
+            ...(taskId ? { task_id: taskId } : {}),
+          });
+          result.indexed += 1;
+        } catch (error) {
+          result.skipped += 1;
+          result.failures.push({
+            id,
+            kind,
+            sessionId,
+            ...(taskId ? { taskId } : {}),
+            reason: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    };
+
+    await indexChunks(
+      "prompt",
+      undefined,
+      chunkTextForEmbedding(session.shared_context.raw_input ?? ""),
+      (index) => index === 0 ? `prompt::${sessionId}` : `prompt::${sessionId}::chunk${index + 1}`,
+    );
+
+    for (const [taskId, rawResult] of Object.entries(session.task_results ?? {})) {
+      const taskResult = rawResult as { success?: boolean; summary?: string; raw_output?: string };
+      if (!taskResult.success) continue;
+
+      const taskText = taskResult.summary ?? taskResult.raw_output ?? taskId;
+      await indexChunks(
+        "task",
+        taskId,
+        chunkTextForEmbedding(taskText),
+        (index) => index === 0 ? `task::${sessionId}::${taskId}` : `task::${sessionId}::${taskId}::chunk${index + 1}`,
+      );
+
+      await indexChunks(
+        "output",
+        taskId,
+        chunkTextForEmbedding(taskResult.raw_output ?? ""),
+        (index) => index === 0 ? `output::${sessionId}::${taskId}` : `output::${sessionId}::${taskId}::chunk${index + 1}`,
       );
     }
 
-    for (const [taskId, rawResult] of Object.entries(session.task_results ?? {})) {
-      const result = rawResult as { success?: boolean; summary?: string; raw_output?: string };
-      if (!result.success) continue;
-
-      const taskText = result.summary ?? result.raw_output ?? taskId;
-      for (const [index, chunk] of chunkTextForEmbedding(taskText).entries()) {
-        const taskVec = await this.embedder.embed(chunk);
-        this.store.upsert(
-          index === 0 ? `task::${sessionId}::${taskId}` : `task::${sessionId}::${taskId}::chunk${index + 1}`,
-          taskVec,
-          {
-            kind: "task",
-            session_id: sessionId,
-            task_id: taskId,
-          },
-        );
-      }
-
-      for (const [index, chunk] of chunkTextForEmbedding(result.raw_output ?? "").entries()) {
-        const outVec = await this.embedder.embed(chunk);
-        this.store.upsert(
-          index === 0 ? `output::${sessionId}::${taskId}` : `output::${sessionId}::${taskId}::chunk${index + 1}`,
-          outVec,
-          {
-            kind: "output",
-            session_id: sessionId,
-            task_id: taskId,
-          },
-        );
-      }
-    }
+    return result;
   }
 }

--- a/src/core/rag/vector-store.ts
+++ b/src/core/rag/vector-store.ts
@@ -34,6 +34,11 @@ export interface SearchResult {
   meta: EmbeddingMeta;
 }
 
+export interface VectorStoreStats {
+  rowCount: number;
+  sessionCount: number;
+}
+
 export class VectorStore {
   private db: _Db | null = null;
 
@@ -146,5 +151,22 @@ export class VectorStore {
     if (!row) return;
     db.prepare("DELETE FROM vec_index WHERE rowid = ?").run(row.rowid);
     db.prepare("DELETE FROM embedding_meta WHERE rowid = ?").run(row.rowid);
+  }
+
+  getStats(): VectorStoreStats {
+    const db = this.conn;
+    const row = db
+      .prepare<{ rowCount: number; sessionCount: number }>(
+        `SELECT
+          COUNT(*) AS rowCount,
+          COUNT(DISTINCT session_id) AS sessionCount
+         FROM embedding_meta`,
+      )
+      .get();
+
+    return {
+      rowCount: row?.rowCount ?? 0,
+      sessionCount: row?.sessionCount ?? 0,
+    };
   }
 }

--- a/tests/ts/unit/cli/format.test.ts
+++ b/tests/ts/unit/cli/format.test.ts
@@ -180,6 +180,66 @@ describe("formatSuccess", () => {
     expect(formatted).not.toContain("task::a13f9c2b::t2");
   });
 
+  it("renders RAG indexing summary for partial indexing", () => {
+    const formatted = formatSuccess(
+      {
+        ...result,
+        ragIndexingSummary: {
+          status: "partial" as const,
+          attempted: 3,
+          indexed: 2,
+          skipped: 1,
+          dbRowCount: 12,
+          dbSessionCount: 4,
+          failures: [
+            {
+              id: "output::a13f9c2b::t2",
+              kind: "output" as const,
+              sessionId: "a13f9c2b",
+              taskId: "t2",
+              reason: "context too long",
+            },
+          ],
+        },
+      },
+      false,
+    );
+
+    expect(formatted).toContain("RAG 인덱싱");
+    expect(formatted).toContain("부분 완료");
+    expect(formatted).toContain("2/3");
+    expect(formatted).toContain("1개 스킵");
+    expect(formatted).toContain("DB 12 rows / 4 sessions");
+    expect(formatted).toContain("output t2: context too long");
+  });
+
+  it("renders non-fatal RAG indexing failure", () => {
+    const formatted = formatSuccess(
+      {
+        ...result,
+        ragIndexingSummary: {
+          status: "failed" as const,
+          attempted: 0,
+          indexed: 0,
+          skipped: 0,
+          failures: [
+            {
+              id: "session::test-session",
+              kind: "output" as const,
+              sessionId: "test-session",
+              reason: "db unavailable",
+            },
+          ],
+        },
+      },
+      false,
+    );
+
+    expect(formatted).toContain("RAG 인덱싱");
+    expect(formatted).toContain("실패 (non-fatal)");
+    expect(formatted).toContain("db unavailable");
+  });
+
   it("falls back to semanticContext when RAG display summary is absent", () => {
     const formatted = formatSuccess(
       {

--- a/tests/ts/unit/cli/tui/design/tokens.test.ts
+++ b/tests/ts/unit/cli/tui/design/tokens.test.ts
@@ -3,8 +3,10 @@ import {
   applyTheme,
   getActiveTheme,
   glyph,
+  isNerdFontEnabled,
   isThemeName,
   resolveActiveTheme,
+  setNerdFont,
   spacing,
   statusColor,
   themes,
@@ -46,6 +48,14 @@ describe("design tokens", () => {
   });
 
   describe("glyph", () => {
+    beforeEach(() => {
+      setNerdFont(false);
+    });
+
+    afterEach(() => {
+      setNerdFont(false);
+    });
+
     it("provides expected single-character markers", () => {
       expect(glyph.active).toBe("●");
       expect(glyph.skipped).toBe("○");
@@ -70,6 +80,71 @@ describe("design tokens", () => {
       expect(glyph.cacheAdvise).toBe("⚠");
       expect(glyph.ragInjected).toBe("ⓘ");
       expect(glyph.ragSkipped).toBe("○");
+    });
+  });
+
+  describe("nerd font system", () => {
+    beforeEach(() => {
+      setNerdFont(false);
+    });
+
+    afterEach(() => {
+      setNerdFont(false);
+    });
+
+    it("is disabled by default", () => {
+      expect(isNerdFontEnabled()).toBe(false);
+    });
+
+    it("setNerdFont(true) switches glyph values to nerd font set", () => {
+      const defaultActive = glyph.active;
+      setNerdFont(true);
+      expect(isNerdFontEnabled()).toBe(true);
+      expect(glyph.active).not.toBe(defaultActive);
+      expect(glyph.spinner.length).toBeGreaterThan(0);
+    });
+
+    it("setNerdFont(false) restores default glyph values", () => {
+      setNerdFont(true);
+      setNerdFont(false);
+      expect(isNerdFontEnabled()).toBe(false);
+      expect(glyph.active).toBe("●");
+      expect(glyph.success).toBe("✓");
+      expect(glyph.failure).toBe("✗");
+      expect(glyph.skipped).toBe("○");
+      expect(glyph.cacheHit).toBe("▣");
+      expect(glyph.ragInjected).toBe("ⓘ");
+    });
+
+    it("nerd font glyph set has all required keys", () => {
+      setNerdFont(true);
+      const keys: Array<keyof typeof glyph> = [
+        "active", "done", "skipped", "error", "pending", "info",
+        "warn", "success", "failure", "selected", "arrow", "bullet",
+        "separator", "ellipsisOneChar", "ellipsisThreeDot",
+        "changeAdd", "changeDelete", "changeRename", "changeUpdate",
+        "cacheHit", "cacheMiss", "cacheAdvise", "ragInjected", "ragSkipped",
+      ];
+      for (const key of keys) {
+        expect(typeof glyph[key]).toBe("string");
+        expect((glyph[key] as string).length).toBeGreaterThan(0);
+      }
+      expect(glyph.spinner.length).toBeGreaterThan(0);
+    });
+
+    it("toggling nerd font twice returns to original values", () => {
+      const snapshot = {
+        active: glyph.active,
+        success: glyph.success,
+        cacheHit: glyph.cacheHit,
+        spinner0: glyph.spinner[0],
+      };
+      setNerdFont(true);
+      setNerdFont(false);
+      expect(glyph.active).toBe(snapshot.active);
+      expect(glyph.success).toBe(snapshot.success);
+      expect(glyph.cacheHit).toBe(snapshot.cacheHit);
+      expect(glyph.spinner[0]).toBe(snapshot.spinner0);
     });
   });
 

--- a/tests/ts/unit/cli/tui/panels/pipeline-status.test.ts
+++ b/tests/ts/unit/cli/tui/panels/pipeline-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { PipelineStatusPanel } from "../../../../../../src/cli/tui/panels/pipeline-status.js";
+import { setNerdFont } from "../../../../../../src/cli/tui/design/tokens.js";
 import type { PipelineProgressEvent } from "../../../../../../src/core/pipeline/types.js";
 import type { ActionTimelineEvent } from "../../../../../../src/core/timeline/types.js";
 
@@ -379,6 +380,49 @@ describe("PipelineStatusPanel", () => {
       panel.render(mockContext, mockRegion);
       const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("\n");
       expect(output).not.toContain("캐시");
+    });
+  });
+
+  describe("nerd font glyph integration", () => {
+    afterEach(() => {
+      setNerdFont(false);
+    });
+
+    it("uses default glyphs when nerd font is off", () => {
+      setNerdFont(false);
+      const event: PipelineProgressEvent = { stage: "Executor", status: "end", message: "완료" };
+      panel.update(event);
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("");
+      expect(output).toContain("●");
+    });
+
+    it("uses nerd font glyphs when nerd font is on", () => {
+      setNerdFont(true);
+      const event: PipelineProgressEvent = { stage: "Executor", status: "end", message: "완료" };
+      panel.update(event);
+      mockScreen.write.mockClear();
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("");
+      expect(output).not.toContain("●");
+      expect(output).toContain("Executor");
+    });
+
+    it("switching nerd font mid-session changes subsequent renders", () => {
+      const event: PipelineProgressEvent = { stage: "Executor", status: "end", message: "완료" };
+      panel.update(event);
+
+      setNerdFont(false);
+      panel.render(mockContext, mockRegion);
+      const defaultOutput = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("");
+
+      mockScreen.write.mockClear();
+      setNerdFont(true);
+      panel.render(mockContext, mockRegion);
+      const nerdOutput = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("");
+
+      expect(defaultOutput).toContain("●");
+      expect(nerdOutput).not.toContain("●");
     });
   });
 });

--- a/tests/ts/unit/cli/tui/panels/result-summary.test.ts
+++ b/tests/ts/unit/cli/tui/panels/result-summary.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setNerdFont } from "../../../../../../src/cli/tui/design/tokens.js";
 import { ResultSummaryPanel } from "../../../../../../src/cli/tui/panels/result-summary.js";
 import type { PipelineExecutionResult } from "../../../../../../src/core/pipeline/types.js";
 import type { TokenReductionSnapshot, TokenMetricsSnapshot } from "../../../../../../src/core/utils/tokenMetrics.js";
@@ -646,6 +647,58 @@ describe("ResultSummaryPanel", () => {
       panel.render(mockContext, mockRegion);
       const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
       expect(output).not.toContain("전사 저장");
+    });
+  });
+
+  describe("nerd font glyph integration", () => {
+    const stripAnsi = (s: string): string =>
+      s.replace(/\[[0-?]*[ -/]*[@-~]/g, "");
+
+    afterEach(() => {
+      setNerdFont(false);
+    });
+
+    it("task status uses default glyphs when nerd font is off", () => {
+      setNerdFont(false);
+      panel.setResult(mockResult({
+        taskRecords: [{ taskId: "t1", status: "completed", rawOutput: "" }, { taskId: "t2", status: "failed", rawOutput: "" }],
+      }));
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("");
+      expect(output).toContain("✓");
+      expect(output).toContain("✗");
+    });
+
+    it("task status uses nerd font glyphs when nerd font is on", () => {
+      setNerdFont(true);
+      panel.setResult(mockResult({
+        taskRecords: [{ taskId: "t1", status: "completed", rawOutput: "" }, { taskId: "t2", status: "failed", rawOutput: "" }],
+      }));
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("");
+      expect(output).not.toContain("✓");
+      expect(output).not.toContain("✗");
+      expect(output).toContain("t1");
+      expect(output).toContain("t2");
+    });
+
+    it("switching nerd font between renders changes task status glyphs", () => {
+      const result = mockResult({
+        taskRecords: [{ taskId: "t1", status: "completed", rawOutput: "" }],
+      });
+      panel.setResult(result);
+
+      setNerdFont(false);
+      panel.render(mockContext, mockRegion);
+      const defaultOut = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("");
+
+      mockScreen.write.mockClear();
+      setNerdFont(true);
+      panel.render(mockContext, mockRegion);
+      const nerdOut = mockScreen.write.mock.calls.map((c: any) => stripAnsi(c[0])).join("");
+
+      expect(defaultOut).toContain("✓");
+      expect(nerdOut).not.toContain("✓");
     });
   });
 });

--- a/tests/ts/unit/cli/tui/panels/result-summary.test.ts
+++ b/tests/ts/unit/cli/tui/panels/result-summary.test.ts
@@ -467,6 +467,66 @@ describe("ResultSummaryPanel", () => {
     });
   });
 
+  describe("RAG indexing summary section", () => {
+    it("renders partial indexing status with DB stats and failures", () => {
+      panel.setResult(
+        mockResult({
+          ragIndexingSummary: {
+            status: "partial",
+            attempted: 3,
+            indexed: 2,
+            skipped: 1,
+            dbRowCount: 12,
+            dbSessionCount: 4,
+            failures: [
+              {
+                id: "output::sess::t1",
+                kind: "output",
+                sessionId: "sess",
+                taskId: "t1",
+                reason: "context too long",
+              },
+            ],
+          },
+        }),
+      );
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toContain("RAG 인덱싱");
+      expect(output).toContain("부분 완료");
+      expect(output).toContain("2/3");
+      expect(output).toContain("DB 12 rows/4 sessions");
+      expect(output).toContain("output t1");
+      expect(output).toContain("context too long");
+    });
+
+    it("renders failed indexing as non-fatal", () => {
+      panel.setResult(
+        mockResult({
+          ragIndexingSummary: {
+            status: "failed",
+            attempted: 0,
+            indexed: 0,
+            skipped: 0,
+            failures: [
+              {
+                id: "session::sess",
+                kind: "output",
+                sessionId: "sess",
+                reason: "db unavailable",
+              },
+            ],
+          },
+        }),
+      );
+      panel.render(mockContext, mockRegion);
+      const output = mockScreen.write.mock.calls.map((c: any) => c[0]).join("\n");
+      expect(output).toContain("RAG 인덱싱");
+      expect(output).toContain("실패 (non-fatal)");
+      expect(output).toContain("db unavailable");
+    });
+  });
+
   describe("resume hint banner (P1-3)", () => {
     it("renders banner at top with sessionId, completed count, currentTaskId, ago, and continue command", () => {
       const fiveMinAgo = new Date(Date.now() - 5 * 60_000).toISOString();

--- a/tests/ts/unit/core/pipeline/orchestrator-rag-cache.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator-rag-cache.test.ts
@@ -47,6 +47,15 @@ const ragContextLoaderInstance = vi.hoisted(() => ({
   load: vi.fn(async (): Promise<any[]> => []),
 }));
 
+const vectorStoreInstance = vi.hoisted(() => ({
+  open: vi.fn(),
+  close: vi.fn(),
+  search: vi.fn(() => []),
+  upsert: vi.fn(),
+  delete: vi.fn(),
+  getStats: vi.fn(() => ({ rowCount: 3, sessionCount: 1 })),
+}));
+
 const countRagContextTokensMock = vi.hoisted(() =>
   vi.fn((text: string) => Math.ceil(text.length / 4)),
 );
@@ -78,13 +87,7 @@ vi.mock("../../../../../src/core/rag/embedding-service.js", () => ({
 }));
 
 vi.mock("../../../../../src/core/rag/vector-store.js", () => ({
-  VectorStore: vi.fn(() => ({
-    open: vi.fn(),
-    close: vi.fn(),
-    search: vi.fn(() => []),
-    upsert: vi.fn(),
-    delete: vi.fn(),
-  })),
+  VectorStore: vi.fn(() => vectorStoreInstance),
 }));
 
 vi.mock("../../../../../src/core/rag/semantic-retriever.js", () => ({
@@ -172,10 +175,18 @@ describe("orchestratePipeline — RAG 캐시 통합", () => {
     vi.mocked(EmbeddingService).mockClear();
     embeddingServiceInstance.init.mockClear();
     embeddingServiceInstance.embed.mockClear();
+    embeddingServiceInstance.embed.mockImplementation(async () => new Float32Array(1024));
     embeddingServiceInstance.dispose.mockClear();
     semanticRetrieverInstance.hybridSearch.mockResolvedValue([]);
     ragContextLoaderInstance.load.mockResolvedValue([]);
     countRagContextTokensMock.mockImplementation((text: string) => Math.ceil(text.length / 4));
+    vectorStoreInstance.open.mockClear();
+    vectorStoreInstance.close.mockClear();
+    vectorStoreInstance.search.mockClear();
+    vectorStoreInstance.upsert.mockClear();
+    vectorStoreInstance.delete.mockClear();
+    vectorStoreInstance.getStats.mockClear();
+    vectorStoreInstance.getStats.mockReturnValue({ rowCount: 3, sessionCount: 1 });
 
     nodeRuntimeMocks.completeChatWithNodeLlamaCpp.mockReset();
     nodeRuntimeMocks.buildNodeLlamaRuntimeSignature.mockClear();
@@ -217,6 +228,72 @@ describe("orchestratePipeline — RAG 캐시 통합", () => {
     expect(result.tokenAccounting!.tokensAddedByRagContext).toBe(0);
     expect(result.lightQuality!.cacheHitRate).toBe(1.0);
   }, 30_000);
+
+  it("RAG 인덱싱 성공 시 결과에 row/session count를 포함한다", async () => {
+    vi.mocked(isRagEnabled).mockReturnValue(true);
+
+    const result = await orchestratePipeline(baseRequest);
+
+    expect(result.ragIndexingSummary).toMatchObject({
+      status: "completed",
+      attempted: 3,
+      indexed: 3,
+      skipped: 0,
+      dbRowCount: 3,
+      dbSessionCount: 1,
+    });
+  });
+
+  it("RAG 인덱싱 일부 실패는 partial로 표시하고 파이프라인은 성공 유지한다", async () => {
+    vi.mocked(isRagEnabled).mockReturnValue(true);
+    let callCount = 0;
+    embeddingServiceInstance.embed.mockImplementation(async () => {
+      callCount += 1;
+      if (callCount === 3) throw new Error("output chunk failed");
+      return new Float32Array(1024);
+    });
+
+    const result = await orchestratePipeline(baseRequest);
+
+    expect(result.ok).toBe(true);
+    expect(result.ragIndexingSummary).toMatchObject({
+      status: "partial",
+      attempted: 3,
+      indexed: 2,
+      skipped: 1,
+      dbRowCount: 3,
+      dbSessionCount: 1,
+    });
+    expect(result.ragIndexingSummary?.failures).toEqual([
+      expect.objectContaining({
+        kind: "output",
+        taskId: "t1",
+        reason: "output chunk failed",
+      }),
+    ]);
+  });
+
+  it("RAG 인덱싱 전체 실패는 failed로 표시하고 파이프라인은 성공 유지한다", async () => {
+    vi.mocked(isRagEnabled).mockReturnValue(true);
+    vectorStoreInstance.getStats.mockImplementationOnce(() => {
+      throw new Error("db unavailable");
+    });
+
+    const result = await orchestratePipeline(baseRequest);
+
+    expect(result.ok).toBe(true);
+    expect(result.ragIndexingSummary).toMatchObject({
+      status: "failed",
+      attempted: 0,
+      indexed: 0,
+      skipped: 0,
+    });
+    expect(result.ragIndexingSummary?.failures).toEqual([
+      expect.objectContaining({
+        reason: "db unavailable",
+      }),
+    ]);
+  });
 
   it("RAG 활성화 + F2 전체 miss → EmbeddingService.init 호출됨", async () => {
     // findSuccessfulTaskByHash → null (beforeEach default)

--- a/tests/ts/unit/core/rag/embedding-indexer.test.ts
+++ b/tests/ts/unit/core/rag/embedding-indexer.test.ts
@@ -9,6 +9,7 @@ function makeMockStore(): VectorStore {
     upsert: vi.fn(),
     search: vi.fn().mockReturnValue([]),
     delete: vi.fn(),
+    getStats: vi.fn(() => ({ rowCount: 0, sessionCount: 0 })),
     open: vi.fn(),
     close: vi.fn(),
   } as unknown as VectorStore;
@@ -103,6 +104,34 @@ describe("EmbeddingIndexer", () => {
       (c) => typeof c[0] === "string" && c[0].startsWith("output::sess-abc::t1"),
     );
     expect(outputCalls.length).toBeGreaterThan(1);
+  });
+
+  it("raw_output 청크 일부가 실패해도 task summary 인덱싱은 유지하고 실패만 집계한다", async () => {
+    let callCount = 0;
+    embedder.embed.mockImplementation(async () => {
+      callCount += 1;
+      if (callCount === 3) throw new Error("output chunk failed");
+      return makeVec(4);
+    });
+
+    const indexing = await indexer.indexSession(makeSession() as any);
+
+    expect(store.upsert).toHaveBeenCalledWith(
+      expect.stringContaining("task::sess-abc::t1"),
+      expect.any(Float32Array),
+      expect.objectContaining({ kind: "task", session_id: "sess-abc", task_id: "t1" }),
+    );
+    expect(indexing.indexed).toBe(2);
+    expect(indexing.skipped).toBe(1);
+    expect(indexing.failures).toEqual([
+      expect.objectContaining({
+        id: "output::sess-abc::t1",
+        kind: "output",
+        sessionId: "sess-abc",
+        taskId: "t1",
+        reason: "output chunk failed",
+      }),
+    ]);
   });
 
   it("raw_input이 없는 세션은 prompt 인덱싱을 건너뛴다", async () => {

--- a/tests/ts/unit/core/rag/vector-store.test.ts
+++ b/tests/ts/unit/core/rag/vector-store.test.ts
@@ -88,4 +88,15 @@ describe("VectorStore", () => {
     expect(first?.meta.session_id).toBe("sess-xyz");
     expect(first?.meta.task_id).toBe("t1");
   });
+
+  it("getStats — row/session count를 반환한다", () => {
+    store.upsert("task-1", makeVec([1, 0, 0, 0]), { kind: "task", session_id: "s1" });
+    store.upsert("task-2", makeVec([0, 1, 0, 0]), { kind: "task", session_id: "s2" });
+    store.upsert("task-1", makeVec([0, 1, 0, 0]), { kind: "task", session_id: "s1" });
+
+    expect(store.getStats()).toEqual({
+      rowCount: 2,
+      sessionCount: 2,
+    });
+  });
 });


### PR DESCRIPTION
## 개요

이 PR은 두 개의 독립적인 기능을 포함합니다.

---

## 1. RAG 인덱싱 상태 노출 (`feat: surface rag indexing status`)

RAG 인덱싱 결과를 파이프라인 실행 후 Result 패널과 포맷 출력에 표시합니다.

### 변경 내용

**타입 (`src/core/pipeline/types.ts`)**
- `RagIndexingSummary` — `completed / partial / failed / skipped` 상태 + 시도/인덱싱/스킵 카운트 + DB 통계
- `RagIndexingFailure` — 개별 실패 항목 (kind, sessionId, reason)
- `PipelineExecutionResult`에 `ragIndexingSummary?` 필드 추가

**오케스트레이터 (`src/core/pipeline/orchestrator.ts`)**
- 인덱싱 성공/부분 실패/전체 실패를 구분하여 `ragIndexingSummary` 생성
- 인덱싱 실패는 파이프라인 전체 실패로 전파하지 않음 (non-fatal)

**Result 패널 (`src/cli/tui/panels/result-summary.ts`)**
- `ragIndexingSummary` 기반으로 인덱싱 요약 라인 렌더 (완료 / 부분 완료 + 실패 목록 / 실패)

**포맷 (`src/cli/format.ts`)**
- JSON/verbose 출력에도 RAG 인덱싱 요약 포함

**신규 테스트**
- `format.test.ts` — 60줄, RAG 인덱싱 포맷 케이스
- `result-summary.test.ts` — 인덱싱 완료/부분/실패 렌더 케이스
- `orchestrator-rag-cache.test.ts` — 91줄 확장, 전체 실패 non-fatal 케이스 포함
- `embedding-indexer.test.ts`, `vector-store.test.ts` — 커버리지 확장

---

## 2. Nerd Font 아이콘 옵션 + TUI 구조 개선 (`feat(tui): Nerd Font 아이콘 옵션 + TUI 구조 개선`)

### Nerd Font 토글

| 방법 | 예시 |
|------|------|
| 환경변수 (시작 시) | `DETOKS_NERD_FONT=1 npm run cli` |
| REPL 커맨드 | `/nerd` (토글) · `/nerd on` · `/nerd off` · `/nf` (별칭) |

**기본 글리프 vs Nerd Font 글리프 (예시)**

| 역할 | 기본 | Nerd Font |
|------|------|-----------|
| active | `●` |  (nf-fa-circle) |
| done | `●` |  (nf-fa-check_circle) |
| error | `●` |  (nf-fa-times_circle) |
| success | `✓` |  (nf-fa-check) |
| failure | `✗` |  (nf-fa-times) |
| cacheHit | `▣` |  (nf-fa-database) |
| toolWeb | `◐` |  (nf-fa-globe) |

### GlyphSet 인터페이스

`glyph`를 `as const` 리터럴에서 **mutable `GlyphSet` 객체**로 전환:
- 30개 glyph 키 전체를 타입으로 명시 → `glyph.foo` 오타 시 컴파일 에러
- `setNerdFont(bool)` 호출 시 `Object.assign(glyph, ...)` 으로 런타임 전환

### 상태 변수 정리 (`src/cli/tui/index.ts`)

8개의 `let current*` 변수를 `state` 객체로 통합:

```typescript
// Before
let currentAdapter = options.adapter;
let currentAdapterModel = ...;
let currentVerbose = options.verbose;
// ... 5개 더

// After
const state = {
  adapter: options.adapter,
  adapterModel: ...,
  verbose: options.verbose,
  ...
};
```

### Dirty Flag 시스템

패널별 재렌더 필요 여부를 추적하여 불필요한 화면 쓰기 제거:

```typescript
const dirtyPanels = { pipeline: true, transcript: true, result: true };

// 이벤트 수신 시 해당 패널만 dirty 마킹
// render() 내부에서 dirty한 패널만 실제 렌더
if (dirtyPanels.pipeline) {
  pipelinePanel.render(ctx, statusRegion);
  dirtyPanels.pipeline = false;
}
```

### Exhaustive Switch 교체

정적 lookup 테이블 → `switch` 문으로 교체 → TypeScript가 누락 케이스를 컴파일 에러로 검출:

```typescript
// Before — 런타임에만 undefined 감지
const STATUS_ICONS: Record<Status, string> = { end: glyph.done, ... };

// After — 컴파일 타임에 exhaustiveness 보장
const getStatusIcon = (status: PipelineProgressStatus): string => {
  switch (status) {
    case "end":   return glyph.done;
    case "error": return glyph.error;
    case "skip":  return glyph.skipped;
    case "start": return glyph.active;
    case "info":  return glyph.info;
  }
};
```

**신규 테스트 11개**
- `tokens.test.ts` — nerd font 활성화/비활성화/토글 × GlyphSet 키 완결성 검증
- `pipeline-status.test.ts` — nerd font 전환 전후 렌더 출력 비교
- `result-summary.test.ts` — nerd font glyph 전환 통합 케이스

---

## 테스트 결과

```
Test Files  115 passed | 1 skipped (116)
     Tests  1234 passed | 3 skipped (1237)
```

## 체크리스트

- [x] `npm run typecheck` — 타입 에러 없음
- [x] `npm test` — 1234 tests passed
- [x] `DETOKS_NERD_FONT=1` 환경변수로 시작 시 자동 활성화
- [x] `/nerd`, `/nerd on`, `/nerd off`, `/nf` 커맨드 동작 확인
- [x] `setNerdFont()` 후 이후 render에서 즉시 전환됨 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)