### PR TITLE
fix(tui/codex): embedded-pane UX 3종 수정 — Enter 1회 실행·한국어 응답·멀티라인 approval

### DIFF
--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -1656,21 +1656,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
                     )?.usage ?? input
                   : input;
               const normalizedPrompt = resolvedPrompt.trim();
-              const shouldRequestApproval =
-                embeddedPaneMode &&
-                options.executionMode === "real" &&
-                normalizedPrompt.length > 0 &&
-                !normalizedPrompt.startsWith("/");
-
-              if (shouldRequestApproval) {
-                hasExecuted = true;
-                registerRunBlock(resolvedPrompt, "pending-approval");
-                pendingApprovalPrompt = resolvedPrompt;
-                skipApprovalLineFeed = char === "\r";
-                render();
-              } else {
-                executePrompt(resolvedPrompt);
-              }
+              executePrompt(resolvedPrompt);
               // P3-3: capture in history + persist async (non-fatal on failure).
               inputHistory.push(normalizedPrompt);
               void saveHistoryToDisk(historyPath, inputHistory.toArray()).catch(

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -174,6 +174,22 @@ const APPROVAL_PROMPT_HINT_PATTERNS = [
   /\bcontinue\b/i,
 ] as const;
 
+// Stricter y/n patterns used for multi-row approval detection to reduce false positives.
+const APPROVAL_STRICT_HINT_PATTERNS = [
+  /\by\/n\b/i,
+  /\byes\/no\b/i,
+  /\[y\/n\]/i,
+  /\[y\/N\]/i,
+] as const;
+
+// Matches lines that consist only of box-drawing / border characters + whitespace.
+// These decorative rows (e.g. "╰──────────╯") appear at the edges of codex approval
+// dialogs and should be skipped rather than treated as meaningful content.
+const DECORATIVE_LINE_RE = /^[\s╭╮╰╯─│┌┐└┘├┤┬┴┼╔╗╚╝═║╠╣╦╩╬▲▼◀▶•·\-━┅┄━─]+$/u;
+
+const isDecorativeLine = (text: string): boolean =>
+  text.length > 0 && DECORATIVE_LINE_RE.test(text);
+
 interface RenderedRowInfo {
   cells: TerminalCell[];
   plainText: string;
@@ -1310,7 +1326,21 @@ export class EmbeddedTerminalPane {
     }
 
     const { rows } = this.ensureRenderCache(Math.max(1, maxWidth));
-    for (let index = rows.length - 1; index >= 0; index -= 1) {
+
+    // Codex may render approval dialogs across multiple rows (e.g. a box UI with a border row
+    // at the bottom). Scan up to 8 rows from the bottom:
+    //   • Decorative border rows (╰──╯) are skipped so they don't break the scan.
+    //   • Single-line approval is detected immediately and returned.
+    //   • Verb and strict-hint are accumulated across rows for multi-row dialogs.
+    //   • The first non-decorative row that has neither a verb nor a strict hint stops
+    //     the scan — it means meaningful non-approval output appeared (approval resolved).
+    const APPROVAL_SCAN_WINDOW = 8;
+    const scanStart = Math.max(0, rows.length - APPROVAL_SCAN_WINDOW);
+
+    let approvalVerbLine: string | undefined;
+    let hasStrictHint = false;
+
+    for (let index = rows.length - 1; index >= scanStart; index -= 1) {
       const row = rows[index];
       if (row === undefined || row.plainText.length === 0) {
         continue;
@@ -1320,6 +1350,12 @@ export class EmbeddedTerminalPane {
         continue;
       }
 
+      // Purely decorative border lines (e.g. "╰──────╯") do not break the scan
+      if (isDecorativeLine(row.plainText)) {
+        continue;
+      }
+
+      // Single-line approval (fastest path)
       if (isApprovalPromptLine(row.plainText)) {
         return {
           kind: "approval",
@@ -1328,7 +1364,31 @@ export class EmbeddedTerminalPane {
         };
       }
 
-      return null;
+      // Accumulate verb / strict hint for multi-row dialog detection
+      const lineHasVerb = APPROVAL_PROMPT_PATTERNS.some((p) => p.test(row.plainText));
+      const lineHasStrictHint = APPROVAL_STRICT_HINT_PATTERNS.some((p) => p.test(row.plainText));
+
+      if (lineHasVerb && approvalVerbLine === undefined) {
+        approvalVerbLine = row.plainText;
+      }
+      if (lineHasStrictHint) {
+        hasStrictHint = true;
+      }
+
+      // Stop at the first meaningful row that is unrelated to approval —
+      // subsequent output means the approval was already resolved.
+      if (!lineHasVerb && !lineHasStrictHint) {
+        break;
+      }
+    }
+
+    // Multi-row approval: verb on one row, [y/n] hint on another
+    if (approvalVerbLine !== undefined && hasStrictHint) {
+      return {
+        kind: "approval",
+        label: "Codex 승인 대기",
+        detail: approvalVerbLine,
+      };
     }
 
     return null;

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1401,7 +1401,10 @@ export const orchestratePipeline = async (
         // 다른 모드: 번역된 원본 명령 + RAG 컨텍스트 + 태스크 정보 포함.
         let prompt: string;
         if (request.presentationMode === "embedded-pane") {
-          prompt = compiledPrompt.compressed_prompt;
+          // 한국어 입력이면 응답 언어 지시를 앞에 붙여 codex가 한국어로 응답하도록 한다.
+          prompt = responseLanguageInstruction
+            ? `${responseLanguageInstruction}${compiledPrompt.compressed_prompt}`
+            : compiledPrompt.compressed_prompt;
         } else {
           const promptParts: string[] = [];
           if (responseLanguageInstruction) promptParts.push(responseLanguageInstruction.trimEnd());

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -647,6 +647,35 @@ describe("EmbeddedTerminalPane", () => {
     expect(pane.getStatusBannerLine(80, { now: Date.now() })).toBeNull();
   });
 
+  // T8b: multi-row approval dialog (verb on one row, [y/N] hint on another)
+  it("getStatusBannerLine detects multi-row approval when verb and hint are on separate rows", () => {
+    // Simulate codex box-style approval dialog
+    pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "╭─ Execute Command? ───────────────────╮\n" });
+    pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "│ curl -I https://api.github.com      │\n" });
+    pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "│ Allow? [y/N]                        │\n" });
+    pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "╰──────────────────────────────────────╯\n" });
+
+    const banner = pane.getStatusBannerLine(80, { now: Date.now() });
+    expect(banner).not.toBeNull();
+    expect(banner?.severity).toBe("warn");
+    expect(banner?.text).toContain("승인 대기");
+  });
+
+  it("getStatusBannerLine clears multi-row approval when subsequent non-approval output appears", () => {
+    pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "│ Allow? [y/N]                        │\n" });
+    pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "╰──────────────────────────────────────╯\n" });
+    expect(pane.getStatusBannerLine(80, { now: Date.now() })).not.toBeNull();
+
+    // Non-approval output appears — approval resolved
+    pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "HTTP/2 200\n" });
+    expect(pane.getStatusBannerLine(80, { now: Date.now() })).toBeNull();
+  });
+
+  it("getStatusBannerLine does not detect approval from decorative-only border lines", () => {
+    pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "╰──────────────────────────────────────╯\n" });
+    expect(pane.getStatusBannerLine(80, { now: Date.now() })).toBeNull();
+  });
+
   // T9: getFocusFooterLine — correct hint per focus state
   it("getFocusFooterLine includes Ctrl+T hint for detoks-input focus", () => {
     pane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "output\n" });


### PR DESCRIPTION
## Summary

embedded-pane(`--embedded-cli-ui --execution-mode real`) 모드에서 발생하는 세 가지 UX 문제를 수정합니다.

## Changes

### 1. Enter 한 번으로 즉시 실행 (`src/cli/tui/index.ts`)

`embedded-pane + executionMode=real` 조합에서 첫 Enter가 `pending-approval` 상태를 만들어 두 번째 Enter에서야 실행되던 2단계 확인 흐름을 제거했습니다.

```
before: Enter → "실행 확인 대기" 배너 → Enter → 실행
after:  Enter → 즉시 실행 ✓
```

`shouldRequestApproval` 분기와 `pendingApprovalPrompt` 세팅 로직 삭제 (−15줄).

---

### 2. 한국어 입력 시 한국어 응답 복원 (`src/core/pipeline/orchestrator.ts`)

PR #308에서 embedded-pane 프롬프트를 `compressed_prompt`(번역된 영어)만 전달하도록 단순화할 때 `responseLanguageInstruction`("Respond entirely in Korean.")이 누락되어 항상 영어로 응답하는 회귀가 발생했습니다.

```typescript
// before
prompt = compiledPrompt.compressed_prompt;

// after
prompt = responseLanguageInstruction
  ? `${responseLanguageInstruction}${compiledPrompt.compressed_prompt}`
  : compiledPrompt.compressed_prompt;
```

---

### 3. 멀티-라인 approval 다이얼로그 감지 (`src/cli/tui/panels/embedded-terminal.ts`)

codex가 박스 UI(`╭─╮/╰─╯`)로 approval을 렌더할 때 verb와 `[y/N]` hint가 서로 다른 행에 있어 단일-행 패턴 매칭이 실패하는 버그 수정.

- `isDecorativeLine()` 헬퍼 추가 — 순수 박스-드로잉 문자 행 판별
- `APPROVAL_STRICT_HINT_PATTERNS` 추가 — 멀티-행 false positive 방지
- `getInteractionState` → 8-행 스캔 윈도우 + break-on-non-approval 로직
- 테스트 3건 추가 (멀티-행 감지, 해소 후 배너 소멸, 데코레이티브 전용 행 무시)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run tests/ts/unit/cli/` — 1166 tests pass
- [x] `npx vitest run tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts` — 46 tests pass
- [ ] E2E: `--embedded-cli-ui --execution-mode real` 에서 한국어 프롬프트 입력 → Enter 1회 → 한국어 응답 확인
- [ ] E2E: codex approval 다이얼로그 → 배너 표시 + Enter 승인 / Esc 거절

## Related PRs

- #307 — orchestrator 프롬프트에 사용자 원본 명령 포함
- #308 — embedded-pane compressed_prompt 단순화 + 타이머·PTY resize 수정 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)