### PR TITLE
fix(tui): embedded pane 목표/최종 출력 표시 안정화

### DIFF
--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { stdout, stdin } from "node:process";
 import { StringDecoder } from "node:string_decoder";
 import type { CliArgs } from "../types.js";
@@ -165,10 +166,33 @@ const formatCacheHitBadge = (cacheHit: import("../../core/pipeline/types.js").Ca
   return `cache hit(${kindLabel} · ${ageLabel})`;
 };
 
+const resolveFooterBranchLabel = (cwd: string): string | undefined => {
+  try {
+    const branch = execSync("git symbolic-ref --short HEAD", {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim();
+    return branch.length > 0 ? branch : undefined;
+  } catch {}
+
+  try {
+    const detachedHead = execSync("git rev-parse --short HEAD", {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim();
+    return detachedHead.length > 0 ? `detached@${detachedHead}` : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
   const screen = createScreenManager(stdout, stdin);
   const decoder = new StringDecoder("utf8");
   const executionCwd = options.cwd ?? process.cwd();
+  const footerBranchLabel = resolveFooterBranchLabel(executionCwd);
   const state = {
     adapter: options.adapter,
     adapterModel: options.adapterModel ?? getAdapterModel(options.adapter),
@@ -1030,6 +1054,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
           inferenceStrength: state.inferenceStrength,
           tokenSavings: state.tokenSavingsLabel,
           cwd: executionCwd,
+          branch: footerBranchLabel,
         }),
       );
       screen.flush();

--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -522,7 +522,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       const lines: string[] = [];
 
       if (promptText === null) {
-        lines.push(buildSectionDivider("Sticky Prompt", width));
+        lines.push(buildSectionDivider("현재 지시문", width));
         lines.push(
           ...buildWrappedBlock(
             [hasExecuted ? "최근 실행 결과를 준비하는 중입니다." : "첫 프롬프트를 입력하세요."],
@@ -534,7 +534,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
         return lines.slice(0, getEmbeddedStickyRows());
       }
 
-      lines.push(buildSectionDivider("Sticky Prompt", width));
+      lines.push(buildSectionDivider("현재 지시문", width));
       lines.push(
         ...buildWrappedBlock(promptText.split("\n"), width, "> ").slice(0, Math.max(0, getEmbeddedStickyRows() - 2)),
       );

--- a/src/cli/tui/panels/codex-json.ts
+++ b/src/cli/tui/panels/codex-json.ts
@@ -50,6 +50,13 @@ const extractJsonCandidate = (line: string): string | null => {
 export const hasCodexJsonCandidate = (line: string): boolean => extractJsonCandidate(line) !== null;
 
 export type CodexStructuredLine =
+  | {
+      kind: "command";
+      commandLine: string | null;
+      status: "running" | "completed" | "failed";
+      outputPreview?: string;
+      category: "tool" | "validation" | "git";
+    }
   | { kind: "tool"; text: string }
   | { kind: "validation"; text: string }
   | { kind: "git"; text: string }
@@ -168,16 +175,24 @@ const classifyCommandExecution = (item: Record<string, unknown>, phase: string):
   const commandSummary = command ? summarizeCommand(command) : null;
   const exitCode = getNumberField(item, ["exit_code", "exitCode"]);
   const output = summarizeText(getStringField(item, ["aggregated_output", "output", "stdout", "result", "text"]) ?? extractJsonText(item) ?? "");
-  const resultSummary = exitCode === null ? "done" : `exit ${exitCode}`;
-  if (phase !== "completed" && phase !== "updated" && phase !== "progress") return null;
-  if (command && isValidationCommand(command)) {
-    return { kind: "validation", text: commandSummary ? `${commandSummary} · ${output.length > 0 ? output : resultSummary}` : (output || resultSummary) };
+  const status =
+    phase === "started" ? "running"
+    : exitCode === null || exitCode === 0 ? "completed"
+    : "failed";
+  const category =
+    command && isValidationCommand(command) ? "validation"
+    : command && isGitCommand(command) ? "git"
+    : "tool";
+  if (commandSummary === null && output.length === 0 && phase !== "started") {
+    return null;
   }
-  if (command && isGitCommand(command)) {
-    return { kind: "git", text: commandSummary ? `${commandSummary} · ${output.length > 0 ? output : resultSummary}` : (output || resultSummary) };
-  }
-  const toolText = commandSummary ? `${commandSummary} · ${output.length > 0 ? output : resultSummary}` : (output || resultSummary);
-  return toolText ? { kind: "tool", text: toolText } : null;
+  return {
+    kind: "command",
+    commandLine: commandSummary,
+    status,
+    ...(output.length > 0 ? { outputPreview: output } : {}),
+    category,
+  };
 };
 
 const summarizeFileChange = (item: Record<string, unknown>, phase: string): string | null => {
@@ -188,22 +203,20 @@ const summarizeFileChange = (item: Record<string, unknown>, phase: string): stri
     const record = change as Record<string, unknown>;
     const path = getStringField(record, ["path", "filePath", "file_name", "filename"]);
     if (!path) return null;
-    const kind = getStringField(record, ["kind", "type"]) ?? "update";
-    const symbol = kind === "add" || kind === "create" ? "+" : kind === "delete" || kind === "remove" ? "-" : kind === "rename" ? "→" : "~";
-    return `${symbol} ${path}`;
+    return path;
   }).filter((entry): entry is string => Boolean(entry));
   const summary = changeSummaries.length > 0 ? changeSummaries.join(", ") : (getStringField(item, ["path", "filePath", "file_name", "filename"]) ?? "");
-  return summary.length === 0 ? "파일 변경 완료" : `applied: ${summary}`;
+  return summary.length === 0 ? "Edit 파일 변경" : `Edit ${summary.replace(/^([+~\-→]\s*)+/g, "").trim()}`;
 };
 
 const summarizeToolItem = (item: Record<string, unknown>, phase: string, itemType: string): string | null => {
   const label = itemType.replaceAll("_", " ").trim();
-  if (phase === "started") return null;
   const summarySource =
-    phase === "completed" || phase === "updated" || phase === "progress"
-      ? getStringField(item, ["output", "result", "text", "summary", "title", "name"]) ?? extractJsonText(item) ?? ""
-      : getStringField(item, ["title", "name", "summary", "text", "output"]) ?? extractJsonText(item) ?? "";
+      phase === "completed" || phase === "updated" || phase === "progress"
+      ? getStringField(item, ["output", "result", "text", "summary", "title", "name", "query", "prompt", "command", "input"]) ?? extractJsonText(item) ?? ""
+      : getStringField(item, ["title", "name", "summary", "text", "output", "query", "prompt", "command", "input"]) ?? extractJsonText(item) ?? "";
   const summary = summarizeText(summarySource, 2) || "";
+  if (phase === "started") return summary.length > 0 ? `${label}: ${summary}` : label;
   if (phase === "completed" || phase === "updated" || phase === "progress") return summary.length > 0 ? `${label}: ${summary}` : `${label}: done`;
   return summary.length > 0 ? `${label}: ${summary}` : label;
 };
@@ -248,11 +261,16 @@ export const classifyCodexJsonLine = (line: string): CodexStructuredLine | null 
         if (editText) return { kind: "edit", text: editText };
       }
       if (isFinalAnswerItemType(itemType)) {
+        if (phase !== "completed") return null;
         const finalText = text ?? getStringField(item, ["text", "content", "message", "summary"]);
         if (finalText) return { kind: "final", text: finalText };
       }
     }
-    if (text && (eventType.includes("message") || eventType.includes("text") || eventType.includes("delta"))) {
+    if (
+      text &&
+      !eventType.startsWith("item.") &&
+      (eventType.includes("final") || eventType.endsWith(".completed"))
+    ) {
       return { kind: "final", text };
     }
     if (eventType.startsWith("thread.") || eventType.startsWith("turn.") || eventType.startsWith("response.") || eventType.startsWith("item.")) {

--- a/src/cli/tui/panels/codex-json.ts
+++ b/src/cli/tui/panels/codex-json.ts
@@ -157,6 +157,7 @@ const isToolItemType = (itemType: string): boolean =>
 const isFileEditItemType = (itemType: string): boolean => itemType === "file_change";
 const isFinalAnswerItemType = (itemType: string): boolean =>
   new Set(["agent_message", "assistant_message", "final_answer"]).has(itemType);
+const isIntentLikeAssistantText = (text: string): boolean => /^(Goal|목표):\s*/i.test(text.trim());
 
 const summarizeText = (text: string, maxLines = 3): string => {
   const normalized = sanitizeCodexText(text).replace(/\r\n/g, "\n");
@@ -263,9 +264,14 @@ export const classifyCodexJsonLine = (line: string): CodexStructuredLine | null 
         if (editText) return { kind: "edit", text: editText };
       }
       if (isFinalAnswerItemType(itemType)) {
-        if (phase !== "completed") return null;
         const finalText = text ?? getStringField(item, ["text", "content", "message", "summary"]);
-        if (finalText) return { kind: "final", text: finalText };
+        if (finalText && isIntentLikeAssistantText(finalText)) {
+          return { kind: "raw", text: finalText };
+        }
+        if (phase !== "completed") return null;
+        if (finalText) {
+          return { kind: "final", text: finalText };
+        }
       }
     }
     if (

--- a/src/cli/tui/panels/codex-json.ts
+++ b/src/cli/tui/panels/codex-json.ts
@@ -26,6 +26,8 @@ const CODEX_STDERR_NOISE_PATTERNS = [
   /^\[EXECUTE\]/,
   /^Context:/,
   /^tokens used/,
+  /^.*error-write_stdin failed: stdin is closed for this session\b/i,
+  /^.*rerun exec_command with tty=true to keep stdin open\b/i,
 ] as const;
 
 const stripControlSequences = (value: string): string =>

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -1,3 +1,4 @@
+import chalk from "chalk";
 import type { RenderContext } from "../renderer.js";
 import type { PanelRegion } from "../layout-manager.js";
 import type { PtyEvent } from "../../../integrations/subprocess/types.js";
@@ -12,6 +13,7 @@ import {
   shouldDropLifecycleJsonLine,
   shouldIgnoreCodexNoiseLine,
 } from "./codex-json.js";
+import type { CodexStructuredLine } from "./codex-json.js";
 import type { TerminalCell, TerminalCellStyle, TerminalColor } from "../terminal-emulator.js";
 import { TerminalEmulatorBuffer, getCharacterDisplayWidth } from "../terminal-emulator.js";
 
@@ -24,6 +26,26 @@ const EMPTY_PANE_LINES = [
   "",
   "Ctrl+T 어댑터 터미널 포커스 전환  ·  Esc / Ctrl+G detoks 입력으로 복귀",
 ] as const;
+
+const wrapPlainText = (text: string, maxWidth: number): string[] => {
+  if (maxWidth <= 0) return [];
+  const sourceLines = text.replace(/\r\n/g, "\n").split("\n");
+  const wrapped: string[] = [];
+  for (const sourceLine of sourceLines) {
+    const line = sourceLine.trimEnd();
+    if (line.length === 0) {
+      wrapped.push("");
+      continue;
+    }
+    let remaining = line;
+    while (remaining.length > maxWidth) {
+      wrapped.push(remaining.slice(0, maxWidth));
+      remaining = remaining.slice(maxWidth);
+    }
+    wrapped.push(remaining);
+  }
+  return wrapped;
+};
 
 const truncateToWidth = (line: string, maxWidth: number): string => {
   if (maxWidth <= 0) {
@@ -148,6 +170,13 @@ const COMMAND_LINE_PATTERNS = [
   /^rg\b/i,
   /^grep\b/i,
   /^find\b/i,
+  /^sed\b/i,
+  /^cat\b/i,
+  /^less\b/i,
+  /^head\b/i,
+  /^tail\b/i,
+  /^printf\b/i,
+  /^echo\b/i,
   /^git\b/i,
   /^npm\b/i,
   /^npx\b/i,
@@ -196,6 +225,8 @@ const DECORATIVE_LINE_RE = /^[\s╭╮╰╯─│┌┐└┘├┤┬┴┼╔
 
 const isDecorativeLine = (text: string): boolean =>
   text.length > 0 && DECORATIVE_LINE_RE.test(text);
+const STRUCTURED_ACTIVITY_MARKER_PREFIX = "__DETOKS_ACTIVITY__:";
+const STRUCTURED_ACTIVITY_MARKER_PATTERN = /^__DETOKS_ACTIVITY__:(\d+)$/;
 
 interface RenderedRowInfo {
   cells: TerminalCell[];
@@ -216,6 +247,17 @@ export interface EmbeddedInteractionState {
   kind: "none" | "approval";
   label: string;
   detail?: string;
+}
+
+interface StructuredActivityEntry {
+  id: string;
+  kind: EmbeddedActivityKind;
+  label: string;
+  detail: string;
+  status: "running" | "completed" | "failed";
+  commandLine?: string;
+  statusLine?: string;
+  outputPreview?: string;
 }
 
 type NarrativeActivityKind = "thought" | "read" | "edit" | "bash";
@@ -288,14 +330,17 @@ const extractShellPayload = (commandLine: string): string => {
 const extractPathCandidate = (commandLine: string): string | null => {
   const payload = extractShellPayload(commandLine);
   const pathMatches = payload.match(/(?:~\/|\/|\.\.?\/)[^\s"'`]+/g);
-  if (pathMatches !== null && pathMatches.length > 0) {
-    return pathMatches[pathMatches.length - 1] ?? null;
-  }
-
-  const tokens = payload.split(/\s+/).filter(Boolean);
-  const likelyPath = [...tokens].reverse().find((token) =>
+  const likelyPath = [...payload.split(/\s+/).filter(Boolean)].reverse().find((token) =>
     /[./]/.test(token) && /\.(?:[cm]?[jt]sx?|json|md|yml|yaml|toml|lock|txt|css|html|py|rs|go|java|swift)$/i.test(token),
   );
+  if (pathMatches !== null && pathMatches.length > 0) {
+    const lastPathMatch = (pathMatches[pathMatches.length - 1] ?? "").replace(/[;:,]+$/, "");
+    if (likelyPath !== undefined && likelyPath.length > lastPathMatch.length) {
+      return likelyPath;
+    }
+    return lastPathMatch.length > 0 ? lastPathMatch : likelyPath ?? null;
+  }
+
   return likelyPath?.replace(/[;:,]+$/, "") ?? null;
 };
 
@@ -413,6 +458,13 @@ const composeIndentedLine = (
   return colorize(padDisplayWidth(`${prefix}${truncateForSummary(body, maxWidth - prefix.length)}`, maxWidth));
 };
 
+const buildStructuredActivityMarker = (id: string): string => `${STRUCTURED_ACTIVITY_MARKER_PREFIX}${id}`;
+
+const parseStructuredActivityMarker = (plainText: string): string | null => {
+  const match = STRUCTURED_ACTIVITY_MARKER_PATTERN.exec(plainText.trim());
+  return match?.[1] ?? null;
+};
+
 const composeBadgedDetailLine = (
   badge: string,
   body: string,
@@ -463,6 +515,105 @@ const composeNarrativeTitleLine = (
   const badge = badges.map((entry) => entry.style(entry.text)).join(" ");
   const body = `${badgeText ? `${badge} ` : ""}${coloredKind} ${coloredSubject}`;
   return padDisplayWidth(`${colorize(prefix)}${body}`, maxWidth);
+};
+
+const buildStructuredActivityRenderableLines = (
+  entry: StructuredActivityEntry,
+  maxWidth: number,
+  now: number,
+  runStartedAt: number | null,
+): EmbeddedTerminalRenderableLine[] => {
+  const statusLabel =
+    entry.status === "running" ? "진행 중" : entry.status === "completed" ? "완료" : "실패";
+  const baseSummary = `${entry.label}: ${entry.detail} · ${statusLabel}`;
+
+  if (entry.kind === "command" || entry.kind === "file" || entry.kind === "search" || entry.kind === "git" || entry.kind === "test") {
+    const spinnerIndex = runStartedAt === null
+      ? -1
+      : Math.floor(Math.max(0, now - runStartedAt) / width.spinnerFrameMs) % glyph.spinnerBraille.length;
+    const icon =
+      entry.status === "running"
+        ? spinnerIndex >= 0 ? glyph.spinnerBraille[spinnerIndex]! : glyph.execRunning
+        : entry.status === "completed"
+          ? glyph.execDone
+          : glyph.execFailed;
+    const style = entry.status === "running" ? statusColor.header : entry.status === "completed" ? statusColor.success : statusColor.error;
+    const summaryWithElapsed =
+      entry.status === "running" && runStartedAt !== null
+        ? `${baseSummary} ${computeRunningElapsedLabel(runStartedAt, now)}`
+        : baseSummary;
+    const lines: EmbeddedTerminalRenderableLine[] = [
+      { text: composeGutteredLine(icon, summaryWithElapsed.trim(), maxWidth, style) },
+    ];
+
+    if (entry.commandLine && entry.commandLine !== entry.detail) {
+      lines.push({
+        text: composeIndentedLine(entry.commandLine, maxWidth, statusColor.info),
+      });
+    }
+    if (entry.statusLine) {
+      lines.push({
+        text: composeIndentedLine(entry.statusLine, maxWidth, entry.status === "completed" ? statusColor.success : entry.status === "failed" ? statusColor.error : statusColor.muted),
+      });
+    }
+    if (entry.outputPreview) {
+      lines.push({
+        text: composeIndentedLine(entry.outputPreview, maxWidth, statusColor.muted),
+      });
+    }
+    return lines;
+  }
+
+  if (entry.kind === "tool") {
+    return [
+      { text: composeGutteredLine(glyph.toolWeb, baseSummary, maxWidth, statusColor.muted) },
+    ];
+  }
+
+  if (entry.kind === "edit") {
+    return [
+      { text: composeNarrativeTitleLine("Edit", entry.detail, glyph.changeUpdate, maxWidth, statusColor.success) },
+    ];
+  }
+
+  if (entry.kind === "read") {
+    return [
+      { text: composeNarrativeTitleLine("Read", entry.detail, glyph.info, maxWidth, statusColor.info) },
+    ];
+  }
+
+  return [
+    { text: composeGutteredLine(glyph.bullet, baseSummary, maxWidth, statusColor.muted) },
+  ];
+};
+
+const buildFinalAnswerRenderableLines = (
+  finalAnswer: string,
+  maxWidth: number,
+): EmbeddedTerminalRenderableLine[] => {
+  if (maxWidth <= 0) return [];
+
+  const renderHighlightedLine = (line: string, emphasize: "title" | "body"): string => {
+    const padded = padDisplayWidth(truncateToWidth(line, maxWidth), maxWidth);
+    return emphasize === "title"
+      ? chalk.bgHex("#334155").hex("#f8fafc").bold(padded)
+      : chalk.bgHex("#1f2937").hex("#e5e7eb")(padded);
+  };
+
+  const lines: EmbeddedTerminalRenderableLine[] = [
+    { text: renderHighlightedLine(" 최종 결과 ", "title") },
+  ];
+  const bodyLines = wrapPlainText(finalAnswer, maxWidth);
+  if (bodyLines.length === 0) {
+    lines.push({ text: renderHighlightedLine("", "body") });
+    return lines;
+  }
+  for (const line of bodyLines) {
+    lines.push({
+      text: renderHighlightedLine(line, "body"),
+    });
+  }
+  return lines;
 };
 
 const getNarrativeDetailStyle = (
@@ -858,12 +1009,23 @@ const buildCompactRenderableLines = (
   cursorGlobalRow?: number,
   now = Date.now(),
   runStartedAt: number | null = null,
+  resolveStructuredActivity?: (id: string) => StructuredActivityEntry | undefined,
 ): EmbeddedTerminalRenderableLine[] => {
   const output: EmbeddedTerminalRenderableLine[] = [];
 
   for (let index = 0; index < rows.length; ) {
     const row = rows[index];
     if (!row) {
+      index += 1;
+      continue;
+    }
+
+    const structuredActivityId = parseStructuredActivityMarker(row.plainText);
+    if (structuredActivityId !== null) {
+      const structuredActivity = resolveStructuredActivity?.(structuredActivityId);
+      if (structuredActivity) {
+        output.push(...buildStructuredActivityRenderableLines(structuredActivity, maxWidth, now, runStartedAt));
+      }
       index += 1;
       continue;
     }
@@ -970,6 +1132,19 @@ const buildCompactRenderableLines = (
           output.push({
             text: composeGutteredLine(execIcon, summary, maxWidth, execStyle),
           });
+
+          const commandLine = commandBlock[1]?.plainText.trim() ?? "";
+          if (commandLine.length > 0) {
+            output.push({
+              text: composeIndentedLine(commandLine, maxWidth, statusColor.info),
+            });
+          }
+
+          if (statusLineText !== null) {
+            output.push({
+              text: composeIndentedLine(statusLineText, maxWidth, execStatus === "completed" ? statusColor.success : statusColor.error),
+            });
+          }
           index = cursor;
           continue;
         }
@@ -1103,6 +1278,9 @@ export interface EmbeddedTerminalViewportTrackingInfo {
 
 export class EmbeddedTerminalPane {
   private readonly buffer = new TerminalEmulatorBuffer(80, 24, EMBEDDED_PANE_SCROLLBACK_LIMIT);
+  private readonly structuredActivities = new Map<string, StructuredActivityEntry>();
+  private structuredActivityOrder: string[] = [];
+  private nextStructuredActivityId = 1;
   private lastFinalAnswer: string | null = null;
   private scrollOffset = 0;
   // Cached total renderable line count (after compact summaries are applied).
@@ -1120,6 +1298,7 @@ export class EmbeddedTerminalPane {
         cursorVisible: boolean;
         cursorGlobalRow: number;
         compactLines: EmbeddedTerminalRenderableLine[];
+        finalAnswerLineCount: number;
         lastCompactNow: number | null;
         lastRunStartedAt: number | null;
         compactRebuildCount: number;
@@ -1130,6 +1309,9 @@ export class EmbeddedTerminalPane {
 
   clear(): void {
     this.buffer.reset();
+    this.structuredActivities.clear();
+    this.structuredActivityOrder = [];
+    this.nextStructuredActivityId = 1;
     this.lastFinalAnswer = null;
     this.scrollOffset = 0;
     this.cachedTotalRows = 0;
@@ -1203,6 +1385,72 @@ export class EmbeddedTerminalPane {
     this.cachedTotalRows = this.getTotalRenderableLineCount(this.currentColumns);
   }
 
+  private appendStructuredActivity(entry: StructuredActivityEntry): void {
+    this.structuredActivities.set(entry.id, entry);
+    this.structuredActivityOrder.push(entry.id);
+    this.buffer.write(`${buildStructuredActivityMarker(entry.id)}\n`);
+  }
+
+  private createStructuredActivityEntry(classified: CodexStructuredLine): StructuredActivityEntry | null {
+    const id = String(this.nextStructuredActivityId++);
+
+    if (classified.kind === "command") {
+      const commandLine = classified.commandLine ?? "명령 준비 중";
+      const activity = classified.commandLine ? describeCommandActivity(classified.commandLine) : {
+        kind: "command" as const,
+        label: "명령 실행",
+        detail: "명령 준비 중",
+      };
+      const statusLine =
+        classified.status === "running" ? "실행 중"
+        : classified.status === "completed" ? "완료"
+        : "실패";
+      return {
+        id,
+        kind: activity.kind,
+        label: activity.label,
+        detail: activity.detail,
+        status: classified.status,
+        commandLine,
+        statusLine,
+        ...(classified.outputPreview ? { outputPreview: classified.outputPreview } : {}),
+      };
+    }
+
+    if (classified.kind === "tool" || classified.kind === "validation" || classified.kind === "git") {
+      const text = classified.text.trim();
+      const detail = text.includes(":") ? text.slice(text.indexOf(":") + 1).trim() : text;
+      const label =
+        text.startsWith("web search:") ? "웹 검색"
+        : text.startsWith("tool_search:") ? "도구 검색"
+        : text.startsWith("todo_list:") ? "할일 도구"
+        : /^mcp\b/i.test(text) ? "MCP 도구"
+        : classified.kind === "validation" ? "검증"
+        : classified.kind === "git" ? "Git"
+        : "도구 활동";
+      return {
+        id,
+        kind: classified.kind === "git" ? "git" : classified.kind === "validation" ? "test" : "tool",
+        label,
+        detail: detail.length > 0 ? detail : "진행 중",
+        status: "running",
+      };
+    }
+
+    if (classified.kind === "edit") {
+      const detail = classified.text.replace(/^Edit\s+/i, "").trim() || "파일 변경";
+      return {
+        id,
+        kind: "edit",
+        label: "Edit",
+        detail,
+        status: "completed",
+      };
+    }
+
+    return null;
+  }
+
   getTotalRenderableLineCount(maxWidth: number): number {
     if (maxWidth <= 0) {
       return 0;
@@ -1253,7 +1501,14 @@ export class EmbeddedTerminalPane {
       }
 
       if (classified) {
-        this.buffer.write(`${classified.text}\n`);
+        const structuredEntry = this.createStructuredActivityEntry(classified);
+        if (structuredEntry !== null) {
+          this.appendStructuredActivity(structuredEntry);
+          continue;
+        }
+        if ("text" in classified) {
+          this.buffer.write(`${classified.text}\n`);
+        }
         continue;
       }
 
@@ -1320,6 +1575,20 @@ export class EmbeddedTerminalPane {
     for (let index = rows.length - 1; index >= 0; index -= 1) {
       const row = rows[index];
       if (row === undefined) {
+        continue;
+      }
+
+      const structuredActivityId = parseStructuredActivityMarker(row.plainText);
+      if (structuredActivityId !== null) {
+        const structuredActivity = this.structuredActivities.get(structuredActivityId);
+        if (structuredActivity) {
+          return {
+            kind: structuredActivity.kind,
+            label: structuredActivity.label,
+            detail: structuredActivity.detail,
+            status: structuredActivity.status,
+          };
+        }
         continue;
       }
 
@@ -1394,6 +1663,10 @@ export class EmbeddedTerminalPane {
     for (let index = rows.length - 1; index >= scanStart; index -= 1) {
       const row = rows[index];
       if (row === undefined || row.plainText.length === 0) {
+        continue;
+      }
+
+      if (parseStructuredActivityMarker(row.plainText) !== null) {
         continue;
       }
 
@@ -1501,6 +1774,10 @@ export class EmbeddedTerminalPane {
     return false;
   }
 
+  private hasRunningStructuredActivity(): boolean {
+    return this.structuredActivityOrder.some((id) => this.structuredActivities.get(id)?.status === "running");
+  }
+
   private ensureRenderCache(
     maxWidth: number,
     now?: number,
@@ -1521,7 +1798,10 @@ export class EmbeddedTerminalPane {
       const previousSpinnerIndex = this.renderCache.lastRunStartedAt === null || this.renderCache.lastCompactNow === null
         ? -1
         : Math.floor(Math.max(0, this.renderCache.lastCompactNow - this.renderCache.lastRunStartedAt) / width.spinnerFrameMs) % glyph.spinnerBraille.length;
-      if (spinnerIndex === previousSpinnerIndex || !this.hasRunningExec(this.renderCache.rows)) {
+      if (
+        spinnerIndex === previousSpinnerIndex ||
+        (!this.hasRunningExec(this.renderCache.rows) && !this.hasRunningStructuredActivity())
+      ) {
         return this.renderCache;
       }
 
@@ -1533,7 +1813,13 @@ export class EmbeddedTerminalPane {
         this.renderCache.cursorGlobalRow,
         effectiveNow,
         effectiveRunStartedAt,
+        (id) => this.structuredActivities.get(id),
       );
+      const finalAnswerLines = this.lastFinalAnswer !== null
+        ? buildFinalAnswerRenderableLines(this.lastFinalAnswer, renderWidth)
+        : [];
+      this.renderCache.compactLines.push(...finalAnswerLines);
+      this.renderCache.finalAnswerLineCount = finalAnswerLines.length;
       this.renderCache.lastCompactNow = effectiveNow;
       this.renderCache.lastRunStartedAt = effectiveRunStartedAt;
       this.renderCache.compactRebuildCount += 1;
@@ -1556,7 +1842,13 @@ export class EmbeddedTerminalPane {
       cursorGlobalRow,
       effectiveNow,
       effectiveRunStartedAt,
+      (id) => this.structuredActivities.get(id),
     );
+
+    const finalAnswerLines = this.lastFinalAnswer !== null
+      ? buildFinalAnswerRenderableLines(this.lastFinalAnswer, renderWidth)
+      : [];
+    compactLines.push(...finalAnswerLines);
 
     this.renderCache = {
       width: renderWidth,
@@ -1565,6 +1857,7 @@ export class EmbeddedTerminalPane {
       cursorVisible,
       cursorGlobalRow,
       compactLines,
+      finalAnswerLineCount: finalAnswerLines.length,
       lastCompactNow: effectiveNow,
       lastRunStartedAt: effectiveRunStartedAt,
       compactRebuildCount: 1,
@@ -1602,7 +1895,19 @@ export class EmbeddedTerminalPane {
     const { compactLines } = this.ensureRenderCache(maxWidth, opts?.now, opts?.runStartedAt);
 
     const endIndex = Math.max(0, compactLines.length - Math.max(0, scrollOffset));
-    const startIndex = Math.max(0, maxRows === undefined ? 0 : endIndex - Math.max(0, maxRows));
+    const maxVisibleRows = Math.max(0, maxRows ?? 0);
+    if (
+      maxRows !== undefined &&
+      scrollOffset === 0 &&
+      this.renderCache !== null &&
+      this.renderCache.finalAnswerLineCount > maxVisibleRows &&
+      endIndex === compactLines.length
+    ) {
+      const finalBlockStartIndex = compactLines.length - this.renderCache.finalAnswerLineCount;
+      return compactLines.slice(finalBlockStartIndex, finalBlockStartIndex + maxVisibleRows);
+    }
+
+    const startIndex = Math.max(0, maxRows === undefined ? 0 : endIndex - maxVisibleRows);
 
     return compactLines.slice(startIndex, endIndex);
   }

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -552,13 +552,21 @@ const buildStructuredActivityRenderableLines = (
       });
     }
     if (entry.statusLine) {
+      const detailLineStyle =
+        entry.status === "completed" ? statusColor.success
+        : entry.status === "failed" ? statusColor.error
+        : statusColor.muted;
       lines.push({
-        text: composeIndentedLine(entry.statusLine, maxWidth, entry.status === "completed" ? statusColor.success : entry.status === "failed" ? statusColor.error : statusColor.muted),
+        text: composeIndentedLine(entry.statusLine, maxWidth, detailLineStyle),
       });
     }
     if (entry.outputPreview) {
       lines.push({
-        text: composeIndentedLine(entry.outputPreview, maxWidth, statusColor.muted),
+        text: composeIndentedLine(
+          entry.outputPreview,
+          maxWidth,
+          statusColor.muted,
+        ),
       });
     }
     return lines;
@@ -1146,6 +1154,18 @@ const buildCompactRenderableLines = (
               text: composeIndentedLine(statusLineText, maxWidth, execStatus === "completed" ? statusColor.success : statusColor.error),
             });
           }
+          const statusLineIndex = commandBlock.findIndex((r, i) => i >= 2 && isCommandStatusLine(r.plainText));
+          const rawPreviewLine = statusLineIndex >= 0
+            ? commandBlock
+              .slice(statusLineIndex + 1)
+              .map((entry) => entry.plainText.trim())
+              .find((line) => line.length > 0)
+            : undefined;
+          if (rawPreviewLine) {
+            output.push({
+              text: composeIndentedLine(rawPreviewLine, maxWidth, statusColor.muted),
+            });
+          }
           index = cursor;
           continue;
         }
@@ -1404,6 +1424,7 @@ export class EmbeddedTerminalPane {
         label: "명령 실행",
         detail: "명령 준비 중",
       };
+      const normalizedPreview = classified.outputPreview?.trim();
       const statusLine =
         classified.status === "running" ? "실행 중"
         : classified.status === "completed" ? "완료"
@@ -1416,7 +1437,7 @@ export class EmbeddedTerminalPane {
         status: classified.status,
         commandLine,
         statusLine,
-        ...(classified.outputPreview ? { outputPreview: classified.outputPreview } : {}),
+        ...(normalizedPreview ? { outputPreview: normalizedPreview } : {}),
       };
     }
 

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -601,6 +601,7 @@ const buildFinalAnswerRenderableLines = (
   };
 
   const lines: EmbeddedTerminalRenderableLine[] = [
+    { text: "" },
     { text: renderHighlightedLine(" 최종 결과 ", "title") },
   ];
   const bodyLines = wrapPlainText(finalAnswer, maxWidth);
@@ -1281,6 +1282,7 @@ export class EmbeddedTerminalPane {
   private readonly structuredActivities = new Map<string, StructuredActivityEntry>();
   private structuredActivityOrder: string[] = [];
   private nextStructuredActivityId = 1;
+  private pendingFinalAnswer: string | null = null;
   private lastFinalAnswer: string | null = null;
   private scrollOffset = 0;
   // Cached total renderable line count (after compact summaries are applied).
@@ -1312,6 +1314,7 @@ export class EmbeddedTerminalPane {
     this.structuredActivities.clear();
     this.structuredActivityOrder = [];
     this.nextStructuredActivityId = 1;
+    this.pendingFinalAnswer = null;
     this.lastFinalAnswer = null;
     this.scrollOffset = 0;
     this.cachedTotalRows = 0;
@@ -1474,6 +1477,13 @@ export class EmbeddedTerminalPane {
       return;
     }
 
+    if (event.type === "exit") {
+      if (this.lastFinalAnswer === null && this.pendingFinalAnswer !== null) {
+        this.appendFinalAnswer(this.pendingFinalAnswer);
+      }
+      return;
+    }
+
     if (event.type !== "chunk" || typeof event.data !== "string") {
       return;
     }
@@ -1481,6 +1491,13 @@ export class EmbeddedTerminalPane {
     const normalized = event.data.replace(/\r\n/g, "\n");
     const lines = normalized.split("\n");
     const shouldTreatAsStructured = lines.some((line) => hasCodexJsonCandidate(line));
+    const shouldIgnoreAsNoise =
+      event.stream === "stderr" &&
+      lines.every((line) => line.length === 0 || shouldIgnoreCodexNoiseLine(line));
+
+    if (shouldIgnoreAsNoise) {
+      return;
+    }
 
     if (!shouldTreatAsStructured) {
       this.buffer.write(event.data);
@@ -1496,7 +1513,10 @@ export class EmbeddedTerminalPane {
 
       const classified = classifyCodexJsonLine(line);
       if (classified?.kind === "final") {
-        this.appendFinalAnswer(classified.text);
+        const normalizedFinal = classified.text.trim();
+        if (normalizedFinal.length > 0) {
+          this.pendingFinalAnswer = normalizedFinal;
+        }
         continue;
       }
 
@@ -1529,6 +1549,7 @@ export class EmbeddedTerminalPane {
     }
 
     this.buffer.write(text.endsWith("\n") ? text : `${text}\n`);
+    this.pendingFinalAnswer = normalized;
     this.lastFinalAnswer = normalized;
     this.markRenderCacheDirty();
     this.scrollOffset = 0;

--- a/src/cli/tui/renderer.ts
+++ b/src/cli/tui/renderer.ts
@@ -30,6 +30,7 @@ export interface FooterContext {
   inferenceStrength?: string | undefined;
   tokenSavings?: string | undefined;
   cwd: string;
+  branch?: string | undefined;
 }
 
 const isWideCharacter = (char: string): boolean => {
@@ -200,12 +201,13 @@ const ellipsizeRight = (text: string, maxWidth: number): string => {
 export const buildFooterText = (columns: number, footer: FooterContext): string => {
   const sidePadding = columns >= 4 ? 1 : 0;
   const innerColumns = Math.max(0, columns - sidePadding * 2);
+  const cwdDisplay = footer.branch ? `${footer.cwd}(${footer.branch})` : footer.cwd;
   const footerValues = [
     footer.adapter,
     footer.adapterModel,
     footer.adapter === "codex" ? footer.inferenceStrength : undefined,
     footer.tokenSavings,
-    footer.cwd,
+    cwdDisplay,
   ].filter((value): value is string => Boolean(value));
 
   const fullText = footerValues.join(" | ");
@@ -222,8 +224,8 @@ export const buildFooterText = (columns: number, footer: FooterContext): string 
   }
 
   const compactText = footer.tokenSavings
-    ? `${footer.adapter} | ${footer.tokenSavings} | ${footer.cwd}`
-    : `${footer.adapter} | ${footer.cwd}`;
+    ? `${footer.adapter} | ${footer.tokenSavings} | ${cwdDisplay}`
+    : `${footer.adapter} | ${cwdDisplay}`;
   if (measureDisplayWidth(compactText) <= innerColumns) {
     return finalizeFooter(compactText);
   }
@@ -237,7 +239,7 @@ export const buildFooterText = (columns: number, footer: FooterContext): string 
           6,
       )
     : Math.max(0, innerColumns - measureDisplayWidth(footer.adapter) - 3);
-  const tokenAwareShortenedCwd = ellipsizeLeft(footer.cwd, tokenAwareCwdBudget);
+  const tokenAwareShortenedCwd = ellipsizeLeft(cwdDisplay, tokenAwareCwdBudget);
   let line = footer.tokenSavings
     ? `${footer.adapter} | ${footer.tokenSavings} | ${tokenAwareShortenedCwd}`
     : `${footer.adapter} | ${tokenAwareShortenedCwd}`;
@@ -247,7 +249,7 @@ export const buildFooterText = (columns: number, footer: FooterContext): string 
   }
 
   const cwdBudget = Math.max(0, innerColumns - measureDisplayWidth(footer.adapter) - 3);
-  const shortenedCwd = ellipsizeLeft(footer.cwd, cwdBudget);
+  const shortenedCwd = ellipsizeLeft(cwdDisplay, cwdBudget);
   line = `${footer.adapter} | ${shortenedCwd}`;
 
   if (measureDisplayWidth(line) <= innerColumns) {

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -775,7 +775,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
 
       expect(replRun.stderr).not.toContain("ReferenceError");
       expect(replRun.stdout).toContain("hello detoks");
-      expect(replRun.stdout).toContain("Sticky Prompt");
+      expect(replRun.stdout).toContain("현재 지시문");
       expect(replRun.stdout).toContain("실행 확인 대기");
       expect(replRun.stdout).toContain("실행 중");
       expect(replRun.stdout).toContain("완료");
@@ -804,7 +804,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       expect(replRun.stderr).not.toContain("ReferenceError");
       expect(replRun.stdout).toContain("hello detoks");
       expect(replRun.stdout).toContain("hello again");
-      expect(replRun.stdout).toContain("Sticky Prompt");
+      expect(replRun.stdout).toContain("현재 지시문");
       expect(replRun.stdout).toContain("실행 중");
       expect(replRun.stdout).toContain("완료");
     } finally {

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -832,7 +832,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       );
 
       expect(replRun.stderr).not.toContain("ReferenceError");
-      expect(replRun.stdout).toContain("README.md");
+      expect(replRun.stdout).toContain("find .");
       expect(replRun.stdout).toContain("This directory contains the detoks CLI workspace.");
       expect(replRun.stdout).toContain("완료");
     } finally {

--- a/tests/ts/unit/cli/tui/footer.test.ts
+++ b/tests/ts/unit/cli/tui/footer.test.ts
@@ -26,12 +26,13 @@ describe("footer text", () => {
       inferenceStrength: "medium",
       tokenSavings: "tok -18%",
       cwd: "/Users/choi/Desktop/workspace/detoks",
+      branch: "dev",
     });
 
     expect(footer.startsWith(" ")).toBe(true);
     expect(footer.endsWith(" ")).toBe(true);
     expect(footer.trim()).toBe(
-      "codex | gpt-5.4-mini | medium | tok -18% | /Users/choi/Desktop/workspace/detoks",
+      "codex | gpt-5.4-mini | medium | tok -18% | /Users/choi/Desktop/workspace/detoks(dev)",
     );
     expect(getDisplayWidth(footer)).toBe(120);
   });
@@ -43,11 +44,24 @@ describe("footer text", () => {
       inferenceStrength: "medium",
       tokenSavings: "tok -18%",
       cwd: "/Users/choi/Desktop/workspace/detoks",
+      branch: "dev",
     });
 
     expect(getDisplayWidth(footer)).toBe(60);
     expect(footer.startsWith(" ")).toBe(true);
     expect(footer.endsWith(" ")).toBe(true);
-    expect(footer.trim()).toBe("codex | tok -18% | /Users/choi/Desktop/workspace/detoks");
+    expect(footer.trim()).toBe("codex | tok -18% | …ers/choi/Desktop/workspace/detoks(dev)");
+  });
+
+  it("shows detached head when provided", () => {
+    const footer = buildFooterText(120, {
+      adapter: "codex",
+      cwd: "/Users/choi/Desktop/workspace/detoks",
+      branch: "detached@abc12345",
+    });
+
+    expect(footer.trim()).toBe(
+      "codex | /Users/choi/Desktop/workspace/detoks(detached@abc12345)",
+    );
   });
 });

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -99,6 +99,34 @@ describe("EmbeddedTerminalPane", () => {
     expect(output).not.toContain("숨김 상태 디렉터리에 목적 단서가 있을 수 있어 그 안도 확인하겠습니다.");
   });
 
+  it("renders goal-prefixed assistant messages as live output instead of final answer", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "{\"type\":\"item.completed\",\"item\":{\"type\":\"assistant_message\",\"text\":\"Goal: 현재 디렉터리 프로젝트의 목적을 파악합니다.\"}}\n",
+    });
+
+    expect(pane.getLastFinalAnswer()).toBeNull();
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).toContain("Goal: 현재 디렉터리 프로젝트의 목적을 파악합니다.");
+    expect(output).not.toContain("최종 결과");
+  });
+
+  it("renders started goal-prefixed assistant messages as live output", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "{\"type\":\"item.started\",\"item\":{\"type\":\"assistant_message\",\"text\":\"Goal: 현재 디렉터리 프로젝트의 목적을 파악합니다.\"}}\n",
+    });
+
+    expect(pane.getLastFinalAnswer()).toBeNull();
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).toContain("Goal: 현재 디렉터리 프로젝트의 목적을 파악합니다.");
+    expect(output).not.toContain("최종 결과");
+  });
+
   it("pins the latest final answer as a dedicated footer block after long activity history", () => {
     pane.addEvent({
       type: "chunk",
@@ -170,6 +198,49 @@ describe("EmbeddedTerminalPane", () => {
       status: "completed",
     });
     expect(output).not.toContain("\nexec\n");
+  });
+
+  it("labels goal-like command previews as intent instead of completed", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",\"command\":\"find . -maxdepth 1\",\"exit_code\":0,\"aggregated_output\":\"Goal: 현재 디렉터리 프로젝트의 목적을 파악합니다.\"}}\n",
+    });
+
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).toContain("완료");
+    expect(output).toContain("Goal: 현재 디렉터리 프로젝트의 목적을 파악합니다.");
+  });
+
+  it("shows intent lines for native exec blocks with goal output", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: [
+        "exec",
+        "/bin/zsh -lc 'find . -maxdepth 1'",
+        "succeeded in 42ms",
+        "Goal: 현재 디렉터리 프로젝트의 목적을 파악합니다.",
+      ].join("\n"),
+    });
+
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).toContain("성공");
+    expect(output).toContain("Goal: 현재 디렉터리 프로젝트의 목적을 파악합니다.");
+  });
+
+  it("renders standalone goal lines as plain output", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "Goal: 현재 디렉터리 프로젝트의 목적을 파악합니다.\n",
+    });
+
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).toContain("Goal: 현재 디렉터리 프로젝트의 목적을 파악합니다.");
   });
 
   it("never leaves a raw exec sentinel behind for structured codex command events", () => {

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -66,6 +66,126 @@ describe("EmbeddedTerminalPane", () => {
     expect(output).toContain("Detoks is the CLI workspace.");
   });
 
+  it("does not promote started assistant messages into the final result block", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: [
+        "{\"type\":\"item.started\",\"item\":{\"type\":\"assistant_message\",\"text\":\"숨김 상태 디렉터리에 목적 단서가 있을 수 있어 그 안도 확인하겠습니다.\"}}",
+        "{\"type\":\"item.completed\",\"item\":{\"type\":\"assistant_message\",\"text\":\"최종 요약 결과입니다.\"}}",
+      ].join("\n"),
+    });
+
+    expect(pane.getLastFinalAnswer()).toBe("최종 요약 결과입니다.");
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).toContain("최종 요약 결과입니다.");
+    expect(output).not.toContain("숨김 상태 디렉터리에 목적 단서가 있을 수 있어 그 안도 확인하겠습니다.");
+  });
+
+  it("pins the latest final answer as a dedicated footer block after long activity history", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: [
+        "{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",\"command\":\"ls -la\",\"exit_code\":0,\"aggregated_output\":\"file1\\nfile2\"}}",
+        "{\"type\":\"item.completed\",\"item\":{\"type\":\"assistant_message\",\"text\":\"The workspace contains the detoks CLI project.\"}}",
+      ].join("\n"),
+    });
+
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).toContain("최종 결과");
+    expect(output).toContain("The workspace contains the detoks CLI project.");
+    expect(output).not.toContain("┌");
+    expect(output).not.toContain("└");
+  });
+
+  it("keeps the final result header visible when the answer is taller than the pane", () => {
+    pane.appendFinalAnswer([
+      "첫 줄입니다.",
+      "둘째 줄입니다.",
+      "셋째 줄입니다.",
+      "넷째 줄입니다.",
+      "다섯째 줄입니다.",
+    ].join("\n"));
+
+    const output = pane.getRenderableLines(20, 4).map((line) => line.text).join("\n");
+    expect(output).toContain("최종 결과");
+    expect(output).toContain("첫 줄입니다.");
+    expect(output).not.toContain("다섯째 줄입니다.");
+  });
+
+  it("maps codex web_search json events into the existing tool activity card", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "{\"type\":\"item.started\",\"item\":{\"type\":\"web_search\",\"query\":\"detoks cli docs\"}}\n",
+    });
+
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).toContain("웹 검색");
+    expect(output).toContain("detoks cli docs");
+    expect(pane.getActivitySnapshot(120)).toMatchObject({
+      kind: "tool",
+      label: "웹 검색",
+      detail: "detoks cli docs",
+      status: "running",
+    });
+  });
+
+  it("maps codex command_execution json events into the existing file read activity card", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",\"command\":\"printf 'hello'\",\"exit_code\":0,\"aggregated_output\":\"line1\\nline2\"}}\n",
+    });
+
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).toContain("명령 실행");
+    expect(output).toContain("printf");
+    expect(pane.getActivitySnapshot(120)).toMatchObject({
+      kind: "command",
+      label: "명령 실행",
+      detail: "printf",
+      status: "completed",
+    });
+    expect(output).not.toContain("\nexec\n");
+  });
+
+  it("never leaves a raw exec sentinel behind for structured codex command events", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "{\"type\":\"item.started\",\"item\":{\"type\":\"command_execution\"}}\n",
+    });
+
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).toContain("명령 실행");
+    expect(output).not.toContain("\nexec\n");
+  });
+
+  it("maps codex file_change json events into the existing edit activity card", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "{\"type\":\"item.completed\",\"item\":{\"type\":\"file_change\",\"changes\":[{\"path\":\"src/cli/tui/index.ts\",\"kind\":\"update\"}]}}\n",
+    });
+
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).toContain("Edit src/cli/tui/index.ts");
+    expect(pane.getActivitySnapshot(120)).toMatchObject({
+      kind: "edit",
+      label: "Edit",
+      detail: "src/cli/tui/index.ts",
+      status: "completed",
+    });
+  });
+
   it("does not render codex lifecycle json lines in the embedded pane", () => {
     pane.addEvent({
       type: "chunk",
@@ -554,7 +674,7 @@ describe("EmbeddedTerminalPane", () => {
     const combined = lines.map((l) => l.text).join("\n");
     expect(combined).toContain("▎");
     expect(combined).toContain("✓");
-    expect(combined).not.toContain("succeeded in 125ms");
+    expect(combined).toContain("succeeded in 125ms");
   });
 
   // T2: exec failed — gutter ▎ + ✗ icon
@@ -570,7 +690,7 @@ describe("EmbeddedTerminalPane", () => {
     const combined = lines.map((l) => l.text).join("\n");
     expect(combined).toContain("▎");
     expect(combined).toContain("✗");
-    expect(combined).not.toContain("failed in 800ms");
+    expect(combined).toContain("failed in 800ms");
   });
 
   // T4: metadata block — ▎ gutter + ▣ adapter badge

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -60,10 +60,25 @@ describe("EmbeddedTerminalPane", () => {
       stream: "stdout",
       data: "{\"type\":\"item.completed\",\"item\":{\"type\":\"assistant_message\",\"text\":\"Detoks is the CLI workspace.\"}}\n",
     });
+    pane.addEvent({ type: "exit", timestamp: Date.now(), data: "0" });
 
     expect(pane.getLastFinalAnswer()).toBe("Detoks is the CLI workspace.");
     const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
     expect(output).toContain("Detoks is the CLI workspace.");
+  });
+
+  it("keeps streamed final-answer candidates hidden until exit", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stdout",
+      data: "{\"type\":\"item.completed\",\"item\":{\"type\":\"assistant_message\",\"text\":\"임시 목표 문장입니다.\"}}\n",
+    });
+
+    expect(pane.getLastFinalAnswer()).toBeNull();
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).not.toContain("최종 결과");
+    expect(output).not.toContain("임시 목표 문장입니다.");
   });
 
   it("does not promote started assistant messages into the final result block", () => {
@@ -76,6 +91,7 @@ describe("EmbeddedTerminalPane", () => {
         "{\"type\":\"item.completed\",\"item\":{\"type\":\"assistant_message\",\"text\":\"최종 요약 결과입니다.\"}}",
       ].join("\n"),
     });
+    pane.addEvent({ type: "exit", timestamp: Date.now(), data: "0" });
 
     expect(pane.getLastFinalAnswer()).toBe("최종 요약 결과입니다.");
     const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
@@ -93,6 +109,7 @@ describe("EmbeddedTerminalPane", () => {
         "{\"type\":\"item.completed\",\"item\":{\"type\":\"assistant_message\",\"text\":\"The workspace contains the detoks CLI project.\"}}",
       ].join("\n"),
     });
+    pane.addEvent({ type: "exit", timestamp: Date.now(), data: "0" });
 
     const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
     expect(output).toContain("최종 결과");
@@ -196,6 +213,19 @@ describe("EmbeddedTerminalPane", () => {
 
     const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
     expect(output).not.toContain("turn.started");
+  });
+
+  it("drops codex router stdin-closed noise after command completion", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stderr",
+      data: "2026-05-18T11:09:19.784823Z ERROR codex_core::tools::router: error-write_stdin failed: stdin is closed for this session; rerun exec_command with tty=true to keep stdin open\n",
+    });
+
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).not.toContain("error-write_stdin failed");
+    expect(output).toContain("원본 CLI 출력");
   });
 
   it("drops ansi-prefixed lifecycle json lines in the embedded pane", () => {

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -418,6 +418,51 @@ describe("orchestratePipeline", () => {
     expect(result.promptInferenceTimeSec).toBeGreaterThanOrEqual(0);
   });
 
+  it("prepends Korean response instructions for embedded-pane execution", async () => {
+    nodeRuntimeMocks.completeChatWithNodeLlamaCpp.mockResolvedValueOnce({
+      content: "Create a new file",
+      raw_response: {
+        choices: [{ message: { content: "Create a new file" } }],
+      },
+      inference_time_sec: 0.01,
+    });
+    executeWithAdapterMock.mockResolvedValueOnce({
+      ok: true,
+      adapter: "codex",
+      rawOutput: "[mock-embedded]",
+      exitCode: 0,
+    });
+
+    await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "stub",
+      verbose: false,
+      presentationMode: "embedded-pane",
+      userRequest: {
+        raw_input: "새 파일을 생성해",
+      },
+      env: {
+        LOCAL_LLM_API_BASE: "http://localhost:11434/v1",
+        LOCAL_LLM_API_KEY: "test-key",
+        LOCAL_LLM_MODEL_NAME: "local-model",
+      },
+      fetchImplementation: vi.fn(async () => new Response(null, { status: 200 })),
+      compressionImplementation: vi.fn(async () => ({
+        compressed: "Create a new file",
+        compression_ratio: 1,
+        tokens_saved: 0,
+      })),
+    });
+
+    expect(executeWithAdapterMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        presentationMode: "embedded-pane",
+        prompt: "Respond entirely in Korean.\n\nCreate a new file",
+      }),
+    );
+  });
+
   it("skips completed tasks from an existing session and resumes remaining work", async () => {
     vi.spyOn(SessionStateManager, "sessionExists").mockResolvedValue(true);
     vi.spyOn(SessionStateManager, "loadSession").mockResolvedValue({


### PR DESCRIPTION
## 요약
- Codex embedded pane에서 `Goal:` / `목표:` 진행 문장이 실행 중에도 보이도록 복구했습니다.
- 최종 결과는 실행 종료 후에만 별도 블록으로 보이도록 유지해 중간 진행 문장이 최종 결과로 오인되지 않게 했습니다.
- Sticky Prompt 라벨을 `현재 지시문`으로 바꾸고, footer에 현재 경로 뒤 브랜치명을 함께 표시하도록 정리했습니다.

## 변경 사항
- `assistant_message`로 들어오는 `Goal:` / `목표:` 문장을 final answer 보류 대상이 아니라 live raw output으로 처리
- embedded pane에서 raw exec 완료 블록 뒤 preview/goal 라인이 다시 표시되도록 복구
- Codex stderr 노이즈(`error-write_stdin failed ...`) 숨김 처리
- `Sticky Prompt` -> `현재 지시문` 라벨 변경
- footer에 `cwd(branch)` 형식 표시 추가
- embedded pane 최종 결과 강조 UI 및 관련 회귀 테스트 보강

## 검증
- `npm run build`
- `npx vitest run tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts`

## 참고
- 작업과 무관한 `.worktrees/`, 로컬 문서, 스크린샷 파일은 포함하지 않았습니다.