### PR TITLE
fix(tui): stabilize Codex embedded execution output

### DIFF
--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -1991,18 +1991,16 @@ dirtyPanels.pipeline = true;
           );
         }
 
-        const hasVisibleOutput = embeddedPaneMode
-          ? embeddedTerminalPane.hasVisibleContent()
-          : transcriptPanel.hasVisibleContent();
-        if (!hasVisibleOutput) {
-          const finalOutput = result.rawOutput.trim();
-          if (finalOutput.length > 0) {
-            if (embeddedPaneMode) {
-              embeddedTerminalPane.appendFinalAnswer(finalOutput);
-            } else {
-              transcriptPanel.appendFinalAnswer(finalOutput);
-            }
+        const finalOutput = result.rawOutput.trim();
+        if (embeddedPaneMode) {
+          if (
+            finalOutput.length > 0 &&
+            embeddedTerminalPane.getLastFinalAnswer() !== finalOutput
+          ) {
+            embeddedTerminalPane.appendFinalAnswer(finalOutput);
           }
+        } else if (!transcriptPanel.hasVisibleContent() && finalOutput.length > 0) {
+          transcriptPanel.appendFinalAnswer(finalOutput);
         }
 
         const workspaceAfter = captureWorkspaceSnapshot(executionCwd);

--- a/src/cli/tui/panels/codex-json.ts
+++ b/src/cli/tui/panels/codex-json.ts
@@ -1,0 +1,288 @@
+const CODEX_LIFECYCLE_TYPES = new Set([
+  "thread.started",
+  "turn.started",
+  "turn.completed",
+  "item.started",
+  "item.updated",
+  "item.completed",
+  "response.started",
+  "response.completed",
+]);
+
+const CODEX_STDERR_NOISE_PATTERNS = [
+  /^Reading additional input from stdin\.\.\.$/,
+  /^OpenAI Codex v[\d.]+/,
+  /^--------$/,
+  /^workdir:/,
+  /^model:/,
+  /^provider:/,
+  /^approval:/,
+  /^sandbox:/,
+  /^reasoning effort:/,
+  /^reasoning summaries:/,
+  /^session id:/,
+  /^user$/,
+  /^codex$/,
+  /^\[EXECUTE\]/,
+  /^Context:/,
+  /^tokens used/,
+] as const;
+
+const stripControlSequences = (value: string): string =>
+  value
+    .replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "");
+
+export const sanitizeCodexText = (value: string): string => stripControlSequences(value).replace(/\r/g, "");
+
+const extractJsonCandidate = (line: string): string | null => {
+  const normalized = sanitizeCodexText(line).trim();
+  const start = normalized.indexOf("{");
+  const end = normalized.lastIndexOf("}");
+  if (start < 0 || end < start) {
+    return null;
+  }
+
+  const candidate = normalized.slice(start, end + 1).trim();
+  return candidate.startsWith("{") && candidate.endsWith("}") ? candidate : null;
+};
+
+export const hasCodexJsonCandidate = (line: string): boolean => extractJsonCandidate(line) !== null;
+
+export type CodexStructuredLine =
+  | { kind: "tool"; text: string }
+  | { kind: "validation"; text: string }
+  | { kind: "git"; text: string }
+  | { kind: "edit"; text: string }
+  | { kind: "final"; text: string }
+  | { kind: "diagnostic"; text: string }
+  | { kind: "raw"; text: string };
+
+const getRecordField = (value: unknown, key: string): Record<string, unknown> | null => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const nested = record[key];
+  if (!nested || typeof nested !== "object" || Array.isArray(nested)) {
+    return null;
+  }
+  return nested as Record<string, unknown>;
+};
+
+const getArrayField = (value: unknown, key: string): unknown[] | null => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const nested = record[key];
+  return Array.isArray(nested) ? nested : null;
+};
+
+const getStringField = (value: unknown, keys: string[]): string | null => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of keys) {
+    const nested = record[key];
+    if (typeof nested === "string") {
+      const sanitized = sanitizeCodexText(nested);
+      if (sanitized.length > 0) {
+        return sanitized;
+      }
+    }
+  }
+  return null;
+};
+
+const getNumberField = (value: unknown, keys: string[]): number | null => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of keys) {
+    const nested = record[key];
+    if (typeof nested === "number" && Number.isFinite(nested)) {
+      return nested;
+    }
+  }
+  return null;
+};
+
+const extractJsonText = (value: unknown): string | null => {
+  if (typeof value === "string") {
+    const sanitized = sanitizeCodexText(value);
+    return sanitized.length > 0 ? sanitized : null;
+  }
+  if (Array.isArray(value)) {
+    const pieces = value.map((item) => extractJsonText(item)).filter((item): item is string => Boolean(item));
+    return pieces.length > 0 ? pieces.join("") : null;
+  }
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of [
+    "message", "text", "delta", "content", "output", "summary", "stdout", "stderr", "aggregated_output", "result",
+  ] as const) {
+    const extracted = extractJsonText(record[key]);
+    if (extracted) return extracted;
+  }
+  return null;
+};
+
+const normalizeEventType = (value: unknown): string => {
+  if (typeof value !== "string") return "";
+  return sanitizeCodexText(value).replaceAll("/", ".").trim();
+};
+
+const getEventPhase = (eventType: string): string => {
+  const parts = eventType.split(".");
+  return parts[parts.length - 1] ?? "";
+};
+
+const isToolItemType = (itemType: string): boolean =>
+  new Set(["command_execution", "mcp_tool_call", "web_search", "todo_list", "tool_search"]).has(itemType);
+
+const isFileEditItemType = (itemType: string): boolean => itemType === "file_change";
+const isFinalAnswerItemType = (itemType: string): boolean =>
+  new Set(["agent_message", "assistant_message", "final_answer"]).has(itemType);
+
+const summarizeText = (text: string, maxLines = 3): string => {
+  const normalized = sanitizeCodexText(text).replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n").map((line) => line.trim()).filter((line) => line.length > 0);
+  if (lines.length === 0) return "";
+  if (lines.length <= maxLines) return lines.join(" · ");
+  return `${lines.slice(0, maxLines).join(" · ")} · … (+${lines.length - maxLines}줄)`;
+};
+
+const summarizeCommand = (command: string): string => sanitizeCodexText(command).replace(/\s+/g, " ").trim();
+const isValidationCommand = (command: string): boolean =>
+  /\b(npm run (typecheck|build|lint)|vitest|npm test|pnpm test|yarn test|bun test|tsc)\b/i.test(command);
+const isGitCommand = (command: string): boolean =>
+  /\bgit\b\s+(add|commit|push|status|diff|checkout|merge|rebase)\b/i.test(command);
+
+const classifyCommandExecution = (item: Record<string, unknown>, phase: string): CodexStructuredLine | null => {
+  const command = getStringField(item, ["command"]);
+  const commandSummary = command ? summarizeCommand(command) : null;
+  const exitCode = getNumberField(item, ["exit_code", "exitCode"]);
+  const output = summarizeText(getStringField(item, ["aggregated_output", "output", "stdout", "result", "text"]) ?? extractJsonText(item) ?? "");
+  const resultSummary = exitCode === null ? "done" : `exit ${exitCode}`;
+  if (phase !== "completed" && phase !== "updated" && phase !== "progress") return null;
+  if (command && isValidationCommand(command)) {
+    return { kind: "validation", text: commandSummary ? `${commandSummary} · ${output.length > 0 ? output : resultSummary}` : (output || resultSummary) };
+  }
+  if (command && isGitCommand(command)) {
+    return { kind: "git", text: commandSummary ? `${commandSummary} · ${output.length > 0 ? output : resultSummary}` : (output || resultSummary) };
+  }
+  const toolText = commandSummary ? `${commandSummary} · ${output.length > 0 ? output : resultSummary}` : (output || resultSummary);
+  return toolText ? { kind: "tool", text: toolText } : null;
+};
+
+const summarizeFileChange = (item: Record<string, unknown>, phase: string): string | null => {
+  if (phase !== "completed" && phase !== "updated" && phase !== "progress") return null;
+  const changes = getArrayField(item, "changes");
+  const changeSummaries = (changes ?? []).map((change) => {
+    if (!change || typeof change !== "object" || Array.isArray(change)) return null;
+    const record = change as Record<string, unknown>;
+    const path = getStringField(record, ["path", "filePath", "file_name", "filename"]);
+    if (!path) return null;
+    const kind = getStringField(record, ["kind", "type"]) ?? "update";
+    const symbol = kind === "add" || kind === "create" ? "+" : kind === "delete" || kind === "remove" ? "-" : kind === "rename" ? "→" : "~";
+    return `${symbol} ${path}`;
+  }).filter((entry): entry is string => Boolean(entry));
+  const summary = changeSummaries.length > 0 ? changeSummaries.join(", ") : (getStringField(item, ["path", "filePath", "file_name", "filename"]) ?? "");
+  return summary.length === 0 ? "파일 변경 완료" : `applied: ${summary}`;
+};
+
+const summarizeToolItem = (item: Record<string, unknown>, phase: string, itemType: string): string | null => {
+  const label = itemType.replaceAll("_", " ").trim();
+  if (phase === "started") return null;
+  const summarySource =
+    phase === "completed" || phase === "updated" || phase === "progress"
+      ? getStringField(item, ["output", "result", "text", "summary", "title", "name"]) ?? extractJsonText(item) ?? ""
+      : getStringField(item, ["title", "name", "summary", "text", "output"]) ?? extractJsonText(item) ?? "";
+  const summary = summarizeText(summarySource, 2) || "";
+  if (phase === "completed" || phase === "updated" || phase === "progress") return summary.length > 0 ? `${label}: ${summary}` : `${label}: done`;
+  return summary.length > 0 ? `${label}: ${summary}` : label;
+};
+
+export const shouldIgnoreCodexNoiseLine = (line: string): boolean => {
+  const normalized = sanitizeCodexText(line).trim();
+  if (normalized.length === 0) return true;
+  return CODEX_STDERR_NOISE_PATTERNS.some((pattern) => pattern.test(normalized));
+};
+
+const looksLikeLifecycleNoise = (line: string): boolean => {
+  const normalized = sanitizeCodexText(line).trim();
+  if (normalized.length === 0) return false;
+  for (const type of CODEX_LIFECYCLE_TYPES) {
+    if (normalized === type || normalized.startsWith(`${type}[`) || normalized.startsWith(`${type} `) || normalized.startsWith(`${type}:`)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const classifyCodexJsonLine = (line: string): CodexStructuredLine | null => {
+  const candidate = extractJsonCandidate(line);
+  if (candidate === null) return null;
+  try {
+    const parsed = JSON.parse(candidate) as Record<string, unknown>;
+    const eventType = normalizeEventType(parsed.type ?? parsed.method ?? "");
+    const phase = getEventPhase(eventType);
+    const item = getRecordField(parsed, "item");
+    const itemType = normalizeEventType(item?.type ?? item?.kind ?? item?.name ?? "");
+    const text = extractJsonText(item ?? parsed);
+    if (eventType === "error" || eventType === "warning") return { kind: "diagnostic", text: (text ?? eventType) || "diagnostic" };
+    if (item) {
+      if (isToolItemType(itemType)) {
+        if (itemType === "command_execution") return classifyCommandExecution(item, phase);
+        const toolText = summarizeToolItem(item, phase, itemType);
+        if (toolText) return { kind: "tool", text: toolText };
+        if (phase !== "started" && text) return { kind: "tool", text };
+      }
+      if (isFileEditItemType(itemType)) {
+        const editText = summarizeFileChange(item, phase) ?? text;
+        if (editText) return { kind: "edit", text: editText };
+      }
+      if (isFinalAnswerItemType(itemType)) {
+        const finalText = text ?? getStringField(item, ["text", "content", "message", "summary"]);
+        if (finalText) return { kind: "final", text: finalText };
+      }
+    }
+    if (text && (eventType.includes("message") || eventType.includes("text") || eventType.includes("delta"))) {
+      return { kind: "final", text };
+    }
+    if (eventType.startsWith("thread.") || eventType.startsWith("turn.") || eventType.startsWith("response.") || eventType.startsWith("item.")) {
+      return null;
+    }
+    return text ? { kind: "raw", text } : null;
+  } catch {
+    return null;
+  }
+};
+
+export const shouldDropLifecycleJsonLine = (line: string): boolean => {
+  const candidate = extractJsonCandidate(line);
+  if (candidate === null) return false;
+  try {
+    const parsed = JSON.parse(candidate) as Record<string, unknown>;
+    const eventType = normalizeEventType(parsed.type ?? parsed.method ?? "");
+    if (eventType.startsWith("thread.") || eventType.startsWith("turn.") || eventType.startsWith("response.")) return true;
+    if (eventType.startsWith("item.")) return classifyCodexJsonLine(line) === null;
+    return false;
+  } catch {
+    return false;
+  }
+};
+
+export const isCodexJsonOrNoiseLine = (line: string): boolean => {
+  return (
+    hasCodexJsonCandidate(line) ||
+    shouldIgnoreCodexNoiseLine(line) ||
+    looksLikeLifecycleNoise(line) ||
+    shouldDropLifecycleJsonLine(line)
+  );
+};

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -5,6 +5,13 @@ import { getContentArea } from "../layout-manager.js";
 import { padDisplayWidth } from "../renderer.js";
 import { fillRemaining } from "./base.js";
 import { glyph, statusColor, width, type Style } from "../design/tokens.js";
+import {
+  classifyCodexJsonLine,
+  hasCodexJsonCandidate,
+  sanitizeCodexText,
+  shouldDropLifecycleJsonLine,
+  shouldIgnoreCodexNoiseLine,
+} from "./codex-json.js";
 import type { TerminalCell, TerminalCellStyle, TerminalColor } from "../terminal-emulator.js";
 import { TerminalEmulatorBuffer, getCharacterDisplayWidth } from "../terminal-emulator.js";
 
@@ -1080,6 +1087,7 @@ export interface EmbeddedTerminalViewportTrackingInfo {
 
 export class EmbeddedTerminalPane {
   private readonly buffer = new TerminalEmulatorBuffer(80, 24, EMBEDDED_PANE_SCROLLBACK_LIMIT);
+  private lastFinalAnswer: string | null = null;
   private scrollOffset = 0;
   // Cached total renderable line count (after compact summaries are applied).
   // Mark dirty on writes and rebuild lazily during render/scroll queries so
@@ -1106,6 +1114,7 @@ export class EmbeddedTerminalPane {
 
   clear(): void {
     this.buffer.reset();
+    this.lastFinalAnswer = null;
     this.scrollOffset = 0;
     this.cachedTotalRows = 0;
     this.currentColumns = 80;
@@ -1205,19 +1214,61 @@ export class EmbeddedTerminalPane {
       return;
     }
 
-    this.buffer.write(event.data);
+    const normalized = event.data.replace(/\r\n/g, "\n");
+    const lines = normalized.split("\n");
+    const shouldTreatAsStructured = lines.some((line) => hasCodexJsonCandidate(line));
+
+    if (!shouldTreatAsStructured) {
+      this.buffer.write(event.data);
+      this.markRenderCacheDirty();
+      this.scrollOffset = 0;
+      return;
+    }
+
+    for (const line of lines) {
+      if (line.length === 0 || shouldIgnoreCodexNoiseLine(line) || shouldDropLifecycleJsonLine(line)) {
+        continue;
+      }
+
+      const classified = classifyCodexJsonLine(line);
+      if (classified?.kind === "final") {
+        this.appendFinalAnswer(classified.text);
+        continue;
+      }
+
+      if (classified) {
+        this.buffer.write(`${classified.text}\n`);
+        continue;
+      }
+
+      const sanitized = sanitizeCodexText(line);
+      if (sanitized.trim().length > 0) {
+        this.buffer.write(`${sanitized}\n`);
+      }
+    }
+
     this.markRenderCacheDirty();
     this.scrollOffset = 0;
   }
 
   appendFinalAnswer(text: string): void {
-    if (text.trim().length === 0) {
+    const normalized = text.trim();
+    if (normalized.length === 0) {
       return;
     }
 
     this.buffer.write(text.endsWith("\n") ? text : `${text}\n`);
+    this.lastFinalAnswer = normalized;
     this.markRenderCacheDirty();
     this.scrollOffset = 0;
+  }
+
+  hasFinalAnswer(): boolean {
+    return this.lastFinalAnswer !== null;
+  }
+
+  getLastFinalAnswer(): string | null {
+    return this.lastFinalAnswer;
   }
 
   hasVisibleContent(): boolean {

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -915,7 +915,7 @@ const buildCompactRenderableLines = (
       }
 
       let statusIndex = -1;
-      for (let lookahead = 2; lookahead < Math.min(rows.length - index, 8); lookahead += 1) {
+      for (let lookahead = 2; lookahead < Math.min(rows.length - index, 50); lookahead += 1) {
         const candidate = rows[index + lookahead];
         if (candidate !== undefined && isCommandStatusLine(candidate.plainText)) {
           commandBlock.push(candidate);
@@ -1263,7 +1263,7 @@ export class EmbeddedTerminalPane {
         }
 
         let statusLine: string | null = null;
-        for (let lookahead = index + 2; lookahead < Math.min(rows.length, index + 10); lookahead += 1) {
+        for (let lookahead = index + 2; lookahead < Math.min(rows.length, index + 50); lookahead += 1) {
           const candidate = rows[lookahead]?.plainText ?? "";
           if (isCommandStatusLine(candidate)) {
             statusLine = candidate;
@@ -1375,7 +1375,7 @@ export class EmbeddedTerminalPane {
       }
 
       let hasStatusLine = false;
-      for (let lookahead = index + 2; lookahead < Math.min(rows.length, index + 8); lookahead += 1) {
+      for (let lookahead = index + 2; lookahead < Math.min(rows.length, index + 50); lookahead += 1) {
         if (isCommandStatusLine(rows[lookahead]?.plainText ?? "")) {
           hasStatusLine = true;
           break;

--- a/src/cli/tui/terminal-emulator.ts
+++ b/src/cli/tui/terminal-emulator.ts
@@ -710,6 +710,17 @@ export class TerminalEmulatorBuffer {
     }
 
     if (sequence === "\u001b[?1049l") {
+      // Flush non-blank alternate screen rows to scrollback so codex's TUI
+      // output survives the screen switch (otherwise the content is discarded).
+      const altRows = this.alternateScreenBuffer;
+      let lastNonBlank = altRows.length - 1;
+      while (lastNonBlank >= 0 && altRows[lastNonBlank]!.every((cell) => cell.char.length === 0)) {
+        lastNonBlank -= 1;
+      }
+      for (let i = 0; i <= lastNonBlank; i += 1) {
+        this.pushScrollback(altRows[i]!);
+      }
+
       this.alternateScreen = false;
       if (this.savedMainState) {
         this.mainScreen = this.savedMainState.screen.map((row) => cloneRow(row, this.columns));

--- a/src/integrations/adapters/codex/adapter.ts
+++ b/src/integrations/adapters/codex/adapter.ts
@@ -1,9 +1,15 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../../core/executor/types.js";
 import type { AdapterExecutionContext, CliAdapter } from "../interface.js";
 import { getCodexReasoningEffortOverride } from "../../../cli/config/config-manager.js";
 import { executeAdapterViaSubprocess } from "../real.js";
 import { buildStubRawOutput } from "../stub.js";
 import { buildWorkspaceCommandArgs, buildWorkspaceIsolationEnv } from "../workspace-env.js";
+
+const createCodexLastMessagePath = (): string =>
+  join(mkdtempSync(join(tmpdir(), "detoks-codex-last-message-")), "last-message.txt");
 
 export class CodexStubAdapter implements CliAdapter {
   readonly target = "codex" as const;
@@ -37,6 +43,7 @@ export class CodexStubAdapter implements CliAdapter {
     }
 
     if (request.presentationMode === "embedded-pane") {
+      const outputLastMessagePath = createCodexLastMessagePath();
       return {
         command: "codex",
         args: [
@@ -46,15 +53,19 @@ export class CodexStubAdapter implements CliAdapter {
           ...workspaceArgs,
           ...(reasoningEffort ? ["-c", `model_reasoning_effort=${reasoningEffort}`] : []),
           ...(request.model ? ["--model", request.model] : []),
+          "--json",
           "-",
           "--sandbox",
           "workspace-write",
           "--skip-git-repo-check",
+          "--output-last-message",
+          outputLastMessagePath,
         ],
         ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
         ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
         input: request.prompt,
         interactiveAfterInput: true,
+        outputLastMessagePath,
       };
     }
 

--- a/src/integrations/adapters/real.ts
+++ b/src/integrations/adapters/real.ts
@@ -1,3 +1,5 @@
+import { readFileSync, rmSync } from "node:fs";
+import { dirname } from "node:path";
 import type { AdapterExecutionContext, CliAdapter } from "./interface.js";
 import type { AdapterExecutionRequest, AdapterExecutionResult } from "../../core/executor/types.js";
 import { createPtySubprocessRunner } from "../subprocess/runner.js";
@@ -7,6 +9,37 @@ import type {
   PtyResult,
   TranscriptAwareSubprocessRunner,
 } from "../subprocess/types.js";
+
+const readOutputLastMessage = (path?: string): string | null => {
+  if (!path) {
+    return null;
+  }
+
+  try {
+    const text = readFileSync(path, "utf8").trim();
+    return text.length > 0 ? text : null;
+  } catch {
+    return null;
+  } finally {
+    try {
+      rmSync(dirname(path), { recursive: true, force: true });
+    } catch {
+      // Cleanup is best-effort only.
+    }
+  }
+};
+
+const resolveRawOutput = (
+  result: { stdout: string; stderr: string; exitCode: number; timedOut: boolean },
+  outputLastMessagePath?: string,
+): string => {
+  const lastMessage = readOutputLastMessage(outputLastMessagePath);
+  if (!result.timedOut && result.exitCode === 0 && lastMessage !== null) {
+    return lastMessage;
+  }
+
+  return !result.timedOut && result.exitCode === 0 ? result.stdout : (result.stdout || result.stderr);
+};
 
 export const shouldUseRealExecution = (context?: AdapterExecutionContext): boolean =>
   context?.executionMode === "real";
@@ -66,7 +99,7 @@ export const executeAdapterViaSubprocess = async (
 
     return {
       success: !result.timedOut && result.exitCode === 0,
-      rawOutput: !result.timedOut && result.exitCode === 0 ? result.stdout : (result.stdout || result.stderr),
+      rawOutput: resolveRawOutput(result, subprocessRequest.outputLastMessagePath),
       exitCode: result.exitCode,
       ...(result.stderr.length > 0 ? { stderr: result.stderr } : {}),
       transcript: result.transcript,
@@ -87,7 +120,7 @@ export const executeAdapterViaSubprocess = async (
 
   return {
     success: !result.timedOut && result.exitCode === 0,
-    rawOutput: !result.timedOut && result.exitCode === 0 ? result.stdout : (result.stdout || result.stderr),
+    rawOutput: resolveRawOutput(result, subprocessRequest.outputLastMessagePath),
     exitCode: result.exitCode,
     ...(result.stderr.length > 0 ? { stderr: result.stderr } : {}),
   };
@@ -105,7 +138,7 @@ export const executeAdapterViaPtySubprocess = async (
 
   return {
     success: !result.timedOut && result.exitCode === 0,
-    rawOutput: (!result.timedOut && result.exitCode === 0) ? result.stdout : (result.stdout || result.stderr),
+    rawOutput: resolveRawOutput(result, subprocessRequest.outputLastMessagePath),
     exitCode: result.exitCode,
     ...(result.stderr.length > 0 ? { stderr: result.stderr } : {}),
     transcript: result.transcript,

--- a/src/integrations/subprocess/runner.ts
+++ b/src/integrations/subprocess/runner.ts
@@ -379,6 +379,29 @@ const runWithNodePty = (
 
   let stdout = "";
   let settled = false;
+  let stdoutPending = "";
+  let stderrPending = "";
+  const lineBufferedJson = isCodexJsonStreamRequest(request);
+
+  const pushLines = (
+    chunk: string,
+    stream: "stdout" | "stderr",
+    pending: string,
+  ): string => {
+    const combined = `${pending}${chunk}`.replace(/\r\n/g, "\n");
+    const lines = combined.split("\n");
+    const nextPending = combined.endsWith("\n") ? "" : (lines.pop() ?? "");
+
+    for (const line of lines) {
+      emitEvent({
+        type: "chunk",
+        stream,
+        data: `${line}\n`,
+      });
+    }
+
+    return nextPending;
+  };
 
   const finish = (code: number, timedOut: boolean): void => {
     if (settled) {
@@ -427,10 +450,24 @@ const runWithNodePty = (
 
   ptyProcess.onData((data) => {
     stdout += data;
+    if (lineBufferedJson) {
+      stdoutPending = pushLines(data, "stdout", stdoutPending);
+      return;
+    }
     emitEvent({ type: "chunk", stream: "stdout", data });
   });
 
   ptyProcess.onExit(({ exitCode }) => {
+    if (lineBufferedJson) {
+      if (stdoutPending.length > 0) {
+        emitEvent({ type: "chunk", stream: "stdout", data: stdoutPending });
+        stdoutPending = "";
+      }
+      if (stderrPending.length > 0) {
+        emitEvent({ type: "chunk", stream: "stderr", data: stderrPending });
+        stderrPending = "";
+      }
+    }
     finish(exitCode ?? 0, false);
   });
 
@@ -458,7 +495,7 @@ export const createPtySubprocessRunner = (
     run: (request: SubprocessRequest) => baseRunner.run(request),
 
     async runWithTranscript(request: SubprocessRequest): Promise<PtyResult> {
-      if (isCodexJsonStreamRequest(request)) {
+      if (isCodexJsonStreamRequest(request) && !request.interactiveAfterInput) {
         return await runStreamingJsonProcess(request, options);
       }
 

--- a/src/integrations/subprocess/types.ts
+++ b/src/integrations/subprocess/types.ts
@@ -5,6 +5,7 @@ export interface SubprocessRequest {
   env?: Record<string, string>;
   input?: string;
   interactiveAfterInput?: boolean;
+  outputLastMessagePath?: string;
 }
 
 export interface SubprocessResult {

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -307,15 +307,23 @@ const liveLocalLlmSmoke =
 const createFakeBinary = (
   dir: string,
   command: "codex" | "gemini" | "claude",
-  options: { exitCode?: number; stderr?: string } = {},
+  options: { exitCode?: number; stderr?: string; lastMessageText?: string; progressOnly?: boolean } = {},
 ) => {
   const binaryPath = join(dir, command);
   writeFileSync(
     binaryPath,
     `#!/usr/bin/env node
+const { writeFileSync } = require("node:fs");
 let input = "";
 let finished = false;
 let finishTimer = null;
+const args = process.argv.slice(2);
+const jsonMode = args.includes("--json");
+const outputLastMessageIndex = args.indexOf("--output-last-message");
+const outputLastMessagePath =
+  outputLastMessageIndex >= 0 && outputLastMessageIndex + 1 < args.length
+    ? args[outputLastMessageIndex + 1]
+    : null;
 const finish = () => {
   if (finished) {
     return;
@@ -326,7 +334,19 @@ const finish = () => {
     finishTimer = null;
   }
   ${options.stderr ? `process.stderr.write(${JSON.stringify(options.stderr)});` : ""}
-  process.stdout.write(\`[fake:${command}] \${input}\`);
+  ${options.lastMessageText ? `
+  if (outputLastMessagePath) {
+    writeFileSync(outputLastMessagePath, ${JSON.stringify(options.lastMessageText)}, "utf8");
+  }
+  ` : ""}
+  if (jsonMode) {
+    process.stdout.write('{"type":"turn.started"}\\n');
+    ${options.progressOnly
+      ? `process.stdout.write('{"type":"item.completed","item":{"type":"command_execution","command":"find .","aggregated_output":"README.md","exit_code":0}}\\n');`
+      : `process.stdout.write(JSON.stringify({ type: "item.completed", item: { type: "assistant_message", text: \`[fake:${command}] \${input}\` } }) + "\\n");`}
+  } else {
+    ${options.progressOnly ? `process.stdout.write("OpenAI Codex v0.0.0\\n검색: README* · 진행 중\\n");` : `process.stdout.write(\`[fake:${command}] \${input}\`);`}
+  }
   process.exit(${options.exitCode ?? 0});
 };
 const scheduleFinish = () => {
@@ -760,7 +780,6 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       expect(replRun.stdout).toContain("실행 중");
       expect(replRun.stdout).toContain("완료");
       expect(replRun.stdout).toContain("[fake:codex]");
-      expect(replRun.stdout).toContain("tok -");
     } finally {
       rmSync(tempDir, { force: true, recursive: true });
     }
@@ -787,6 +806,34 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       expect(replRun.stdout).toContain("hello again");
       expect(replRun.stdout).toContain("Sticky Prompt");
       expect(replRun.stdout).toContain("실행 중");
+      expect(replRun.stdout).toContain("완료");
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  }, 30_000);
+
+  it("appends the final answer from codex output-last-message even when only progress text was streamed", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "detoks-cli-embedded-last-message-"));
+
+    try {
+      createFakeBinary(tempDir, "codex", {
+        lastMessageText: "This directory contains the detoks CLI workspace.\n",
+        progressOnly: true,
+      });
+      const replRun = runCliWithInputFromCwdEnvAndTimeout(
+        tempDir,
+        ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
+        "Explain the purpose of this directory in one sentence.\n\n/exit\n",
+        {
+          PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+          DETOKS_CACHE_DISABLED: "1",
+        },
+        20_000,
+      );
+
+      expect(replRun.stderr).not.toContain("ReferenceError");
+      expect(replRun.stdout).toContain("README.md");
+      expect(replRun.stdout).toContain("This directory contains the detoks CLI workspace.");
       expect(replRun.stdout).toContain("완료");
     } finally {
       rmSync(tempDir, { force: true, recursive: true });

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -43,6 +43,53 @@ describe("EmbeddedTerminalPane", () => {
     expect(output).toContain("world");
   });
 
+  it("tracks appended final answers for embedded fallback dedupe", () => {
+    expect(pane.hasFinalAnswer()).toBe(false);
+    expect(pane.getLastFinalAnswer()).toBeNull();
+
+    pane.appendFinalAnswer("final answer");
+
+    expect(pane.hasFinalAnswer()).toBe(true);
+    expect(pane.getLastFinalAnswer()).toBe("final answer");
+  });
+
+  it("extracts final answers from codex json events", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "{\"type\":\"item.completed\",\"item\":{\"type\":\"assistant_message\",\"text\":\"Detoks is the CLI workspace.\"}}\n",
+    });
+
+    expect(pane.getLastFinalAnswer()).toBe("Detoks is the CLI workspace.");
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).toContain("Detoks is the CLI workspace.");
+  });
+
+  it("does not render codex lifecycle json lines in the embedded pane", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "{\"type\":\"turn.started\"}\n",
+    });
+
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).not.toContain("turn.started");
+  });
+
+  it("drops ansi-prefixed lifecycle json lines in the embedded pane", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "\u001b[2m{\"type\":\"thread.started\"}\u001b[0m\n",
+    });
+
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).not.toContain("thread.started");
+  });
+
   it("renders Korean wide characters without placeholder spacing", () => {
     pane.addEvent({
       type: "chunk",

--- a/tests/ts/unit/integrations/adapters/adapter-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/adapter-path.test.ts
@@ -200,10 +200,13 @@ describe("adapter subprocess path", () => {
         "/tmp",
         "--model",
         "gpt-5",
+        "--json",
         "-",
         "--sandbox",
         "workspace-write",
         "--skip-git-repo-check",
+        "--output-last-message",
+        expect.stringMatching(/last-message\.txt$/),
       ],
         cwd: "/tmp",
         env: {
@@ -211,6 +214,7 @@ describe("adapter subprocess path", () => {
         },
         input: "",
       interactiveAfterInput: true,
+      outputLastMessagePath: expect.stringMatching(/last-message\.txt$/),
     });
   });
 

--- a/tests/ts/unit/integrations/adapters/real-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/real-path.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { CodexStubAdapter } from "../../../../../src/integrations/adapters/codex/adapter.js";
 import { ClaudeStubAdapter } from "../../../../../src/integrations/adapters/claude/adapter.js";
 import { GeminiStubAdapter } from "../../../../../src/integrations/adapters/gemini/adapter.js";
+import { executeAdapterViaSubprocess } from "../../../../../src/integrations/adapters/real.js";
 import type { ActionTimelineEvent } from "../../../../../src/core/timeline/types.js";
 import type { SubprocessRequest, TranscriptAwareSubprocessRunner } from "../../../../../src/integrations/subprocess/types.js";
 
@@ -121,6 +122,59 @@ describe("adapter execution modes", () => {
       "tool_call",
       "tool_result",
     ]);
+  });
+
+  it("prefers codex output-last-message text over PTY progress output in embedded mode", async () => {
+    capturedRequests.length = 0;
+    const transcriptRunner: TranscriptAwareSubprocessRunner = {
+      async run(request: SubprocessRequest) {
+        capturedRequests.push(request);
+        return {
+          stdout: "progress only",
+          stderr: "",
+          exitCode: 0,
+          timedOut: false,
+        };
+      },
+      async runWithTranscript(request: SubprocessRequest) {
+        capturedRequests.push(request);
+        if (request.outputLastMessagePath) {
+          writeFileSync(request.outputLastMessagePath, "final embedded answer\n", "utf8");
+        }
+        return {
+          stdout: "progress only",
+          stderr: "",
+          exitCode: 0,
+          timedOut: false,
+          transcript: {
+            events: [],
+            startTime: 1,
+            endTime: 2,
+            totalDuration: 1,
+            exitCode: 0,
+            timedOut: false,
+          },
+        };
+      },
+    };
+    const result = await executeAdapterViaSubprocess(
+      new CodexStubAdapter(),
+      {
+        mode: "repl",
+        prompt: "embedded prompt",
+        verbose: false,
+        cwd: "/workspace",
+        presentationMode: "embedded-pane",
+      },
+      {
+        executionMode: "real",
+        subprocessRunner: transcriptRunner,
+      },
+    );
+
+    expect(capturedRequests).toHaveLength(1);
+    expect(capturedRequests[0]?.outputLastMessagePath).toMatch(/last-message\.txt$/);
+    expect(result.rawOutput).toBe("final embedded answer");
   });
 
   it("records gemini real execution requests with the gemini command", async () => {

--- a/tests/ts/unit/integrations/subprocess/runner.test.ts
+++ b/tests/ts/unit/integrations/subprocess/runner.test.ts
@@ -202,4 +202,53 @@ describe("createRealSubprocessRunner", () => {
 			),
 		).toBe(true);
 	});
+
+	it("keeps codex json requests on PTY when interactiveAfterInput is enabled", async () => {
+		const dir = tempDirs.at(-1)!;
+		const codexScript = join(dir, "codex");
+		writeFileSync(
+			codexScript,
+			[
+				"#!/bin/sh",
+				"prompt=$(cat)",
+				"printf '{\"type\":\"turn.started\"}\\n'",
+				"printf 'approval required\\n'",
+				"IFS= read -r answer < /dev/tty",
+				"printf '{\"type\":\"item.completed\",\"item\":{\"type\":\"assistant_message\",\"text\":\"done\"}}\\n'",
+				"printf 'answer:%s\\n' \"$answer\"",
+			].join("\n"),
+			"utf8",
+		);
+		chmodSync(codexScript, 0o755);
+
+		let capturedController: { write: (data: string) => void } | null = null;
+		let answered = false;
+		const runner = createPtySubprocessRunner({
+			onController: (controller) => {
+				capturedController = controller;
+			},
+			onEvent: (event) => {
+				if (!answered && event.type === "chunk" && event.data?.includes("approval required")) {
+					answered = true;
+					capturedController?.write("y\r");
+				}
+			},
+		});
+
+		const result = await runner.runWithTranscript({
+			command: "codex",
+			args: ["exec", "--json", "-", "--sandbox", "workspace-write"],
+			input: "hello",
+			interactiveAfterInput: true,
+			env: {
+				...process.env,
+				PATH: `${dir}:${process.env.PATH ?? ""}`,
+			},
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("approval required");
+		expect(result.stdout).toContain("\"assistant_message\"");
+		expect(result.stdout).toContain("answer:y");
+	}, 10_000);
 });


### PR DESCRIPTION
## Summary
- Route embedded-pane Codex execution through `--json` plus `--output-last-message` so the final answer can be recovered reliably.
- Parse Codex JSON stream lines in the embedded terminal pane and suppress lifecycle noise / duplicate final-answer rendering.
- Preserve the final answer from real subprocess execution and keep the TUI fallback behavior consistent.

## Validation
- `npx vitest run tests/ts/unit/integrations/subprocess/runner.test.ts tests/ts/unit/integrations/adapters/real-path.test.ts tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts tests/ts/unit/integrations/adapters/adapter-path.test.ts tests/ts/integration/cli-smoke.test.ts`
- Targeted smoke case passed: `appends the final answer from codex output-last-message even when only progress text was streamed`