### PR TITLE
fix(tui): slash autocomplete 패널 렌더링 복구 + README 최신화

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -4,7 +4,7 @@
   <a href="./README.md">Language</a> | <a href="./README.ko.md">한국어</a>
 </p>
 
-detoks is an **interactive wrapper CLI** that sits in front of LLM CLIs such as `codex` and `gemini`.
+detoks is an **interactive wrapper CLI** that sits in front of LLM CLIs such as `codex`, `gemini`, and `claude`.
 Its goal is to make LLM CLI workflows more stable and reproducible by organizing input, context, state, and execution boundaries.
 
 <p align="center">
@@ -13,16 +13,25 @@ Its goal is to make LLM CLI workflows more stable and reproducible by organizing
 
 ## At a glance
 
-- one-shot execution and REPL mode
-- task graph / context / state management
-- separated adapter / subprocess boundaries
+- One-shot execution and REPL mode (text or full-screen TUI)
+- Task graph / context / state management
+- Separated adapter / subprocess boundaries: `codex` / `gemini` / `claude`
 - `stub` / `real` execution modes
-- session save and resume workflow
+- Session save and resume workflow (checkpoint support)
+- **RAG system**: cross-session context reuse, semantic search, failure pattern recognition
+- **Cache system**: cross-session cache, hash-based validity checks, `/cache` REPL command
+- **TUI mode** (full screen):
+  - Live pipeline status / cache stream / RAG context summary
+  - Theme system: `dark` / `light` / `colorblind` built-in palettes
+  - Runtime resizable split view: `/layout` command + Alt+↑/↓
+  - Inline cursor editing: Ctrl+A/E, ←/→, Home/End
+  - Input history: ↑/↓ to recall previous prompts + disk persistence
+  - Nerd Font icon support
 
 ## Requirements
 
 - Node.js `>=24.15.0 <26`
-- `codex` or `gemini` CLI when using the corresponding adapter
+- `codex`, `gemini`, or `claude` CLI when using the corresponding adapter
 - GGUF model loadable by `node-llama-cpp` when using local model inference
 
 See [STACK_VERSIONS.md](./docs/STACK_VERSIONS.md) and [LLAMA_CPP_SERVER_SPEC.md](./docs/LLAMA_CPP_SERVER_SPEC.md) for version details.
@@ -69,19 +78,107 @@ detoks repl
 detoks "summarize the current repo status"
 ```
 
-REPL example:
+REPL examples:
 
 ```bash
+# Text REPL (default)
 detoks repl --adapter codex --execution-mode stub
+
+# TUI REPL (full-screen UI)
+detoks repl --adapter codex --execution-mode stub --tui
+
+# TUI — light theme
+DETOKS_THEME=light detoks repl --adapter gemini --tui
+
+# TUI — Nerd Font icons
+DETOKS_NERD_FONT=1 detoks repl --adapter claude --tui
 ```
+
+## TUI REPL commands
+
+Slash commands available during TUI / Text REPL:
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show available commands |
+| `/adapter` | Switch adapter (codex / gemini / claude) |
+| `/model` | Change model |
+| `/cache [stats\|clear\|disable\|enable]` | Manage RAG cache state |
+| `/layout [reset\|transcript=N\|result=N\|+\|-]` | Resize TUI split at runtime |
+| `/nerd [on\|off]` | Toggle Nerd Font icons |
+| `/verbose` | Toggle verbose output |
+| `/exit` | Exit REPL |
+
+TUI keyboard shortcuts:
+
+| Shortcut | Action |
+|----------|--------|
+| ↑ / ↓ | Navigate input history |
+| ←/→, Home/End | Move cursor |
+| Ctrl+A / Ctrl+E | Jump to line start / end |
+| Alt+↑ / Alt+↓ | Resize split view |
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DETOKS_THEME` | TUI theme: `dark` / `light` / `colorblind` | `dark` |
+| `DETOKS_NERD_FONT` | Enable Nerd Font icons (`1` = on) | `0` |
 
 ## What detoks does
 
 1. Organizes input into work units
 2. Builds task graphs and dependencies
-3. Injects only the context needed for the current step
+3. Injects only the context needed for the current step (with cross-session RAG retrieval)
 4. Executes through adapter / subprocess boundaries
-5. Saves results to session state for later reuse
+5. Saves results to session state for later reuse (cache + pattern learning)
+
+## Changelog
+
+### Development version (dev — next release)
+
+**TUI improvements**
+- Theme system: `dark` / `light` / `colorblind` built-in palettes + `DETOKS_THEME` env var
+- Runtime resizable split view: `/layout` REPL command + Alt+↑/↓ shortcut
+- Inline cursor editing: Ctrl+A/E, ←/→, Home/End, position-aware backspace
+- Input history: ↑/↓ recall + disk persistence across sessions
+- Nerd Font icon support: `DETOKS_NERD_FONT=1` or `/nerd on`
+- Adapter transcript auto-save + result panel file path display
+- Result panel: Resume hint / Task grid / Verbose cost always visible
+- Live cache stream + RAG context summary always visible
+- Embedded PTY rendering optimization (contiguous wide-char rendering)
+- Design tokens + event router + declarative layout schema
+
+**RAG system (Phase 1–2)**
+- Cross-session cache: reuse context from previous sessions in current prompt
+- Semantic search: vector search via sqlite-vec + BGE-M3 embeddings
+- Pattern learning: task sequence extraction, failure pattern recognition, workflow template generation
+- ProjectMemory project_id isolation (separate cache per project)
+- `/cache [stats|clear|disable|enable]` REPL command
+- KURE-v1 embedding model + automatic first-run download
+- RAG indexing progress displayed in TUI
+
+**Translation and other**
+- Translation preamble automatic removal + fallback stability improvements
+- Translation model visualization benchmark script (`npm run benchmark:translate-report`)
+
+---
+
+### 0.1.2 (2026-05-06)
+
+- Improved install documentation: local / global / npx flows clarified
+- First-run model setup persistence stabilized
+
+### 0.1.1 (2026-05-04) — First public npm release
+
+- `@sorlros/detoks` published to npm
+- `claude` adapter added (third official adapter alongside `codex` and `gemini`)
+- Task type persisted in session results (survives restart)
+- Codex reasoning flow improvements
+- Local model execution via `node-llama-cpp` (GGUF)
+- TUI foundation: embedded PTY, real-time streaming, Korean IME input handling
+- Session checkpoint: save, list, continue, fork, restore
+- Role 1 translation pipeline + Guardrails output validation
 
 ## Documentation
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -4,7 +4,7 @@
   <a href="./README.md">Language</a> | <a href="./README.en.md">English</a>
 </p>
 
-detoks는 `codex`, `gemini` 같은 LLM CLI 앞단에서 동작하는 **interactive wrapper CLI**입니다.
+detoks는 `codex`, `gemini`, `claude` 같은 LLM CLI 앞단에서 동작하는 **interactive wrapper CLI**입니다.
 입력, 컨텍스트, 세션, 실행 경계를 정리해 **LLM CLI 작업 흐름을 더 안정적이고 재현 가능하게** 만드는 것이 목표입니다.
 
 <p align="center">
@@ -13,16 +13,25 @@ detoks는 `codex`, `gemini` 같은 LLM CLI 앞단에서 동작하는 **interacti
 
 ## 한눈에 보기
 
-- one-shot 실행과 REPL 모드 지원
+- one-shot 실행과 REPL 모드 (text / TUI 전체 화면)
 - task graph / context / state 관리
-- adapter / subprocess 경계 분리
+- adapter / subprocess 경계 분리: `codex` / `gemini` / `claude`
 - `stub` / `real` 실행 모드
-- 세션 저장 및 재개 기반 워크플로우
+- 세션 저장 및 재개 기반 워크플로우 (checkpoint 지원)
+- **RAG 시스템**: 세션 간 컨텍스트 재사용, 의미 검색, 실패 패턴 인식
+- **캐시 시스템**: Cross-Session Cache, 해시 기반 유효성 검사, `/cache` REPL 명령
+- **TUI 모드** (전체 화면):
+  - 실시간 파이프라인 상태 / 캐시 라이브 스트림 / RAG 컨텍스트 요약
+  - 테마 시스템: `dark` / `light` / `colorblind` 내장 팔레트
+  - 런타임 분할 크기 조절: `/layout` 명령 + Alt+↑/↓
+  - 인라인 커서 편집: Ctrl+A/E, ←/→, Home/End
+  - 입력 히스토리: ↑/↓ 로 이전 프롬프트 recall + 디스크 영속
+  - Nerd Font 아이콘 지원
 
 ## 요구 사항
 
 - Node.js `>=24.15.0 <26`
-- `codex` 또는 `gemini` CLI: 해당 adapter를 사용할 때
+- `codex`, `gemini`, 또는 `claude` CLI: 해당 adapter를 사용할 때
 - 로컬 모델 추론 사용 시: `node-llama-cpp`에서 로드 가능한 GGUF 모델
 
 자세한 버전 기준은 [STACK_VERSIONS.md](./docs/STACK_VERSIONS.md)와 [LLAMA_CPP_SERVER_SPEC.md](./docs/LLAMA_CPP_SERVER_SPEC.md)를 참고하세요.
@@ -72,16 +81,104 @@ detoks "summarize the current repo status"
 REPL 예시:
 
 ```bash
+# Text REPL (기본값)
 detoks repl --adapter codex --execution-mode stub
+
+# TUI REPL (전체 화면 UI)
+detoks repl --adapter codex --execution-mode stub --tui
+
+# TUI — 라이트 테마
+DETOKS_THEME=light detoks repl --adapter gemini --tui
+
+# TUI — Nerd Font 아이콘 활성화
+DETOKS_NERD_FONT=1 detoks repl --adapter claude --tui
 ```
+
+## TUI REPL 명령어
+
+TUI / Text REPL 실행 중 사용할 수 있는 슬래시 명령:
+
+| 명령 | 설명 |
+|------|------|
+| `/help` | 사용 가능한 명령 목록 표시 |
+| `/adapter` | 어댑터 전환 (codex / gemini / claude) |
+| `/model` | 모델 변경 |
+| `/cache [stats\|clear\|disable\|enable]` | RAG 캐시 상태 관리 |
+| `/layout [reset\|transcript=N\|result=N\|+\|-]` | TUI 분할 크기 런타임 조절 |
+| `/nerd [on\|off]` | Nerd Font 아이콘 토글 |
+| `/verbose` | 상세 출력 토글 |
+| `/exit` | REPL 종료 |
+
+TUI 키보드 단축키:
+
+| 단축키 | 동작 |
+|--------|------|
+| ↑ / ↓ | 입력 히스토리 탐색 |
+| ←/→, Home/End | 커서 이동 |
+| Ctrl+A / Ctrl+E | 줄 처음 / 끝으로 이동 |
+| Alt+↑ / Alt+↓ | 분할 크기 조절 |
+
+## 환경 변수
+
+| 변수 | 설명 | 기본값 |
+|------|------|--------|
+| `DETOKS_THEME` | TUI 테마: `dark` / `light` / `colorblind` | `dark` |
+| `DETOKS_NERD_FONT` | Nerd Font 아이콘 활성화 (`1` = on) | `0` |
 
 ## detoks가 해주는 일
 
 1. 입력을 작업 단위로 정리
 2. task graph와 의존성을 구성
-3. 현재 실행에 필요한 context만 주입
+3. 현재 실행에 필요한 context만 주입 (RAG 의미 검색으로 세션 간 재사용)
 4. adapter / subprocess boundary를 통해 실행
-5. 결과를 세션에 저장해 다음 실행에서 재사용
+5. 결과를 세션에 저장해 다음 실행에서 재사용 (캐시 + 패턴 학습)
+
+## 변경 이력
+
+### 개발 버전 (dev — 다음 릴리스 예정)
+
+**TUI 대폭 개선**
+- 테마 시스템: `dark` / `light` / `colorblind` 내장 팔레트 + `DETOKS_THEME` 환경 변수
+- 런타임 분할 크기 조절: `/layout` REPL 명령 + Alt+↑/↓ 단축키
+- 인라인 커서 편집: Ctrl+A/E, ←/→, Home/End, 위치 기반 Backspace
+- 입력 히스토리: ↑/↓ 이전 프롬프트 recall + 디스크 영속
+- Nerd Font 아이콘 지원: `DETOKS_NERD_FONT=1` 또는 `/nerd on`
+- 어댑터 트랜스크립트 자동 저장 + 결과 패널 파일 경로 표시
+- 결과 패널: Resume 안내 / Task grid / Verbose 비용 상시 표시
+- 캐시 라이브 스트림 + RAG 컨텍스트 요약 상시 표시
+- Embedded PTY 렌더링 최적화 (와이드 문자 연속 렌더링)
+- 디자인 토큰 + 이벤트 라우터 + 선언형 레이아웃 스키마 도입
+
+**RAG 시스템 (Phase 1~2)**
+- Cross-Session Cache: 이전 세션 컨텍스트를 현재 prompt에 재사용
+- 의미 검색: sqlite-vec + BGE-M3 임베딩 기반 벡터 검색
+- 패턴 학습: Task 시퀀스 추출, 실패 패턴 인식, 워크플로우 템플릿 자동 생성
+- ProjectMemory project_id 격리 (다중 프로젝트 캐시 분리)
+- `/cache [stats|clear|disable|enable]` REPL 명령 추가
+- KURE-v1 임베딩 모델 적용 + 첫 실행 시 자동 다운로드
+- RAG 인덱싱 진행 상태 TUI 표시
+
+**번역 및 기타**
+- 번역 preamble 자동 제거 + fallback 안정성 개선
+- 번역 모델 시각화 벤치마크 스크립트 추가 (`npm run benchmark:translate-report`)
+
+---
+
+### 0.1.2 (2026-05-06)
+
+- 설치 문서 개선: 로컬 / 전역 / npx 설치 흐름 명확화
+- 최초 실행 모델 설정 영속 안정화
+
+### 0.1.1 (2026-05-04) — 첫 npm 공개 릴리스
+
+- `@sorlros/detoks` npm 패키지 공개
+- `claude` 어댑터 추가 (`codex`, `gemini`에 이어 세 번째 공식 어댑터)
+- task type 세션 결과 영속 (재시작 후에도 task 분류 유지)
+- codex reasoning flow 개선
+- node-llama-cpp 기반 로컬 모델 실행 (GGUF)
+- TUI 기반 구축: embedded PTY, 실시간 스트리밍, 한글 IME 입력 처리
+- 세션 checkpoint 저장 및 재개 (list / continue / fork / restore)
+- Role 1 번역 파이프라인 + Guardrails 출력 검증
 
 ## 문서
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,11 @@ detoks는 `codex`, `gemini`, `claude` 같은 LLM CLI 앞단에서 동작하는 *
 
 ## 🔔 업데이트 안내
 
-`claude` 어댑터가 포함된 새 버전을 사용하려면, 설치된 detoks를 최신 릴리스로 업데이트하세요.
+최신 버전으로 업데이트하세요.
 
-- 전역 설치: `npm install -g @sorlros/detoks@latest`
 - 전역 업데이트: `npm update -g @sorlros/detoks`
-- 로컬 설치: `npm install @sorlros/detoks@latest`
-
-새 기능과 변경점은 GitHub Releases 또는 릴리스 노트에서 함께 안내하는 것을 권장합니다.
+- 전역 재설치: `npm install -g @sorlros/detoks@latest`
+- 로컬 업데이트: `npm install @sorlros/detoks@latest`
 
 <p align="center">
   <img src="./content.png" alt="detoks preview" width="720" />
@@ -23,12 +21,20 @@ detoks는 `codex`, `gemini`, `claude` 같은 LLM CLI 앞단에서 동작하는 *
 
 ## 한눈에 보기
 
-- one-shot 실행과 REPL 모드 지원 (text 또는 TUI)
+- one-shot 실행과 REPL 모드 (text / TUI 전체 화면)
 - task graph / context / state 관리
-- adapter / subprocess 경계 분리
+- adapter / subprocess 경계 분리: `codex` / `gemini` / `claude`
 - `stub` / `real` 실행 모드
-- 세션 저장 및 재개 기반 워크플로우
-- TUI 모드: 실시간 파이프라인 상태, 어댑터 출력, 토큰 절감 메트릭스 표시
+- 세션 저장 및 재개 기반 워크플로우 (checkpoint 지원)
+- **RAG 시스템**: 세션 간 컨텍스트 재사용, 의미 검색, 실패 패턴 인식
+- **캐시 시스템**: Cross-Session Cache, 해시 기반 유효성 검사, `/cache` REPL 명령
+- **TUI 모드** (전체 화면):
+  - 실시간 파이프라인 상태 / 캐시 라이브 스트림 / RAG 컨텍스트 요약
+  - 테마 시스템: `dark` / `light` / `colorblind` 내장 팔레트
+  - 런타임 분할 크기 조절: `/layout` 명령 + Alt+↑/↓
+  - 인라인 커서 편집: Ctrl+A/E, ←/→, Home/End
+  - 입력 히스토리: ↑/↓ 로 이전 프롬프트 recall + 디스크 영속
+  - Nerd Font 아이콘 지원
 
 ## 요구 사항
 
@@ -88,15 +94,99 @@ detoks repl --adapter codex --execution-mode stub
 
 # TUI REPL (전체 화면 UI)
 detoks repl --adapter codex --execution-mode stub --tui
+
+# TUI — 라이트 테마
+DETOKS_THEME=light detoks repl --adapter gemini --tui
+
+# TUI — Nerd Font 아이콘 활성화
+DETOKS_NERD_FONT=1 detoks repl --adapter claude --tui
 ```
+
+## TUI REPL 명령어
+
+TUI / Text REPL 실행 중 사용할 수 있는 슬래시 명령:
+
+| 명령 | 설명 |
+|------|------|
+| `/help` | 사용 가능한 명령 목록 표시 |
+| `/adapter` | 어댑터 전환 (codex / gemini / claude) |
+| `/model` | 모델 변경 |
+| `/cache [stats\|clear\|disable\|enable]` | RAG 캐시 상태 관리 |
+| `/layout [reset\|transcript=N\|result=N\|+\|-]` | TUI 분할 크기 런타임 조절 |
+| `/nerd [on\|off]` | Nerd Font 아이콘 토글 |
+| `/verbose` | 상세 출력 토글 |
+| `/exit` | REPL 종료 |
+
+TUI 키보드 단축키:
+
+| 단축키 | 동작 |
+|--------|------|
+| ↑ / ↓ | 입력 히스토리 탐색 |
+| ←/→, Home/End | 커서 이동 |
+| Ctrl+A / Ctrl+E | 줄 처음 / 끝으로 이동 |
+| Alt+↑ / Alt+↓ | 분할 크기 조절 |
+
+## 환경 변수
+
+| 변수 | 설명 | 기본값 |
+|------|------|--------|
+| `DETOKS_THEME` | TUI 테마: `dark` / `light` / `colorblind` | `dark` |
+| `DETOKS_NERD_FONT` | Nerd Font 아이콘 활성화 (`1` = on) | `0` |
 
 ## detoks가 해주는 일
 
 1. 입력을 작업 단위로 정리
 2. task graph와 의존성을 구성
-3. 현재 실행에 필요한 context만 주입
+3. 현재 실행에 필요한 context만 주입 (RAG 의미 검색으로 세션 간 재사용)
 4. adapter / subprocess boundary를 통해 실행
-5. 결과를 세션에 저장해 다음 실행에서 재사용
+5. 결과를 세션에 저장해 다음 실행에서 재사용 (캐시 + 패턴 학습)
+
+## 변경 이력
+
+### 개발 버전 (dev — 다음 릴리스 예정)
+
+**TUI 대폭 개선**
+- 테마 시스템: `dark` / `light` / `colorblind` 내장 팔레트 + `DETOKS_THEME` 환경 변수
+- 런타임 분할 크기 조절: `/layout` REPL 명령 + Alt+↑/↓ 단축키
+- 인라인 커서 편집: Ctrl+A/E, ←/→, Home/End, 위치 기반 Backspace
+- 입력 히스토리: ↑/↓ 이전 프롬프트 recall + 디스크 영속
+- Nerd Font 아이콘 지원: `DETOKS_NERD_FONT=1` 또는 `/nerd on`
+- 어댑터 트랜스크립트 자동 저장 + 결과 패널 파일 경로 표시
+- 결과 패널: Resume 안내 / Task grid / Verbose 비용 상시 표시
+- 캐시 라이브 스트림 + RAG 컨텍스트 요약 상시 표시
+- Embedded PTY 렌더링 최적화 (와이드 문자 연속 렌더링)
+- 디자인 토큰 + 이벤트 라우터 + 선언형 레이아웃 스키마 도입
+
+**RAG 시스템 (Phase 1~2)**
+- Cross-Session Cache: 이전 세션 컨텍스트를 현재 prompt에 재사용
+- 의미 검색: sqlite-vec + BGE-M3 임베딩 기반 벡터 검색
+- 패턴 학습: Task 시퀀스 추출, 실패 패턴 인식, 워크플로우 템플릿 자동 생성
+- ProjectMemory project_id 격리 (다중 프로젝트 캐시 분리)
+- `/cache [stats|clear|disable|enable]` REPL 명령 추가
+- KURE-v1 임베딩 모델 적용 + 첫 실행 시 자동 다운로드
+- RAG 인덱싱 진행 상태 TUI 표시
+
+**번역 및 기타**
+- 번역 preamble 자동 제거 + fallback 안정성 개선
+- 번역 모델 시각화 벤치마크 스크립트 추가 (`npm run benchmark:translate-report`)
+
+---
+
+### 0.1.2 (2026-05-06)
+
+- 설치 문서 개선: 로컬 / 전역 / npx 설치 흐름 명확화
+- 최초 실행 모델 설정 영속 안정화
+
+### 0.1.1 (2026-05-04) — 첫 npm 공개 릴리스
+
+- `@sorlros/detoks` npm 패키지 공개
+- `claude` 어댑터 추가 (`codex`, `gemini`에 이어 세 번째 공식 어댑터)
+- task type 세션 결과 영속 (재시작 후에도 task 분류 유지)
+- codex reasoning flow 개선
+- node-llama-cpp 기반 로컬 모델 실행 (GGUF)
+- TUI 기반 구축: embedded PTY, 실시간 스트리밍, 한글 IME 입력 처리
+- 세션 checkpoint 저장 및 재개 (list / continue / fork / restore)
+- Role 1 번역 파이프라인 + Guardrails 출력 검증
 
 ## 문서
 

--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -932,7 +932,10 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       const statusRegionEnd = Math.min(inputLayout.separatorRow, statusRegionStart + 8);
       const contentRegionStart = statusRegionEnd;
       const availableContentRows = Math.max(0, inputLayout.separatorRow - contentRegionStart);
-      const transcriptRows = availableContentRows > 0 ? availableContentRows : 0;
+      const transcriptRows =
+        !embeddedPaneMode && availableContentRows > 0
+          ? Math.max(1, Math.floor(availableContentRows * getTranscriptRatio()))
+          : availableContentRows;
       const transcriptRegionEnd = Math.min(
         inputLayout.separatorRow,
         contentRegionStart + transcriptRows,
@@ -952,7 +955,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         renderInputArea(ctx, input, cursor);
       }
 
-      if (slashAutocompleteQuery !== null) {
+      if (!embeddedPaneMode && slashAutocompleteQuery !== null) {
         renderSlashAutocompletePanel(
           ctx,
           resultRegion,


### PR DESCRIPTION
## Summary

- **버그 수정**: `renderInteractiveInput()`에서 `/` 입력 시 자동완성 패널이 표시되지 않던 문제 복구
- **안전 처리**: `--embedded-cli-ui` 모드에서 autocomplete가 embedded terminal pane과 겹치는 위험 차단
- **README 최신화**: 3종 모두(ko/en/main)에 v0.1.1~v0.1.2 변경 이력 및 최신 기능 반영

## 버그 원인

`renderInteractiveInput()`이 `transcriptRows = availableContentRows` (100%) 로 계산해 `resultRegion` 높이가 항상 0이었음. `render()`는 `getTranscriptRatio()`(기본 70%)를 적용해 나머지 30%를 result/autocomplete 영역으로 남기는데, `renderInteractiveInput()`은 그렇지 않아서 autocomplete 패널이 그려질 공간이 없었음.

## 변경 내용

**`src/cli/tui/index.ts`**
- `transcriptRows` 계산에 `getTranscriptRatio()` 적용 (`!embeddedPaneMode` 조건부)
- `renderSlashAutocompletePanel` 호출에 `!embeddedPaneMode` 가드 추가

**README.md / README.ko.md / README.en.md**
- 변경 이력 섹션 추가 (v0.1.1, v0.1.2, dev)
- RAG 시스템, 캐시 시스템, TUI 개선(테마·레이아웃·입력 히스토리·Nerd Font) 반영
- TUI 명령어 표, 키보드 단축키 표, 환경 변수 표 추가

## Test plan

- [ ] `detoks repl --tui` 실행 후 `/` 입력 → 자동완성 패널 표시 확인
- [ ] `/ca`, `/la`, `/ne` 등 입력 → 명령 필터링 확인
- [ ] ↑/↓ 로 목록 선택 후 Enter → 해당 명령 실행 확인
- [ ] `--embedded-cli-ui` 모드에서 `/` 입력 → autocomplete가 표시되지 않음 확인 (겹침 방지)
- [ ] `npm run typecheck` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)