### PR TITLE
fix(codex): 사용자 원본 명령 의도를 orchestrator 프롬프트에 포함

### DIFF
--- a/src/cli/tui/panels/run-block-scrollback.ts
+++ b/src/cli/tui/panels/run-block-scrollback.ts
@@ -137,6 +137,8 @@ export class RunBlockScrollback {
       return [];
     }
 
+    const debugScrollback = process.env.DETOKS_TUI_DEBUG_SCROLLBACK === "1";
+
     if (this.entries.length === 0) {
       return [
         { text: "\x1b[2m실행 히스토리가 없습니다. 프롬프트를 실행하면 여기에 누적됩니다.\x1b[0m" },
@@ -165,6 +167,17 @@ export class RunBlockScrollback {
     const clampedOffset = Math.min(this.scrollOffset, maxOffset);
     const endIndex = Math.max(0, totalLines - clampedOffset);
     const startIndex = Math.max(0, endIndex - viewportHeight);
+
+    if (debugScrollback) {
+      const completed = this.entries.length - (activeEntry !== undefined ? 1 : 0);
+      process.stderr.write(
+        `[scrollback] entries=${this.entries.length} completed=${completed} activeContent=${activeContentCount} viewport=${viewportHeight} offset=${clampedOffset} total=${totalLines}\n`,
+      );
+    }
+
+    if (endIndex <= startIndex) {
+      return [];
+    }
 
     const result: EmbeddedTerminalRenderableLine[] = [];
 
@@ -208,7 +221,8 @@ export class RunBlockScrollback {
             paneOffsetFromBottom,
             opts,
           );
-          result.push(...paneLines);
+          const clipped = paneLines.length > paneMaxRows ? paneLines.slice(-paneMaxRows) : paneLines;
+          result.push(...clipped);
         }
       } else if (activeEntry.snapshotLines !== undefined) {
         for (let i = localStart; i < localEnd; i += 1) {

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1397,7 +1397,21 @@ export const orchestratePipeline = async (
         }
 
         // (6) LLM 실행
-        const prompt = `${responseLanguageInstruction}${ragContext ? `${ragContext}\n\n` : ""}[${task.type.toUpperCase()}] ${task.title}\n\nContext: ${executionContext.context_summary}`;
+        const prompt = [
+          responseLanguageInstruction,
+          ragContext ? `${ragContext}\n\n` : "",
+          `[${task.type.toUpperCase()}] ${task.title}`,
+          "",
+          `User request: ${compiledPrompt.compressed_prompt}`,
+          "",
+          `Context: ${executionContext.context_summary}`,
+        ].join("\n");
+        if (process.env.DETOKS_DEBUG_ADAPTER_PROMPT === "1") {
+          process.stderr.write(
+            `[adapter-prompt] task=${task.id} type=${task.type} bytes=${Buffer.byteLength(prompt, "utf8")}\n` +
+            `--- BEGIN PROMPT ---\n${prompt}\n--- END PROMPT ---\n`,
+          );
+        }
         logger.info(`작업 [${task.id}] 실행 중 type=${task.type}`);
         await emitProgressWithLogging({
           stage: "Executor", status: "start", taskId: task.id,

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1397,15 +1397,13 @@ export const orchestratePipeline = async (
         }
 
         // (6) LLM 실행
-        const prompt = [
-          responseLanguageInstruction,
-          ragContext ? `${ragContext}\n\n` : "",
-          `[${task.type.toUpperCase()}] ${task.title}`,
-          "",
-          `User request: ${compiledPrompt.compressed_prompt}`,
-          "",
-          `Context: ${executionContext.context_summary}`,
-        ].join("\n");
+        const promptParts: string[] = [];
+        if (responseLanguageInstruction) promptParts.push(responseLanguageInstruction.trimEnd());
+        if (ragContext) promptParts.push(ragContext.trimEnd());
+        promptParts.push(`[${task.type.toUpperCase()}] ${task.title}`);
+        promptParts.push(`User request: ${compiledPrompt.compressed_prompt}`);
+        promptParts.push(`Context: ${executionContext.context_summary}`);
+        const prompt = promptParts.join("\n\n");
         if (process.env.DETOKS_DEBUG_ADAPTER_PROMPT === "1") {
           process.stderr.write(
             `[adapter-prompt] task=${task.id} type=${task.type} bytes=${Buffer.byteLength(prompt, "utf8")}\n` +


### PR DESCRIPTION
## Summary

- `orchestrator.ts:1400` 프롬프트 템플릿에 `User request: ${compiledPrompt.compressed_prompt}` 섹션 추가
- 기존 `[TYPE] task.title` + `Context: ...` 구조는 유지하고 번역된 사용자 원본 명령문만 추가
- codex가 명령 실행 의도를 인식해 shell tool 호출 → approval 요청 / 실제 결과 반환 가능
- `DETOKS_DEBUG_ADAPTER_PROMPT=1` 환경변수로 최종 프롬프트를 stderr에서 확인 가능
- `run-block-scrollback.ts` 방어 코드: `endIndex<=startIndex` 가드, pane 슬라이스 클립, `DETOKS_TUI_DEBUG_SCROLLBACK=1` 진단 env

## Changes

- `src/core/pipeline/orchestrator.ts` — 프롬프트 템플릿에 `User request:` 섹션 추가 + 진단 env 로깅
- `src/cli/tui/panels/run-block-scrollback.ts` — 빈 뷰포트 가드, pane 오버플로우 방어, 진단 env

## RAG/Cache 영향

- L1 hash cache (`hashTaskInputV2`) — 키 변화 없음 (task.title 기준)
- L2 RAG 검색 쿼리 — 변화 없음 (`"${task.type} ${task.title}"` 기준)
- L3 패턴 통계 — 변화 없음 (type sequence 기준)
- codex raw_output이 "텍스트 설명"에서 "실제 실행 결과"로 변경 → RAG 임베딩 품질 향상

## Test plan

- [ ] `npm run typecheck` 통과 ✅
- [ ] `npx vitest run tests/ts/unit/cli/tui/panels/run-block-scrollback.test.ts` 17/17 통과 ✅
- [ ] E2E: `DETOKS_DEBUG_ADAPTER_PROMPT=1 npm run cli -- repl --embedded-cli-ui --execution-mode real` 후 `curl -I https://api.github.com 을 실행해서 응답 헤더를 보여줘` → stderr에 `[adapter-prompt]` 블록 확인
- [ ] E2E: `/tmp 에 파일을 만들어줘` 입력 시 codex approval 요청 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)