### PR TITLE
[codex] filter codex stderr noise in embedded terminal

### DIFF
--- a/src/cli/tui/panels/codex-json.ts
+++ b/src/cli/tui/panels/codex-json.ts
@@ -26,7 +26,7 @@ const CODEX_STDERR_NOISE_PATTERNS = [
   /^\[EXECUTE\]/,
   /^Context:/,
   /^tokens used/,
-  /^.*error-write_stdin failed: stdin is closed for this session\b/i,
+  /^.*error[=-]write_stdin failed: stdin is closed for this session\b/i,
   /^.*rerun exec_command with tty=true to keep stdin open\b/i,
 ] as const;
 

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -1510,18 +1510,22 @@ export class EmbeddedTerminalPane {
     }
 
     const normalized = event.data.replace(/\r\n/g, "\n");
-    const lines = normalized.split("\n");
+    const rawLines = normalized.split("\n");
+    const lines =
+      event.stream === "stderr"
+        ? rawLines.filter((line) => line.length > 0 && !shouldIgnoreCodexNoiseLine(line))
+        : rawLines;
+    const filteredData =
+      event.stream === "stderr"
+        ? `${lines.join("\n")}${normalized.endsWith("\n") && lines.length > 0 ? "\n" : ""}`
+        : event.data;
     const shouldTreatAsStructured = lines.some((line) => hasCodexJsonCandidate(line));
-    const shouldIgnoreAsNoise =
-      event.stream === "stderr" &&
-      lines.every((line) => line.length === 0 || shouldIgnoreCodexNoiseLine(line));
-
-    if (shouldIgnoreAsNoise) {
+    if (event.stream === "stderr" && lines.length === 0) {
       return;
     }
 
     if (!shouldTreatAsStructured) {
-      this.buffer.write(event.data);
+      this.buffer.write(filteredData);
       this.markRenderCacheDirty();
       this.scrollOffset = 0;
       return;

--- a/src/cli/tui/panels/transcript.ts
+++ b/src/cli/tui/panels/transcript.ts
@@ -47,6 +47,8 @@ const CODEX_STDERR_NOISE_PATTERNS = [
   /^\[EXECUTE\]/,
   /^Context:/,
   /^tokens used/,
+  /^.*error[=-]write_stdin failed: stdin is closed for this session\b/i,
+  /^.*rerun exec_command with tty=true to keep stdin open\b/i,
 ] as const;
 
 const stripControlSequences = (value: string): string =>

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts
@@ -291,12 +291,29 @@ describe("EmbeddedTerminalPane", () => {
       type: "chunk",
       timestamp: Date.now(),
       stream: "stderr",
-      data: "2026-05-18T11:09:19.784823Z ERROR codex_core::tools::router: error-write_stdin failed: stdin is closed for this session; rerun exec_command with tty=true to keep stdin open\n",
+      data: "2026-05-18T14:49:28.081255Z ERROR codex_core::tools::router: error=write_stdin failed: stdin is closed for this session; rerun exec_command with tty=true to keep stdin open\n",
     });
 
     const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
-    expect(output).not.toContain("error-write_stdin failed");
+    expect(output).not.toContain("write_stdin failed");
     expect(output).toContain("원본 CLI 출력");
+  });
+
+  it("drops codex router stdin-closed noise from mixed stderr chunks", () => {
+    pane.addEvent({
+      type: "chunk",
+      timestamp: Date.now(),
+      stream: "stderr",
+      data: [
+        "실제 경고는 유지합니다.",
+        "2026-05-18T14:49:28.081255Z ERROR codex_core::tools::router: error=write_stdin failed: stdin is closed for this session; rerun exec_command with tty=true to keep stdin open",
+        "",
+      ].join("\n"),
+    });
+
+    const output = pane.getRenderableLines(120).map((line) => line.text).join("\n");
+    expect(output).toContain("실제 경고는 유지합니다.");
+    expect(output).not.toContain("write_stdin failed");
   });
 
   it("drops ansi-prefixed lifecycle json lines in the embedded pane", () => {


### PR DESCRIPTION
## What changed
- filter Codex router `write_stdin failed: stdin is closed for this session` stderr noise in the embedded terminal while preserving real stderr lines in mixed chunks
- expand stderr noise matching to catch both `error-write_stdin` and `error=write_stdin` variants in the shared panel/transcript filters
- add regression coverage for noise-only and mixed stderr chunks

## Why
The embedded pane was surfacing internal Codex router stderr noise that should be hidden from the UI, and mixed stderr chunks could drop useful output along with the noise.

## Impact
- cleaner embedded terminal and transcript output
- real warnings/errors remain visible

## Validation
- `npx vitest run tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts`