### PR TITLE
Fix task graph collapse and preserve pipeline task prompts

### DIFF
--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -402,6 +402,40 @@ function collectTaskOutputText(state: SessionState): {
   return { rawOutputText, summaryText };
 }
 
+function collectDisplayOutputTextFromState(state: SessionState): string {
+  const taskResults = state.task_results ?? {};
+  const tasks = state.task_graph?.tasks ?? [];
+  const completedIds = state.completed_task_ids ?? [];
+  if (tasks.length > 0) {
+    const dependencyIds = new Set(tasks.flatMap((task) => task.depends_on));
+    const terminalTasks = tasks.filter((task) => !dependencyIds.has(task.id));
+    for (const task of terminalTasks.reverse()) {
+      if (!completedIds.includes(task.id)) continue;
+      const rawOutput = (taskResults[task.id] as Record<string, unknown> | undefined)?.raw_output;
+      if (typeof rawOutput === "string" && rawOutput.trim().length > 0) {
+        return rawOutput;
+      }
+    }
+  }
+
+  const completedOutputs = completedIds
+    .map((id) => (taskResults[id] as Record<string, unknown> | undefined)?.raw_output)
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+  const lastCompletedOutput = completedOutputs.at(-1);
+  if (lastCompletedOutput) return lastCompletedOutput;
+
+  return Object.values(taskResults)
+    .map((result) => (result as Record<string, unknown>).raw_output)
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .at(-1) ?? "";
+}
+
+function collectDisplayOutputTextFromRecords(records: TaskExecutionRecord[]): string {
+  return records
+    .filter((record) => record.status === "completed" && record.rawOutput.trim().length > 0)
+    .at(-1)?.rawOutput ?? records.map((record) => record.rawOutput).filter(Boolean).join("\n---\n");
+}
+
 function applySessionTokenMetrics(
   state: SessionState,
   inputOriginalText: string,
@@ -686,7 +720,7 @@ export const orchestratePipeline = async (
           summary: `F1 캐시 hit — 세션 ${cachedSessionId} (${Math.round(cacheAge / 86400000)}일 전)`,
         }),
       );
-      const { rawOutputText, summaryText } = collectTaskOutputText(cachedSession!);
+      const { summaryText } = collectTaskOutputText(cachedSession!);
       return {
         ok: true,
         mode: request.mode,
@@ -695,7 +729,7 @@ export const orchestratePipeline = async (
         nextAction: cachedSession!.next_action ?? "캐시된 결과를 반환했습니다.",
         originalPrompt: request.userRequest.raw_input,
         stages: buildPipelineStages(true),
-        rawOutput: rawOutputText,
+        rawOutput: collectDisplayOutputTextFromState(cachedSession!),
         sessionId: cachedSessionId,
         taskRecords: cachedSession!.completed_task_ids.map((id) => ({
           taskId: id,
@@ -1646,7 +1680,9 @@ export const orchestratePipeline = async (
     originalPrompt: request.userRequest.raw_input,
     tokenMetrics: sessionTokenMetrics.tokenMetrics,
     stages: buildPipelineStages(allOk),
-    rawOutput: taskRecords.map((r) => r.rawOutput).filter(Boolean).join("\n---\n"),
+    rawOutput: allOk
+      ? collectDisplayOutputTextFromState(state)
+      : collectDisplayOutputTextFromRecords(taskRecords),
     sessionId,
     taskRecords,
     ...(adapterTranscript ? { adapterTranscript } : {}),

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1397,23 +1397,15 @@ export const orchestratePipeline = async (
         }
 
         // (6) LLM 실행
-        // embedded-pane: codex exec은 단순 작업 설명만 기대 — 구조화된 템플릿은 모델을 혼란시킴.
-        // 다른 모드: 번역된 원본 명령 + RAG 컨텍스트 + 태스크 정보 포함.
-        let prompt: string;
-        if (request.presentationMode === "embedded-pane") {
-          // 한국어 입력이면 응답 언어 지시를 앞에 붙여 codex가 한국어로 응답하도록 한다.
-          prompt = responseLanguageInstruction
-            ? `${responseLanguageInstruction}${compiledPrompt.compressed_prompt}`
-            : compiledPrompt.compressed_prompt;
-        } else {
-          const promptParts: string[] = [];
-          if (responseLanguageInstruction) promptParts.push(responseLanguageInstruction.trimEnd());
-          if (ragContext) promptParts.push(ragContext.trimEnd());
-          promptParts.push(`[${task.type.toUpperCase()}] ${task.title}`);
-          promptParts.push(`User request: ${compiledPrompt.compressed_prompt}`);
-          promptParts.push(`Context: ${executionContext.context_summary}`);
-          prompt = promptParts.join("\n\n");
-        }
+        // 모든 presentation mode에서 task-specific 지시를 유지한다.
+        // embedded-pane도 원본 프롬프트만 넘기면 여러 task가 같은 일을 반복할 수 있다.
+        const promptParts: string[] = [];
+        if (responseLanguageInstruction) promptParts.push(responseLanguageInstruction.trimEnd());
+        if (ragContext) promptParts.push(ragContext.trimEnd());
+        promptParts.push(`[${task.type.toUpperCase()}] ${task.title}`);
+        promptParts.push(`User request: ${compiledPrompt.compressed_prompt}`);
+        promptParts.push(`Context: ${executionContext.context_summary}`);
+        const prompt = promptParts.join("\n\n");
         if (process.env.DETOKS_DEBUG_ADAPTER_PROMPT === "1") {
           process.stderr.write(
             `[adapter-prompt] task=${task.id} type=${task.type} bytes=${Buffer.byteLength(prompt, "utf8")}\n` +

--- a/src/core/task-graph/TaskGraphProcessor.ts
+++ b/src/core/task-graph/TaskGraphProcessor.ts
@@ -28,6 +28,18 @@ import type { Task, TaskGraph, RequestCategory } from "../../schemas/pipeline.js
  *     → ParallelClassifier.classify()
  */
 export class TaskGraphProcessor {
+  private static readonly DELIVERABLE_TYPES = new Set<RequestCategory>([
+    "create",
+    "document",
+    "plan",
+  ]);
+
+  private static readonly DELIVERABLE_PATTERN =
+    /\b(presentation|slides?|deck|outline|structure|report|proposal|script|summary|brief|document|docs|guide|plan|roadmap|table|matrix|comparison|q&a|questions?|talk\s+track|message|copy|email|memo|one[-\s]?pager)\b/i;
+
+  private static readonly INDEPENDENT_ACTION_START_PATTERN =
+    /^(?:find|locate|trace|track|follow|show|tell|read|search|explore|browse|inspect|analyze|investigate|explain|diagnose|review|compare|assess|evaluate|create|build|generate|scaffold|implement|add|make|draft|set up|spin up|bootstrap|modify|update|change|fix|patch|edit|refactor|rename|rewrite|remove|replace|improve|optimi[sz]e|tune|correct|enable|disable|toggle|test|validate|verify|assert|confirm|ensure|check|lint|typecheck|run|execute|deploy|start|launch|restart|stop|install|migrate|seed|serve|document|summari[sz]e|describe|write|prepare|plan|design|organize|outline|strategize|propose|break down)\b/i;
+
   // 'make' 등 단일 키워드가 create/modify 패턴에 먼저 걸리는 숙어들을 TYPE_PATTERNS보다 먼저 처리.
   // 패턴 순서가 바뀌어도 이 테이블의 판정은 항상 우선한다.
   private static readonly IDIOM_PATTERNS: ReadonlyArray<{
@@ -255,6 +267,14 @@ export class TaskGraphProcessor {
     // ① 먼저 모든 문장의 type을 한 번에 분류 — resolveDependsOn에서 이전 type을 참조하기 때문
     const types: RequestCategory[] = sentences.map((s) => this.classifyType(s));
 
+    if (this.shouldCollapseSingleDeliverable(sentences, types)) {
+      const finalType = types[types.length - 1]!;
+      const mergedSentence = sentences.join(" ");
+      return TaskGraphSchema.parse({
+        tasks: [this.buildTask(mergedSentence, 0, finalType, [])],
+      });
+    }
+
     // ② 각 문장을 Task로 변환하면서 depends_on 결정
     const tasks: Task[] = sentences.map((sentence, index) => {
       const type = types[index]!;
@@ -285,6 +305,32 @@ export class TaskGraphProcessor {
     const curr = types[index] as RequestCategory;
     // t1, t2, t3... — index는 0-based이므로 이전 task id는 `t${index}` (1-based 기준)
     return this.FLOWS_TO[prev]?.includes(curr) ? [`t${index}`] : [];
+  }
+
+  private static shouldCollapseSingleDeliverable(
+    sentences: string[],
+    types: RequestCategory[],
+  ): boolean {
+    if (sentences.length < 2) return false;
+
+    const finalSentence = sentences[sentences.length - 1]!;
+    const finalType = types[types.length - 1]!;
+    if (!this.DELIVERABLE_TYPES.has(finalType)) return false;
+    if (!this.DELIVERABLE_PATTERN.test(finalSentence)) return false;
+
+    const prefixSentences = sentences.slice(0, -1);
+    const prefixTypes = types.slice(0, -1);
+    return prefixSentences.every((sentence, index) =>
+      this.isContextQualifier(sentence, prefixTypes[index]!),
+    );
+  }
+
+  private static isContextQualifier(
+    sentence: string,
+    type: RequestCategory,
+  ): boolean {
+    if (type !== "execute") return false;
+    return !this.INDEPENDENT_ACTION_START_PATTERN.test(sentence.trim());
   }
 
   /**

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -516,6 +516,38 @@ describe("orchestratePipeline", () => {
     );
   });
 
+  it("returns only the terminal task output for successful multi-task runs", async () => {
+    executeWithAdapterMock
+      .mockResolvedValueOnce({
+        ok: true,
+        adapter: "codex",
+        rawOutput: "[mock] explored module",
+        exitCode: 0,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        adapter: "codex",
+        rawOutput: "[mock] final analysis",
+        exitCode: 0,
+      });
+
+    const result = await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "stub",
+      verbose: false,
+      userRequest: {
+        raw_input: "Find the module. Analyze the flow.",
+      },
+    });
+
+    expect(result.taskRecords).toEqual([
+      { taskId: "t1", status: "completed", rawOutput: "[mock] explored module" },
+      { taskId: "t2", status: "completed", rawOutput: "[mock] final analysis" },
+    ]);
+    expect(result.rawOutput).toBe("[mock] final analysis");
+  });
+
   it("skips completed tasks from an existing session and resumes remaining work", async () => {
     vi.spyOn(SessionStateManager, "sessionExists").mockResolvedValue(true);
     vi.spyOn(SessionStateManager, "loadSession").mockResolvedValue({
@@ -719,6 +751,72 @@ describe("orchestratePipeline", () => {
     expect(result.cacheHit?.kind).toBe("session");
     expect(result.cacheHit?.sourceSessionId).toBe("cached-session");
     expect(result.rawOutput).toContain("cached output");
+    expect(executeWithAdapterMock).not.toHaveBeenCalled();
+  });
+
+  it("F1: 캐시된 multi-task 세션은 terminal task output만 반환한다", async () => {
+    const cachedSession = {
+      shared_context: {
+        session_id: "cached-multi-session",
+        raw_input_hash: "willbematched",
+        project_id: "git-test123",
+        failed_task_ids: [],
+      },
+      task_results: {
+        t1: {
+          task_id: "t1",
+          success: true,
+          raw_output: "cached explore output",
+          summary: "cached explore output",
+        },
+        t2: {
+          task_id: "t2",
+          success: true,
+          raw_output: "cached final output",
+          summary: "cached final output",
+        },
+      },
+      current_task_id: null,
+      completed_task_ids: ["t1", "t2"],
+      task_graph: {
+        tasks: [
+          {
+            id: "t1",
+            type: "explore",
+            status: "pending",
+            title: "Find the module.",
+            input_hash: "hash1",
+            depends_on: [],
+          },
+          {
+            id: "t2",
+            type: "analyze",
+            status: "pending",
+            title: "Analyze the flow.",
+            input_hash: "hash2",
+            depends_on: ["t1"],
+          },
+        ],
+      },
+      last_summary: "2개 작업을 모두 완료했습니다",
+      next_action: "파이프라인이 완료되었습니다.",
+      updated_at: new Date().toISOString(),
+    };
+    vi.spyOn(SessionStateManager, "findSuccessfulSessionByInputHash").mockResolvedValue(
+      cachedSession as any,
+    );
+
+    const result = await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "real",
+      verbose: false,
+      projectInfo: { projectId: "git-test123", projectPath: "/test", projectName: "test" },
+      userRequest: { raw_input: "cached prompt" },
+    });
+
+    expect(result.rawOutput).toBe("cached final output");
+    expect(result.taskRecords).toHaveLength(2);
     expect(executeWithAdapterMock).not.toHaveBeenCalled();
   });
 

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -458,7 +458,60 @@ describe("orchestratePipeline", () => {
     expect(executeWithAdapterMock).toHaveBeenCalledWith(
       expect.objectContaining({
         presentationMode: "embedded-pane",
-        prompt: "Respond entirely in Korean.\n\nCreate a new file",
+        prompt: expect.stringContaining("[CREATE] Create a new file"),
+      }),
+    );
+    expect(executeWithAdapterMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("Respond entirely in Korean."),
+      }),
+    );
+    expect(executeWithAdapterMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("User request: Create a new file"),
+      }),
+    );
+  });
+
+  it("keeps task-specific instructions in embedded-pane execution", async () => {
+    nodeRuntimeMocks.completeChatWithNodeLlamaCpp.mockResolvedValueOnce({
+      content: "Find the module. Analyze the flow.",
+      raw_response: {
+        choices: [{ message: { content: "Find the module. Analyze the flow." } }],
+      },
+      inference_time_sec: 0.01,
+    });
+    executeWithAdapterMock.mockResolvedValue({
+      ok: true,
+      adapter: "codex",
+      rawOutput: "[mock-embedded]",
+      exitCode: 0,
+    });
+
+    await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "stub",
+      verbose: false,
+      presentationMode: "embedded-pane",
+      userRequest: {
+        raw_input: "Find the module. Analyze the flow.",
+      },
+    });
+
+    expect(executeWithAdapterMock).toHaveBeenCalledTimes(2);
+    expect(executeWithAdapterMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        presentationMode: "embedded-pane",
+        prompt: expect.stringContaining("[EXPLORE] Find the module."),
+      }),
+    );
+    expect(executeWithAdapterMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        presentationMode: "embedded-pane",
+        prompt: expect.stringContaining("[ANALYZE] Analyze the flow."),
       }),
     );
   });

--- a/tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts
+++ b/tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts
@@ -178,6 +178,41 @@ describe("TaskGraphProcessor", () => {
   });
 
   describe("multi 요청 — sequential 흐름", () => {
+    it("단일 산출물 요청의 컨텍스트 문장들은 하나의 create task로 병합한다", () => {
+      const result = TaskGraphProcessor.process({
+        sentences: [
+          "Next week prepare for the Hyundai IT team meeting.",
+          "From the perspective of AI PC adoption, focus on the advantages of Intel vPro and Core Ultra.",
+          "Create a presentation structure for 15 covering customer concerns, anticipated questions, key points compared to competitors, and reflect any content from the previous meeting.",
+        ],
+      });
+
+      expect(result.tasks).toHaveLength(1);
+      expect(result.tasks[0]).toMatchObject({
+        id: "t1",
+        type: "create",
+        depends_on: [],
+        title: "Next week prepare for the Hyundai IT team meeting. From the perspective of AI PC adoption, focus on the advantages of Intel vPro and Core Ultra. Create a presentation structure for 15 covering customer concerns, anticipated questions, key points compared to competitors, and reflect any content from the previous meeting.",
+      });
+    });
+
+    it("명시적인 선행 작업이 있는 산출물 요청은 병합하지 않는다", () => {
+      const result = TaskGraphProcessor.process({
+        sentences: [
+          "Fetch last month's sales data from the database",
+          "Analyze the differences",
+          "Create a visualization chart",
+        ],
+      });
+
+      expect(result.tasks).toHaveLength(3);
+      expect(result.tasks.map((task) => task.type)).toEqual([
+        "execute",
+        "analyze",
+        "create",
+      ]);
+    });
+
     it("explore → analyze → modify 흐름은 순차 의존을 생성한다", () => {
       const result = TaskGraphProcessor.process({
         sentences: [


### PR DESCRIPTION
## 요약

- 단일 산출물 요청에서 배경/관점 문장이 별도 task로 쪼개져 같은 답변이 반복되는 문제를 수정했습니다.
- `TaskGraphProcessor`에 single-deliverable collapse 로직을 추가해, 마지막 문장이 발표 구조/보고서/스크립트 등 하나의 산출물 생성 요청이고 앞 문장들이 컨텍스트인 경우 1개 task로 병합합니다.
- `embedded-pane` 실행에서도 task-specific prompt(`[TYPE] title`, 원본 요청, context, RAG context)를 유지하도록 수정했습니다.
- 성공한 multi-task 실행과 F1 세션 캐시 hit에서 최종 사용자 출력은 terminal task output 중심으로 반환하고, `taskRecords`에는 전체 task 결과를 계속 보존합니다.

## 관련 이슈

- Closes #

## 변경 유형

- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩터링
- [ ] 문서 수정
- [x] 테스트 추가/수정

## 영향 범위

영향받는 모듈:

- `src/core/task-graph/TaskGraphProcessor.ts`
  - single-deliverable 요청 병합 로직 추가
- `src/core/pipeline/orchestrator.ts`
  - embedded-pane prompt 조립 방식 수정
  - 반환용 `rawOutput` 선택 로직 수정
- `tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts`
  - 단일 산출물 collapse 회귀 테스트 추가
- `tests/ts/unit/core/pipeline/orchestrator.test.ts`
  - embedded-pane task-specific prompt 회귀 테스트 추가
  - terminal task output 반환 회귀 테스트 추가

영향받지 않는 모듈:

- `src/core/task-graph/TaskSentenceSplitter.ts`
- `src/core/task-graph/DAGValidator.ts`
- `src/core/task-graph/DependencyResolver.ts`
- `src/core/task-graph/ParallelClassifier.ts`
- adapter subprocess request 생성 경계
- 세션 저장 포맷과 `taskRecords` 전체 보존 계약

## 수정 내역 상세

### 1. Single Deliverable Collapse

기존에는 아래 입력이 문장 단위로 분리되어 `execute → execute → create` 식으로 실행됐다.

```text
Next week prepare for the Hyundai IT team meeting.
From the perspective of AI PC adoption, focus on the advantages of Intel vPro and Core Ultra.
Create a presentation structure for 15 covering customer concerns, anticipated questions, key points compared to competitors, and reflect any content from the previous meeting.
```

변경 후에는 마지막 문장이 하나의 산출물 요청이고, 앞 문장들이 실제 독립 작업이 아닌 컨텍스트 문장으로 판단되면 1개 `create` task로 병합한다.

```text
t1 create:
Next week prepare for the Hyundai IT team meeting. From the perspective ...
Create a presentation structure ...
```

병합 조건은 보수적으로 잡았다.

- 마지막 task type이 `create`, `document`, `plan` 중 하나
- 마지막 문장에 `presentation`, `deck`, `outline`, `report`, `proposal`, `script`, `summary`, `brief`, `plan` 등 산출물 키워드 포함
- 앞 문장들이 `execute` fallback으로 분류됐고 독립 action starter로 시작하지 않음

따라서 아래처럼 명시적인 순차 작업은 계속 여러 task로 유지된다.

```text
Fetch last month's sales data from the database
Analyze the differences
Create a visualization chart
```

### 2. Embedded Pane Prompt 복구

기존 `embedded-pane`은 task별 title/context를 제거하고 전체 원본 프롬프트만 adapter에 전달했다.

```ts
prompt = responseLanguageInstruction
  ? `${responseLanguageInstruction}${compiledPrompt.compressed_prompt}`
  : compiledPrompt.compressed_prompt;
```

이 때문에 multi-task graph가 만들어진 경우 각 task가 같은 원본 요청을 반복 수행했다.

변경 후에는 모든 presentation mode에서 같은 task-specific 구조를 사용한다.

```ts
const promptParts: string[] = [];
if (responseLanguageInstruction) promptParts.push(responseLanguageInstruction.trimEnd());
if (ragContext) promptParts.push(ragContext.trimEnd());
promptParts.push(`[${task.type.toUpperCase()}] ${task.title}`);
promptParts.push(`User request: ${compiledPrompt.compressed_prompt}`);
promptParts.push(`Context: ${executionContext.context_summary}`);
const prompt = promptParts.join("\n\n");
```

### 3. Terminal Task Output 반환

기존 반환용 `rawOutput`은 모든 task output을 `---`로 이어 붙였다.

```ts
rawOutput: taskRecords.map((r) => r.rawOutput).filter(Boolean).join("\n---\n")
```

이 때문에 UI 최종 답변 영역과 F1 cache hit 결과에서 유사 답변이 여러 번 노출됐다.

변경 후에는 다음 기준으로 표시용 output을 고른다.

1. `task_graph`가 있으면 다른 task의 dependency가 아닌 terminal task를 찾는다.
2. terminal task 중 완료됐고 `raw_output`이 있는 마지막 task output을 반환한다.
3. fallback으로 마지막 completed task output을 반환한다.
4. 실패 케이스는 기존처럼 실패/스킵 기록을 확인할 수 있도록 task record 기반 fallback을 사용한다.

`taskRecords`는 그대로 전체 task 결과를 담으므로 디버깅 정보와 상태 패널 표시에는 영향이 없다.

## 테스트 방법

### Task graph 회귀 테스트

```bash
npx --no-install vitest run \
  tests/ts/unit/core/task-graph/TaskGraphProcessor.test.ts \
  tests/ts/unit/core/task-graph/TaskSentenceSplitter.test.ts
```

결과:

```text
Test Files  2 passed (2)
Tests       159 passed (159)
```

### Orchestrator 회귀 테스트

```bash
npx --no-install vitest run tests/ts/unit/core/pipeline/orchestrator.test.ts
```

결과:

```text
Test Files  1 passed (1)
Tests       18 passed | 1 skipped (19)
```

### 빌드

```bash
npm run build
```

결과:

```text
> @sorlros/detoks@0.1.2 build
> npx --no-install tsc -p tsconfig.json

(0 errors)
```

## 체크리스트

- [x] 로컬에서 테스트했습니다
- [x] 필요한 테스트를 추가/수정했습니다
- [x] 기존 multi-step task graph 동작을 유지하는 회귀 테스트를 추가했습니다
- [x] embedded-pane에서 task-specific prompt가 유지됨을 확인했습니다
- [x] F1 cache hit 결과도 terminal task output 중심으로 표시됨을 확인했습니다
- [x] 브레이킹 체인지 여부를 확인했습니다
- [x] 리뷰하기 좋은 크기로 커밋을 분리했습니다

## 커밋 목록

| 커밋 | 내용 |
|---|---|
| `edf8b2c` | `fix(task-graph): collapse single deliverable context` |
| `793b90f` | `test(task-graph): cover single deliverable collapse` |
| `4476804` | `fix(pipeline): preserve task prompts in embedded pane` |
| `62b3b49` | `fix(pipeline): show terminal task output` |

## 리뷰어 참고사항

- 이번 PR은 반복 답변의 원인을 세 단계로 나눠 해결한다.
  - P0: graph 생성 단계에서 단일 산출물 요청을 1 task로 병합
  - P1: embedded-pane에서도 task별 지시를 유지
  - P2: 최종 표시 output은 terminal task 중심으로 반환
- `TaskSentenceSplitter`는 변경하지 않았다. 문장 분리 정책 전체를 바꾸면 기존 multi-step 워크플로우 영향이 커지므로, 병합은 `TaskGraphProcessor` 후처리로 제한했다.
- terminal output 선택은 표시용 `PipelineExecutionResult.rawOutput`에만 적용된다. 세션 파일의 `task_results`, `taskRecords`, token metrics용 전체 output 수집은 유지된다.
- 산출물 키워드 목록은 보수적으로 시작했다. 실제 사용 중 `worksheet`, `runbook`, `playbook` 등 반복 사례가 확인되면 `DELIVERABLE_PATTERN`에 추가하면 된다.
