### PR TITLE
fix(tui): alternate screen 종료 시 codex 응답 내용 보존

### DIFF
--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -915,7 +915,7 @@ const buildCompactRenderableLines = (
       }
 
       let statusIndex = -1;
-      for (let lookahead = 2; lookahead < Math.min(rows.length - index, 8); lookahead += 1) {
+      for (let lookahead = 2; lookahead < Math.min(rows.length - index, 50); lookahead += 1) {
         const candidate = rows[index + lookahead];
         if (candidate !== undefined && isCommandStatusLine(candidate.plainText)) {
           commandBlock.push(candidate);
@@ -1263,7 +1263,7 @@ export class EmbeddedTerminalPane {
         }
 
         let statusLine: string | null = null;
-        for (let lookahead = index + 2; lookahead < Math.min(rows.length, index + 10); lookahead += 1) {
+        for (let lookahead = index + 2; lookahead < Math.min(rows.length, index + 50); lookahead += 1) {
           const candidate = rows[lookahead]?.plainText ?? "";
           if (isCommandStatusLine(candidate)) {
             statusLine = candidate;
@@ -1375,7 +1375,7 @@ export class EmbeddedTerminalPane {
       }
 
       let hasStatusLine = false;
-      for (let lookahead = index + 2; lookahead < Math.min(rows.length, index + 8); lookahead += 1) {
+      for (let lookahead = index + 2; lookahead < Math.min(rows.length, index + 50); lookahead += 1) {
         if (isCommandStatusLine(rows[lookahead]?.plainText ?? "")) {
           hasStatusLine = true;
           break;

--- a/src/cli/tui/terminal-emulator.ts
+++ b/src/cli/tui/terminal-emulator.ts
@@ -710,6 +710,17 @@ export class TerminalEmulatorBuffer {
     }
 
     if (sequence === "\u001b[?1049l") {
+      // Flush non-blank alternate screen rows to scrollback so codex's TUI
+      // output survives the screen switch (otherwise the content is discarded).
+      const altRows = this.alternateScreenBuffer;
+      let lastNonBlank = altRows.length - 1;
+      while (lastNonBlank >= 0 && altRows[lastNonBlank]!.every((cell) => cell.char.length === 0)) {
+        lastNonBlank -= 1;
+      }
+      for (let i = 0; i <= lastNonBlank; i += 1) {
+        this.pushScrollback(altRows[i]!);
+      }
+
       this.alternateScreen = false;
       if (this.savedMainState) {
         this.mainScreen = this.savedMainState.screen.map((row) => cloneRow(row, this.columns));


### PR DESCRIPTION
## Summary

- codex exec가 alternate screen buffer(`\x1b[?1049h`)를 사용해 TUI를 렌더링하는 경우, 프로세스 종료 시 `\x1b[?1049l`로 main screen 복귀 시 **alternate screen 내용이 버려지는** 근본 원인 수정
- "이 디렉토리의 목적을 설명해줘" 같이 codex가 shell 명령을 실행하는 복잡한 쿼리에서 결과가 표시되지 않던 문제 해결
- 이전 커밋(`612f8b6`)의 lookahead 50행 확장과 함께 embedded-pane 정상 동작 보장

## Changes

- `src/cli/tui/terminal-emulator.ts`: `\x1b[?1049l` 처리 시 alternate screen buffer의 비어있지 않은 행을 scrollback에 flush한 뒤 main screen 복원

## Test plan

- [ ] `npm run typecheck` 통과
- [ ] `npx vitest run tests/ts/unit/cli/tui/terminal-emulator.test.ts` — 15개 기존 테스트 통과
- [ ] `npx vitest run tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts` — 43개 기존 테스트 통과
- [ ] E2E: `detoks repl --embedded-cli-ui --execution-mode real` 실행 후 "이 디렉토리의 목적을 한 문장으로 설명해줘." 입력 → embedded pane에 응답 텍스트 표시 확인