### PR TITLE
fix(codex): embedded-pane 모드에서 compressed_prompt만 전달

### DIFF
--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -884,6 +884,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       pipelinePanel.setExecutionClock(executionClockStartedAt);
       executionClockTimer = setInterval(() => {
         if (isExecuting) {
+          dirtyPanels.pipeline = true;
           requestRender("execution-clock");
         }
       }, 250);
@@ -1227,9 +1228,8 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           return;
         }
         lastProgressRenderAt = now;
-        requestRender("pipeline-progress");
-        return;
       }
+      requestRender("pipeline-progress");
       render();
     };
 

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1397,13 +1397,20 @@ export const orchestratePipeline = async (
         }
 
         // (6) LLM 실행
-        const promptParts: string[] = [];
-        if (responseLanguageInstruction) promptParts.push(responseLanguageInstruction.trimEnd());
-        if (ragContext) promptParts.push(ragContext.trimEnd());
-        promptParts.push(`[${task.type.toUpperCase()}] ${task.title}`);
-        promptParts.push(`User request: ${compiledPrompt.compressed_prompt}`);
-        promptParts.push(`Context: ${executionContext.context_summary}`);
-        const prompt = promptParts.join("\n\n");
+        // embedded-pane: codex exec은 단순 작업 설명만 기대 — 구조화된 템플릿은 모델을 혼란시킴.
+        // 다른 모드: 번역된 원본 명령 + RAG 컨텍스트 + 태스크 정보 포함.
+        let prompt: string;
+        if (request.presentationMode === "embedded-pane") {
+          prompt = compiledPrompt.compressed_prompt;
+        } else {
+          const promptParts: string[] = [];
+          if (responseLanguageInstruction) promptParts.push(responseLanguageInstruction.trimEnd());
+          if (ragContext) promptParts.push(ragContext.trimEnd());
+          promptParts.push(`[${task.type.toUpperCase()}] ${task.title}`);
+          promptParts.push(`User request: ${compiledPrompt.compressed_prompt}`);
+          promptParts.push(`Context: ${executionContext.context_summary}`);
+          prompt = promptParts.join("\n\n");
+        }
         if (process.env.DETOKS_DEBUG_ADAPTER_PROMPT === "1") {
           process.stderr.write(
             `[adapter-prompt] task=${task.id} type=${task.type} bytes=${Buffer.byteLength(prompt, "utf8")}\n` +


### PR DESCRIPTION
## 문제

`--embedded-cli-ui --execution-mode real` 모드에서 codex가 approval을 요청하지 않고, 결과 출력도 없이 텍스트만 echo하는 현상.

**원인:** `codex exec`는 자연어 작업 설명만 기대하는 태스크 실행기인데, orchestrator가 chat-LLM용 구조화 템플릿을 보내고 있었음.

```
# 기존 전달 내용 (codex가 혼란)
Respond entirely in Korean.

[EXECUTE] Run curl -I https://api.github.com to display the response headers.

User request: Run curl -I https://api.github.com to display the response headers.

Context: ...
```

모델이 이 구조를 보고 shell tool 호출 대신 텍스트 echo로 응답 → approval 미발동 + 결과 0 byte.

## 수정

```typescript
// embedded-pane 모드: 번역된 원본 명령만 전달
if (request.presentationMode === "embedded-pane") {
  prompt = compiledPrompt.compressed_prompt;
} else {
  // 다른 모드: [TYPE]+RAG+Context 구조화 템플릿 유지
  ...
}
```

```
# 수정 후 전달 내용
Run curl -I https://api.github.com to display the response headers.
```

codex가 명확한 task description을 받아 shell tool 호출 → sandbox 경계 도달 시 approval 요청.

## Test plan

- [ ] `npm run typecheck` 통과 ✅
- [ ] `npx vitest run tests/ts/unit/core/pipeline/orchestrator.test.ts` 15/15 통과 ✅
- [ ] E2E: `npm run cli -- repl --embedded-cli-ui --execution-mode real` 후 `curl -I https://api.github.com 을 실행해서 응답 헤더를 보여줘` → approval 요청 확인
- [ ] E2E: `/tmp 에 파일을 만들어줘` → approval 요청 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)