### PR TITLE
feat(tui): DETOKS_DEBUG_PTY — codex PTY raw 출력 덤프 진단 도구

### DIFF
--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -1,3 +1,4 @@
+import { appendFileSync } from "node:fs";
 import type { RenderContext } from "../renderer.js";
 import type { PanelRegion } from "../layout-manager.js";
 import type { PtyEvent } from "../../../integrations/subprocess/types.js";
@@ -1219,6 +1220,13 @@ export class EmbeddedTerminalPane {
 
     if (event.type !== "chunk" || typeof event.data !== "string") {
       return;
+    }
+
+    const debugPtyPath = process.env.DETOKS_DEBUG_PTY;
+    if (debugPtyPath) {
+      try {
+        appendFileSync(debugPtyPath, event.data);
+      } catch { /* non-fatal */ }
     }
 
     this.buffer.write(event.data);

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { EmbeddedTerminalPane } from "../../../../../../src/cli/tui/panels/embedded-terminal.js";
 
 describe("EmbeddedTerminalPane", () => {
@@ -725,6 +728,42 @@ describe("EmbeddedTerminalPane", () => {
     const lines = pane.getRenderableLines(15);
     const combined = lines.map((l) => l.text).join("\n");
     expect(combined).not.toContain("▎");
+  });
+
+  // DETOKS_DEBUG_PTY: raw chunk dump
+  describe("DETOKS_DEBUG_PTY raw chunk dump", () => {
+    let tmpDir: string;
+    let dumpPath: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "detoks-pty-test-"));
+      dumpPath = join(tmpDir, "pty.log");
+    });
+
+    afterEach(() => {
+      delete process.env.DETOKS_DEBUG_PTY;
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("appends raw chunk bytes to the dump file when DETOKS_DEBUG_PTY is set", () => {
+      process.env.DETOKS_DEBUG_PTY = dumpPath;
+      const localPane = new EmbeddedTerminalPane();
+
+      localPane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "hello\n" });
+      localPane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "world\n" });
+
+      const content = readFileSync(dumpPath, "utf8");
+      expect(content).toBe("hello\nworld\n");
+    });
+
+    it("does not create a dump file when DETOKS_DEBUG_PTY is unset", () => {
+      delete process.env.DETOKS_DEBUG_PTY;
+      const localPane = new EmbeddedTerminalPane();
+
+      localPane.addEvent({ type: "chunk", timestamp: Date.now(), stream: "stdout", data: "hello\n" });
+
+      expect(() => readFileSync(dumpPath)).toThrow();
+    });
   });
 
   // T12: spinner-only refresh rebuilds compact lines without rebuilding rows cache


### PR DESCRIPTION
## Summary

- `DETOKS_DEBUG_PTY=/tmp/detoks-pty.log` 환경변수 설정 시 embedded-pane이 수신하는 codex PTY 청크를 파일에 실시간 append
- 미설정 시 완전 no-op (process.env 조회 1회 + 분기만)
- try/catch로 파일 쓰기 실패가 detoks crash로 전파되지 않음

## 목적

embedded-pane이 `파일 읽기: ~/.codex/skills/.../SKILL.md - 진행 중` 에서 freeze되는 현상의 **정확한 원인 확정**을 위한 진단 도구.

가설:
- `getActivitySnapshot()` 의 10행 lookahead 제약 → completion 마커 미감지
- narrative bullet 경로의 동일 제약
- codex가 실제로 중간에 종료되어 completion 마커 자체가 없음

PTY raw 덤프로 codex의 실제 출력 형식·순서·종료 시점을 확정한 후 PR-2(parser fix)를 설계.

## Test plan

- [x] `DETOKS_DEBUG_PTY` 설정 시 chunk가 지정 파일에 append되는지 단위 테스트
- [x] 미설정 시 파일이 생성되지 않는지 단위 테스트
- [x] `npm run typecheck` 통과
- [ ] (수동) `DETOKS_DEBUG_PTY=/tmp/pty.log detoks repl --embedded-cli-ui --execution-mode real` → curl 프롬프트 입력 → `/tmp/pty.log` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)