### PR TITLE
fix(tui): 슬래시 명령 화이트리스트 게이트 — 자연어 /경로 통과

### DIFF
--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -18,6 +18,7 @@ import { runModelSetupIfNeeded } from "../model-setup/index.js";
 import {
   handleAdapterSwitch,
   handleSlashCommand,
+  isSlashCommand,
 } from "../repl-commands/index.js";
 import {
   getNextSlashAutocompleteIndex,
@@ -1770,7 +1771,16 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       const workspaceBefore = captureWorkspaceSnapshot(executionCwd);
       let receivedLiveAdapterEvents = false;
       try {
-        if (normalizedPrompt.startsWith("/")) {
+        // Whitelist gate: only treat as slash command if the leading "/" matches
+        // a known command (or alias), or is "/" alone (opens the menu). Otherwise
+        // pass through as a regular prompt — so "/tmp/path 에 파일 만들어줘" 같은
+        // 자연어 경로 시작 문장이 알 수 없는 명령으로 가로채지지 않는다.
+        const trimmedForCommand = normalizedPrompt.trim();
+        const isKnownSlash =
+          trimmedForCommand === "/" ||
+          (trimmedForCommand.startsWith("/") && isSlashCommand(trimmedForCommand, state.adapter));
+
+        if (isKnownSlash) {
           // /clear — reset all run blocks and scrollback (not allowed during execution)
           if (normalizedPrompt === "/clear") {
             if (isExecuting) {

--- a/tests/ts/unit/cli/repl-commands/is-slash-command.test.ts
+++ b/tests/ts/unit/cli/repl-commands/is-slash-command.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { isSlashCommand, getSlashCommand } from "../../../../../src/cli/repl-commands/index.js";
+
+// Test whitelist behavior used by the TUI to decide whether a "/..." input
+// should be treated as a slash command or fall through to prompt execution.
+//
+// The TUI calls isSlashCommand(input, adapter) and only routes to the slash
+// command handler when it returns true. Inputs like "/tmp/path 에 파일..."
+// must fall through to the LLM rather than being intercepted.
+
+describe("isSlashCommand (whitelist gate)", () => {
+  describe("known commands", () => {
+    it.each([
+      "/help",
+      "/h",
+      "/?",
+      "/clear",
+      "/c",
+      "/model",
+      "/m",
+      "/adapter",
+      "/a",
+      "/mode",
+      "/verbose",
+      "/v",
+      "/cache",
+      "/ca",
+      "/layout",
+      "/l",
+      "/nerd",
+      "/nf",
+      "/exit",
+      "/quit",
+      "/q",
+    ])("recognizes %s", (input) => {
+      expect(isSlashCommand(input, "codex")).toBe(true);
+    });
+
+    it("recognizes commands with arguments", () => {
+      expect(isSlashCommand("/layout reset", "codex")).toBe(true);
+      expect(isSlashCommand("/cache stats", "codex")).toBe(true);
+      expect(isSlashCommand("/nerd on", "codex")).toBe(true);
+    });
+
+    it("is case-insensitive on the command name", () => {
+      expect(isSlashCommand("/HELP", "codex")).toBe(true);
+      expect(isSlashCommand("/Clear", "codex")).toBe(true);
+    });
+  });
+
+  describe("natural-language paths starting with /", () => {
+    it.each([
+      "/tmp 디렉토리에 파일을 만들어줘",
+      "/tmp/test.txt 를 읽어줘",
+      "/etc/hosts 내용을 확인해줘",
+      "/var/log 폴더를 확인해줘",
+      "/usr/local/bin 에 무엇이 있는지 보여줘",
+      "/path/to/something",
+    ])("does NOT match natural-language path: %s", (input) => {
+      expect(isSlashCommand(input, "codex")).toBe(false);
+    });
+  });
+
+  describe("non-slash input", () => {
+    it("returns false for plain prompt", () => {
+      expect(isSlashCommand("hello world", "codex")).toBe(false);
+    });
+
+    it("returns false for empty string", () => {
+      expect(isSlashCommand("", "codex")).toBe(false);
+    });
+
+    it("returns false for input not starting with /", () => {
+      expect(isSlashCommand("help", "codex")).toBe(false);
+      expect(isSlashCommand("clear me up", "codex")).toBe(false);
+    });
+  });
+
+  describe("unknown slash commands", () => {
+    it("returns false for unknown command names", () => {
+      expect(isSlashCommand("/unknown", "codex")).toBe(false);
+      expect(isSlashCommand("/xyz123", "codex")).toBe(false);
+      expect(isSlashCommand("/모름", "codex")).toBe(false);
+    });
+  });
+
+  describe("getSlashCommand resolution", () => {
+    it("resolves aliases to the canonical command", () => {
+      expect(getSlashCommand("/h", "codex")?.name).toBe("help");
+      expect(getSlashCommand("/v", "codex")?.name).toBe("verbose");
+      expect(getSlashCommand("/q", "codex")?.name).toBe("exit");
+    });
+
+    it("returns null for unknown commands", () => {
+      expect(getSlashCommand("/tmp", "codex")).toBeNull();
+      expect(getSlashCommand("/etc", "codex")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- detoks REPL에서 `/`로 시작하는 자연어 프롬프트(예: `/tmp 디렉토리에 파일을 만들어줘`)가 알 수 없는 슬래시 명령으로 가로채여 LLM에 전달되지 않던 UX 이슈 수정
- 기존 `isSlashCommand(input, adapter)` 화이트리스트 유틸로 TUI 게이트 교체. 알려진 명령(또는 alias) 또는 `/` 단독일 때만 슬래시 핸들러로 라우팅, 그 외는 프롬프트로 통과
- 화이트리스트 회귀 방지용 단위 테스트 35개 신규 추가

## 화이트리스트 (참조용)

**공통 (BASE_COMMANDS):**
| 명령 | Aliases |
|---|---|
| `/help` | `/h`, `/?` |
| `/clear` | `/c` |
| `/model` | `/m` |
| `/adapter` | `/a` |
| `/mode` | — |
| `/verbose` | `/v` |
| `/cache` | `/ca` |
| `/layout` | `/l` |
| `/nerd` | `/nf` |
| `/exit` | `/quit`, `/q` |

**어댑터별 (인증된 경우):**
- codex: `/codex-models`, `/cms` / `/logout`, `/out`
- gemini: `/gemini-models`, `/gms` / `/logout`, `/out`
- claude: `/claude-models`, `/cls` / `/logout`, `/out`

**특수:** `/` 단독 입력 시 슬래시 명령 메뉴 진입 (기존 동작 보존)

## 동작 변화

| 입력 | 변경 전 | 변경 후 |
|---|---|---|
| `/help` | 도움말 표시 | 동일 |
| `/clear` | RunBlock 초기화 | 동일 |
| `/tmp 디렉토리에 파일 만들어줘` | `[WARN] 알 수 없는 명령어: /tmp ...` 출력 후 무시 | LLM에 프롬프트로 전달 |
| `/etc/hosts 보여줘` | 무시 | LLM 프롬프트 전달 |
| `/xyz123` (실제 오타) | 무시 | LLM 프롬프트 전달 (개선 여지 — 현 PR에서는 통과) |

## Changes

- [src/cli/tui/index.ts](src/cli/tui/index.ts) — `isSlashCommand` import, `normalizedPrompt.startsWith(\"/\")` 게이트를 화이트리스트 검사로 교체
- [tests/ts/unit/cli/repl-commands/is-slash-command.test.ts](tests/ts/unit/cli/repl-commands/is-slash-command.test.ts) — **신규**, 35개 테스트

## Test plan

- [x] `npm run typecheck` 통과
- [x] 신규 테스트 35개 통과 (`npx vitest run tests/ts/unit/cli/repl-commands/is-slash-command.test.ts`)
- [ ] 수동: `--embedded-cli-ui --execution-mode real` 환경에서 `/tmp 디렉토리에 ...` 프롬프트가 LLM에 전달되어 approval 흐름이 발동되는지 확인
- [ ] 수동: 기존 `/help`, `/clear`, `/exit` 등 정상 동작 회귀 없음 확인
- [ ] 수동: `/` 단독 입력 시 슬래시 메뉴 진입 회귀 없음 확인

## 참고: 후속 과제 범위 밖

- 오타로 추정되는 `/xyz123` 같은 입력은 현 PR에서 그대로 통과(LLM에 전달). 차후 \"오타로 의심되는 슬래시 입력에 대한 경고\" 옵션을 검토할 수 있음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)