### PR TITLE
embedded TUI 승인 흐름 복구

### DIFF
--- a/scripts/translate-model-benchmark-report.ts
+++ b/scripts/translate-model-benchmark-report.ts
@@ -14,12 +14,16 @@ import {
 	translate_to_english,
 	type TranslateToEnglishResult,
 } from "../src/core/translate/translate.js";
+import { getDetoksModelFilePath } from "../src/core/model-store.js";
+import { KURE_EMBEDDING_MODEL } from "../src/cli/model-setup/models.js";
 
 type JsonObject = Record<string, unknown>;
 
-const DEFAULT_EMBEDDING_MODEL_PATH =
-	"/Users/siho/.detoks/models/embedding/mykor-KURE-v1-gguf";
 const DEFAULT_EMBEDDING_MODEL_FILE = "KURE-v1-Q4_K_M.gguf";
+
+const getDefaultEmbeddingModelPath = (): string =>
+	process.env.RAG_EMBEDDING_MODEL_PATH?.trim() ||
+	getDetoksModelFilePath(KURE_EMBEDDING_MODEL);
 
 interface BenchmarkArgs {
 	modelsPath?: string;
@@ -134,7 +138,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): BenchmarkArgs
 	let benchmarkOutputDir = "tmp/translate-model-benchmark";
 	let reportOutputPath = "docs/TRANSLATE_MODEL_BENCHMARK_REPORT.md";
 	let title = "번역 모델 벤치마크 분석";
-	let embeddingModelPath = DEFAULT_EMBEDDING_MODEL_PATH;
+	let embeddingModelPath = getDefaultEmbeddingModelPath();
 
 	for (let i = 0; i < argv.length; i += 1) {
 		const current = argv[i];

--- a/src/cli/adapter-info/gemini.ts
+++ b/src/cli/adapter-info/gemini.ts
@@ -27,6 +27,34 @@ const getGeminiConfigPath = (): string => {
   return join(homedir(), ".gemini", "settings.json");
 };
 
+const getGeminiOAuthCredsPath = (): string => {
+  return join(homedir(), ".gemini", "oauth_creds.json");
+};
+
+const hasFreshGeminiOAuthAccessToken = (): boolean => {
+  try {
+    const parsed = JSON.parse(readFileSync(getGeminiOAuthCredsPath(), "utf-8")) as {
+      access_token?: unknown;
+      expiry_date?: unknown;
+    };
+    const expiryDate =
+      typeof parsed.expiry_date === "number"
+        ? parsed.expiry_date
+        : typeof parsed.expiry_date === "string"
+          ? Number.parseInt(parsed.expiry_date, 10)
+          : NaN;
+
+    return (
+      typeof parsed.access_token === "string" &&
+      parsed.access_token.trim().length > 0 &&
+      Number.isFinite(expiryDate) &&
+      expiryDate > Date.now()
+    );
+  } catch {
+    return false;
+  }
+};
+
 export const getGeminiConfig = (): GeminiConfig => {
   const cached = readCache<GeminiConfig>("adapter-config", "gemini", CACHE_TTL_MS.adapterConfig);
   if (cached) {
@@ -54,9 +82,15 @@ export const getGeminiLoginStatus = (): GeminiLoginStatus => {
   }
 
   const config = getGeminiConfig();
+  const authType = config.authType;
+  const authenticated = authType
+    ? authType.toLowerCase().includes("oauth")
+      ? hasFreshGeminiOAuthAccessToken()
+      : true
+    : false;
   const status = {
-    authenticated: !!config.authType,
-    authType: config.authType,
+    authenticated,
+    authType,
   };
 
   writeCache("adapter-status", "gemini", status, CACHE_TTL_MS.adapterStatus);
@@ -69,7 +103,7 @@ export const getGeminiAvailableModels = () => {
 
 export const geminiLogout = (): boolean => {
   try {
-    const configPath = join(homedir(), ".gemini", "oauth_creds.json");
+    const configPath = getGeminiOAuthCredsPath();
     if (existsSync(configPath)) {
       unlinkSync(configPath);
     }

--- a/src/cli/cache/cache-manager.ts
+++ b/src/cli/cache/cache-manager.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { getDetoksHomeDir } from "../../core/state/storage-paths.js";
 
 export interface CacheEntry<T> {
   version: 1;
@@ -11,9 +11,7 @@ export interface CacheEntry<T> {
 
 const CACHE_VERSION = 1 as const;
 
-const getHomeDir = (): string => process.env.HOME ?? homedir();
-
-export const getDetoksCacheDir = (): string => join(getHomeDir(), ".detoks", "cache");
+export const getDetoksCacheDir = (): string => join(getDetoksHomeDir(), "cache");
 
 const getCacheFilePath = (namespace: string, key: string): string =>
   join(getDetoksCacheDir(), namespace, `${key}.json`);
@@ -65,17 +63,22 @@ export const writeCache = <T>(
   value: T,
   ttlMs: number,
 ): void => {
-  ensureCacheDir(namespace);
+  try {
+    ensureCacheDir(namespace);
 
-  const filePath = getCacheFilePath(namespace, key);
-  const payload: CacheEntry<T> = {
-    version: CACHE_VERSION,
-    cachedAt: new Date().toISOString(),
-    ttlMs,
-    value,
-  };
+    const filePath = getCacheFilePath(namespace, key);
+    const payload: CacheEntry<T> = {
+      version: CACHE_VERSION,
+      cachedAt: new Date().toISOString(),
+      ttlMs,
+      value,
+    };
 
-  writeFileSync(filePath, JSON.stringify(payload, null, 2), "utf-8");
+    writeFileSync(filePath, JSON.stringify(payload, null, 2), "utf-8");
+  } catch {
+    // Cache writes are best-effort: auth/status/model flows must still work
+    // when DETOKS_HOME or ~/.detoks is not writable in constrained runtimes.
+  }
 };
 
 export const invalidateCache = (namespace: string, key: string): void => {

--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -462,6 +462,7 @@ export const runReplCommand = async (baseArgs: CliArgs): Promise<void> => {
 
       const tuiOptions: any = {
         adapter: baseArgs.adapter,
+        ...(baseArgs.adapterExplicit ? { adapterExplicit: true } : {}),
         executionMode: baseArgs.executionMode,
         verbose: baseArgs.verbose,
         cwd: executionCwd,

--- a/src/cli/config/config-manager.ts
+++ b/src/cli/config/config-manager.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import type { Adapter } from "../../core/pipeline/types.js";
+import { getDetoksHomeDir } from "../../core/state/storage-paths.js";
 import type { DetoksConfig } from "./types.js";
 import {
   CODEX_REASONING_EFFORT_VALUES,
@@ -10,7 +10,7 @@ import {
 import { DEFAULT_CONFIG } from "./types.js";
 
 const getConfigDir = (): string => {
-  return join(homedir(), ".detoks");
+  return getDetoksHomeDir();
 };
 
 const getConfigPath = (): string => {

--- a/src/cli/model-setup/custom-store.ts
+++ b/src/cli/model-setup/custom-store.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { getDetoksHomeDir } from "../../core/state/storage-paths.js";
 
 interface StoredCustomModel {
   hfRepo: string;
@@ -11,7 +11,7 @@ interface StoredCustomModel {
 }
 
 const getStorePath = (): string =>
-  join(homedir(), ".detoks", "custom-models.json");
+  join(getDetoksHomeDir(), "custom-models.json");
 
 export const loadLastCustomModel = (): StoredCustomModel | null => {
   const path = getStorePath();
@@ -28,7 +28,7 @@ export const loadLastCustomModel = (): StoredCustomModel | null => {
 
 export const saveCustomModel = (model: StoredCustomModel): void => {
   const path = getStorePath();
-  mkdirSync(join(homedir(), ".detoks"), { recursive: true });
+  mkdirSync(getDetoksHomeDir(), { recursive: true });
 
   const list: StoredCustomModel[] = [
     { ...model, savedAt: new Date().toISOString() },

--- a/src/cli/model-setup/index.ts
+++ b/src/cli/model-setup/index.ts
@@ -14,9 +14,18 @@ import {
 const getModelFileStatus = (model: TranslationModel) =>
   inspectLocalModelFile(getDetoksModelFilePath(model));
 
-export const ensureEmbeddingModelReady = async (cwd: string = process.cwd()): Promise<void> => {
+export const ensureEmbeddingModelReady = async (
+  cwd: string = process.cwd(),
+  options: { allowDownload?: boolean } = {},
+): Promise<void> => {
   const embeddingModelPath = getDetoksModelFilePath(KURE_EMBEDDING_MODEL);
   const status = inspectLocalModelFile(embeddingModelPath);
+  const allowDownload =
+    options.allowDownload ?? (Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY));
+
+  if (!allowDownload && shouldDownloadModelFile(status)) {
+    return;
+  }
 
   if (status.kind === "invalid") {
     process.stdout.write(

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -290,6 +290,7 @@ const assertPrompt = (prompt: string | undefined): string => {
 export const parseCliArgs = (argv: string[]): CliArgs => {
   const positionals: string[] = [];
   let adapter: CliArgs["adapter"] = DEFAULT_ADAPTER;
+  let adapterExplicit = false;
   let executionMode: CliArgs["executionMode"] = DEFAULT_EXECUTION_MODE;
   let sessionId: string | undefined;
   let cwd: string | undefined;
@@ -408,6 +409,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
         throw new Error(`지원하지 않는 adapter: ${next}. codex, gemini, 또는 claude를 사용하세요.`);
       }
       adapter = next;
+      adapterExplicit = true;
       i += 1;
       continue;
     }
@@ -418,6 +420,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
         throw new Error(`지원하지 않는 adapter: ${inline}. codex, gemini, 또는 claude를 사용하세요.`);
       }
       adapter = inline;
+      adapterExplicit = true;
       continue;
     }
 
@@ -528,6 +531,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
         ...(cwd ? { cwd } : {}),
         ...(human ? { human: true } : {}),
         adapter,
+        ...(adapterExplicit ? { adapterExplicit: true } : {}),
         executionMode,
         verbose,
         trace,
@@ -759,6 +763,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
         ...(cwd ? { cwd } : {}),
         ...(sessionId ? { sessionId } : {}),
         adapter,
+        ...(adapterExplicit ? { adapterExplicit: true } : {}),
         executionMode,
         verbose,
         trace,
@@ -778,6 +783,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
       inputFile,
       ...(cwd ? { cwd } : {}),
       adapter,
+      ...(adapterExplicit ? { adapterExplicit: true } : {}),
       executionMode,
       verbose,
       trace,
@@ -793,6 +799,7 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     ...(cwd ? { cwd } : {}),
     ...(sessionId ? { sessionId } : {}),
     adapter,
+    ...(adapterExplicit ? { adapterExplicit: true } : {}),
     executionMode,
     verbose,
     trace,

--- a/src/cli/repl-commands/index.ts
+++ b/src/cli/repl-commands/index.ts
@@ -1,4 +1,5 @@
 import { stdout as output } from "node:process";
+import { join } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { spawnSync } from "node:child_process";
 import type { Adapter } from "../../core/pipeline/types.js";
@@ -18,6 +19,7 @@ import { invalidateCache } from "../cache/cache-manager.js";
 import { getCacheStats, clearExpiredSessions, formatCacheStats } from "./cache-command.js";
 import { CACHE_TTL_DAYS } from "../../core/cache/cache-config.js";
 import { resolveSessionsDir } from "../../core/state/SessionStateManager.js";
+import { getDetoksHomeDir } from "../../core/state/storage-paths.js";
 import {
   getCodexReasoningEffortOverride,
   updateAdapterModel,
@@ -115,6 +117,8 @@ const BASE_COMMANDS: SlashCommand[] = [
     usage: "/exit",
   },
 ];
+
+const getSettingsPathLabel = (): string => join(getDetoksHomeDir(), "settings.json");
 
 const getAuthenticatedCommands = (
   adapter: Adapter,
@@ -682,7 +686,7 @@ export const handleCodexModels = async (streams?: SelectWithArrowsStreams): Prom
       }
     }
 
-    output.write(colors.muted(`  설정 저장됨: ~/.detoks/settings.json\n\n`));
+    output.write(colors.muted(`  설정 저장됨: ${getSettingsPathLabel()}\n\n`));
     shouldResumeInput = false;
     return true;
   } finally {
@@ -782,7 +786,7 @@ export const handleGeminiModels = async (streams?: SelectWithArrowsStreams): Pro
     updateAdapterModel("gemini", selected);
     output.write(
       colors.muted(
-        `  설정 저장됨: ~/.detoks/settings.json\n\n`,
+        `  설정 저장됨: ${getSettingsPathLabel()}\n\n`,
       ),
     );
   }
@@ -810,7 +814,7 @@ export const handleClaudeModels = async (streams?: SelectWithArrowsStreams): Pro
     updateAdapterModel("claude", selected);
     output.write(
       colors.muted(
-        `  설정 저장됨: ~/.detoks/settings.json\n\n`,
+        `  설정 저장됨: ${getSettingsPathLabel()}\n\n`,
       ),
     );
   }
@@ -884,7 +888,7 @@ const applySelectedModel = async (selectedModel: TranslationModel): Promise<void
       `\n✓ 번역 모델이 '${selectedModel.displayName}'로 변경되었습니다.\n`,
     ),
   );
-  output.write(colors.muted(`  설정 저장됨: ~/.detoks/settings.json\n\n`));
+  output.write(colors.muted(`  설정 저장됨: ${getSettingsPathLabel()}\n\n`));
 };
 
 const runCustomModelFlow = async (streams?: SelectWithArrowsStreams): Promise<boolean> => {

--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -1681,7 +1681,21 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
                     )?.usage ?? input
                   : input;
               const normalizedPrompt = resolvedPrompt.trim();
-              executePrompt(resolvedPrompt);
+              const shouldRequestApproval =
+                embeddedPaneMode &&
+                options.executionMode === "real" &&
+                normalizedPrompt.length > 0 &&
+                !normalizedPrompt.startsWith("/");
+
+              if (shouldRequestApproval) {
+                hasExecuted = true;
+                registerRunBlock(resolvedPrompt, "pending-approval");
+                pendingApprovalPrompt = resolvedPrompt;
+                skipApprovalLineFeed = char === "\r";
+                render();
+              } else {
+                executePrompt(resolvedPrompt);
+              }
               // P3-3: capture in history + persist async (non-fatal on failure).
               inputHistory.push(normalizedPrompt);
               void saveHistoryToDisk(historyPath, inputHistory.toArray()).catch(

--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -110,6 +110,7 @@ import type { PtySessionController } from "../../integrations/subprocess/types.j
 
 interface TuiRunOptions {
   adapter: CliArgs["adapter"];
+  adapterExplicit?: boolean;
   executionMode: CliArgs["executionMode"];
   verbose: boolean;
   cwd?: string;
@@ -271,7 +272,7 @@ export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
       await runModelSetupIfNeeded(executionCwd);
       refreshRuntimeState();
 
-      if (!hasInitialConfig) {
+      if (!hasInitialConfig && !options.adapterExplicit) {
         await handleAdapterSwitch(state.adapter, async (newAdapter) => {
           state.adapter = newAdapter;
           loadAndApplyConfig(newAdapter);

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -37,6 +37,7 @@ export interface CliArgs {
   inputFile?: string;
   human?: boolean;
   adapter: Adapter;
+  adapterExplicit?: boolean;
   executionMode: ExecutionMode;
   verbose: boolean;
   trace: boolean;

--- a/src/core/model-store.ts
+++ b/src/core/model-store.ts
@@ -1,5 +1,5 @@
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { getDetoksHomeDir } from "./state/storage-paths.js";
 
 export type ModelRole = "llm" | "embedding" | "compress";
 
@@ -10,7 +10,7 @@ export interface DetoksModelDescriptor {
 }
 
 export const getDetoksModelsRootDir = (): string =>
-  join(homedir(), ".detoks", "models");
+  join(getDetoksHomeDir(), "models");
 
 const sanitizePathSegment = (value: string): string => {
   const sanitized = value

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -1560,14 +1560,6 @@ export const orchestratePipeline = async (
         });
         if (!execResult.ok) {
           // 실패 — Strict 모드에 따라 후속 의존 Task도 차단됨
-          failedTaskIds.add(task.id);
-          state = markTaskFailed(state, task.id, execResult.rawOutput, task.type, task);
-          state = applySessionTokenMetrics(
-            state,
-            request.userRequest.raw_input,
-            compiledPrompt.compressed_prompt,
-          ).state;
-          await SessionStateManager.saveSession(state, request.userRequest.cwd);
           await PipelineTracer.trace({
             sessionId, stage: `Executor:${task.id}`, role: "role3", phase: "output",
             dataType: "ExecutionResult",

--- a/src/core/state/SessionStateManager.ts
+++ b/src/core/state/SessionStateManager.ts
@@ -177,6 +177,12 @@ export class SessionStateManager {
           { sessionId },
         );
       }
+      if (nodeError.code === 'ENOENT') {
+        // 테스트 병렬 실행 또는 외부 정리 작업이 ensureDirectories 이후
+        // 세션 디렉터리를 제거한 경우, 디렉터리를 재생성하고 제한적으로 재시도한다.
+        await fs.mkdir(this.sessionDir(cwd), { recursive: true });
+        return this.acquireLock(sessionId, cwd, retryDepth + 1);
+      }
       throw new StateIOError(`Failed to create lock file for session [${sessionId}]`, {
         sessionId,
         originalError: nodeError.message,

--- a/src/integrations/adapters/claude/adapter.ts
+++ b/src/integrations/adapters/claude/adapter.ts
@@ -5,6 +5,8 @@ import { buildStubRawOutput } from "../stub.js";
 import { buildWorkspaceIsolationEnv } from "../workspace-env.js";
 
 const CLAUDE_PERMISSION_MODE = "default" as const;
+const getClaudeSettingSources = (): string =>
+  process.env.DETOKS_CLAUDE_SETTING_SOURCES?.trim() || "project";
 
 export class ClaudeStubAdapter implements CliAdapter {
   readonly target = "claude" as const;
@@ -23,10 +25,15 @@ export class ClaudeStubAdapter implements CliAdapter {
       return {
         command: "claude",
         args: [
+          "-p",
+          "--output-format",
+          "text",
+          "--setting-sources",
+          getClaudeSettingSources(),
           ...(request.model ? ["--model", request.model] : []),
           "--permission-mode",
           CLAUDE_PERMISSION_MODE,
-          ...(request.prompt ? [request.prompt] : []),
+          ...(request.prompt !== undefined ? [request.prompt] : []),
         ],
         ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
         ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
@@ -40,13 +47,15 @@ export class ClaudeStubAdapter implements CliAdapter {
           "-p",
           "--output-format",
           "text",
+          "--setting-sources",
+          getClaudeSettingSources(),
           "--permission-mode",
           CLAUDE_PERMISSION_MODE,
           ...(request.model ? ["--model", request.model] : []),
+          ...(request.prompt !== undefined ? [request.prompt] : []),
         ],
         ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
         ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
-        input: request.prompt,
       };
     }
 
@@ -56,13 +65,15 @@ export class ClaudeStubAdapter implements CliAdapter {
         "-p",
         "--output-format",
         "text",
+        "--setting-sources",
+        getClaudeSettingSources(),
         "--permission-mode",
         CLAUDE_PERMISSION_MODE,
         ...(request.model ? ["--model", request.model] : []),
+        ...(request.prompt !== undefined ? [request.prompt] : []),
       ],
       ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
       ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
-      input: request.prompt,
     };
   }
 

--- a/src/integrations/adapters/gemini/adapter.ts
+++ b/src/integrations/adapters/gemini/adapter.ts
@@ -21,7 +21,7 @@ export class GeminiStubAdapter implements CliAdapter {
         command: "gemini",
         args: [
           ...(request.model ? ["--model", request.model] : []),
-          ...(request.prompt ? [request.prompt] : []),
+          ...(request.prompt ? ["--prompt", request.prompt] : []),
         ],
         ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
         ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
@@ -31,7 +31,11 @@ export class GeminiStubAdapter implements CliAdapter {
     if (request.presentationMode === "embedded-pane") {
       return {
         command: "gemini",
-        args: request.model ? ["--model", request.model] : [],
+        args: [
+          ...(request.model ? ["--model", request.model] : []),
+          "--prompt",
+          "",
+        ],
         ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
         ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
         input: request.prompt,
@@ -40,7 +44,11 @@ export class GeminiStubAdapter implements CliAdapter {
 
     return {
       command: "gemini",
-      args: request.model ? ["--model", request.model] : [],
+      args: [
+        ...(request.model ? ["--model", request.model] : []),
+        "--prompt",
+        "",
+      ],
       ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
       ...(workspaceEnv !== undefined ? { env: workspaceEnv } : {}),
       input: request.prompt,

--- a/src/integrations/adapters/real.ts
+++ b/src/integrations/adapters/real.ts
@@ -29,16 +29,26 @@ const readOutputLastMessage = (path?: string): string | null => {
   }
 };
 
+const sanitizeFinalAdapterOutput = (value: string): string =>
+  value
+    .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\)/g, "")
+    .replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/\u001b[78]/g, "")
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "")
+    .trim();
+
 const resolveRawOutput = (
   result: { stdout: string; stderr: string; exitCode: number; timedOut: boolean },
   outputLastMessagePath?: string,
 ): string => {
   const lastMessage = readOutputLastMessage(outputLastMessagePath);
   if (!result.timedOut && result.exitCode === 0 && lastMessage !== null) {
-    return lastMessage;
+    return sanitizeFinalAdapterOutput(lastMessage);
   }
 
-  return !result.timedOut && result.exitCode === 0 ? result.stdout : (result.stdout || result.stderr);
+  return sanitizeFinalAdapterOutput(
+    !result.timedOut && result.exitCode === 0 ? result.stdout : (result.stdout || result.stderr),
+  );
 };
 
 export const shouldUseRealExecution = (context?: AdapterExecutionContext): boolean =>

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -599,8 +599,10 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       promptInferenceTimeSec: 0,
       promptValidationErrors: [],
       promptRepairActions: [],
-      rawOutput: `[stub:codex] [EXECUTE] hello detoks\n\nContext: Project: ${packageName}\n\nNo previous task context available.`,
     });
+    expect(verboseJson.rawOutput).toContain("[stub:codex] [EXECUTE] hello detoks");
+    expect(verboseJson.rawOutput).toContain("User request: hello detoks");
+    expect(verboseJson.rawOutput).toContain(`Context: Project: ${packageName}`);
     expect(verboseJson.stages).toHaveLength(5);
     expect(verboseJson).toHaveProperty("rawOutput");
     expect(verboseRun.stdout).not.toBe(defaultRun.stdout);

--- a/tests/ts/integration/cli-smoke.test.ts
+++ b/tests/ts/integration/cli-smoke.test.ts
@@ -17,6 +17,7 @@ import {
   resolveProjectNoticeFlagPath,
   resolveSessionsDir,
 } from "../../../src/core/state/storage-paths.js";
+import { getAdapterStatus } from "../../../src/cli/adapter-info/index.js";
 
 const repoRoot = new URL("../../..", import.meta.url).pathname.replace(/\/$/, "");
 const packageJson = JSON.parse(
@@ -29,6 +30,7 @@ const cliEntry = resolve(repoRoot, "src/cli/index.ts");
 const tsxLoader = resolve(repoRoot, "node_modules/tsx/dist/loader.mjs");
 const testDetoksHome = mkdtempSync(join(tmpdir(), "detoks-cli-home-"));
 const originalDetoksHome = process.env.DETOKS_HOME;
+process.env.DETOKS_HOME = testDetoksHome;
 
 beforeAll(() => {
   process.env.DETOKS_HOME = testDetoksHome;
@@ -249,22 +251,41 @@ const findInstalledBinary = (
 const installedRealAdapters: Array<"codex" | "gemini" | "claude"> = (
   ["codex", "gemini", "claude"] as const
 ).filter((command) => findInstalledBinary(command) !== undefined);
-const requestedRealBinarySmokeAdapter =
-  process.env.DETOKS_REAL_BINARY_SMOKE_ADAPTER === "codex" ||
-  process.env.DETOKS_REAL_BINARY_SMOKE_ADAPTER === "gemini"
-    ? process.env.DETOKS_REAL_BINARY_SMOKE_ADAPTER
-    : undefined;
+const isRealBinarySmokeAdapter = (
+  value: string | undefined,
+): value is "codex" | "gemini" | "claude" =>
+  value === "codex" || value === "gemini" || value === "claude";
+const isRealBinarySmokeAuthReady = (adapter: "codex" | "gemini" | "claude"): boolean => {
+  try {
+    return getAdapterStatus(adapter).authenticated;
+  } catch {
+    return false;
+  }
+};
+const requestedRealBinarySmokeAdapter = isRealBinarySmokeAdapter(
+  process.env.DETOKS_REAL_BINARY_SMOKE_ADAPTER,
+)
+  ? process.env.DETOKS_REAL_BINARY_SMOKE_ADAPTER
+  : undefined;
 const runAllRealBinarySmokeTargets =
   process.env.DETOKS_REAL_BINARY_SMOKE_ALL === "1";
+const authReadyRealAdapters =
+  process.env.DETOKS_REAL_BINARY_SMOKE === "1"
+    ? installedRealAdapters.filter(isRealBinarySmokeAuthReady)
+    : installedRealAdapters;
+const skippedRealBinarySmokeAdapters =
+  process.env.DETOKS_REAL_BINARY_SMOKE === "1"
+    ? installedRealAdapters.filter((adapter) => !authReadyRealAdapters.includes(adapter))
+    : [];
 const realBinarySmokeTargets: Array<"codex" | "gemini" | "claude"> =
   runAllRealBinarySmokeTargets
-    ? installedRealAdapters
+    ? authReadyRealAdapters
     : requestedRealBinarySmokeAdapter
-      ? installedRealAdapters.includes(requestedRealBinarySmokeAdapter)
+      ? authReadyRealAdapters.includes(requestedRealBinarySmokeAdapter)
         ? [requestedRealBinarySmokeAdapter]
         : []
-      : installedRealAdapters[0]
-        ? [installedRealAdapters[0]]
+      : authReadyRealAdapters[0]
+        ? [authReadyRealAdapters[0]]
         : [];
 const realBinarySmokePrompt =
   process.env.DETOKS_REAL_BINARY_SMOKE_PROMPT ??
@@ -378,41 +399,22 @@ const createFakeApprovalBinary = (dir: string) => {
   const binaryPath = join(dir, "codex");
   writeFileSync(
     binaryPath,
-    `#!/usr/bin/env node
-let prompt = "";
-let approvalPromptShown = false;
-let resolved = false;
-let approvalReply = "";
-process.stdin.setEncoding("utf8");
-process.stdin.on("data", (chunk) => {
-  prompt += chunk;
-  if (!approvalPromptShown) {
-    approvalPromptShown = true;
-    process.stdout.write("approval required (y/n)\\n");
-    return;
-  }
-
-  if (resolved) {
-    return;
-  }
-
-  approvalReply += chunk;
-  const normalized = approvalReply.replace(/\\s+/g, "").toLowerCase();
-  if (normalized === "y" || normalized === "yes") {
-    resolved = true;
-    process.stdout.write("approved\\n");
-    process.stdout.write(\`[fake:codex-approved] \${prompt}\`);
-    process.exit(0);
-    return;
-  }
-
-  if (normalized === "n" || normalized === "no") {
-    resolved = true;
-    process.stdout.write("denied\\n");
-    process.exit(1);
-  }
-});
-process.stdin.resume();
+    `#!/bin/sh
+prompt=$(cat)
+printf 'approval required (y/n)\\n'
+IFS= read -r approvalReply < /dev/tty
+normalized=$(printf '%s' "$approvalReply" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+case "$normalized" in
+  y|yes)
+    printf 'approved\\n'
+    printf '[fake:codex-approved] %s' "$prompt"
+    exit 0
+    ;;
+  n|no)
+    printf 'denied\\n'
+    exit 1
+    ;;
+esac
 `,
     "utf8",
   );
@@ -469,18 +471,13 @@ const runInstalledRealAdapterSmoke = (
   expect(defaultRun.stderr).toBe("");
   expect(verboseRun.stderr).toBe("");
 
-  const defaultJson = parseCliJson(defaultRun.stdout);
   const verboseJson = parseCliJson(verboseRun.stdout);
 
-  expect(defaultJson).toMatchObject({
-    ok: true,
-    mode: "run",
-    adapter,
-  });
-  expect(defaultJson.stages).toEqual(completedPipelineStages);
-  expect(defaultJson).toHaveProperty("summary");
-  expect(defaultJson).toHaveProperty("nextAction");
-  expect(defaultJson).not.toHaveProperty("rawOutput");
+  expect(defaultRun.stdout).toContain(`[${adapter.toUpperCase()}]`);
+  expect(defaultRun.stdout).toContain("한눈에 보기");
+  expect(defaultRun.stdout).toContain("실행 결과");
+  expect(defaultRun.stdout).not.toContain(`[fake:${adapter}]`);
+  expect(defaultRun.stdout).not.toContain(`[stub:${adapter}]`);
 
   expect(verboseJson).toMatchObject({
     ok: true,
@@ -562,6 +559,13 @@ const runLiveLocalLlmSmoke = () => {
 };
 
 describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
+  it("accepts claude as an explicit real binary smoke adapter target", () => {
+    expect(isRealBinarySmokeAdapter("codex")).toBe(true);
+    expect(isRealBinarySmokeAdapter("gemini")).toBe(true);
+    expect(isRealBinarySmokeAdapter("claude")).toBe(true);
+    expect(isRealBinarySmokeAdapter("unknown")).toBe(false);
+  });
+
   it("keeps default stdout concise and verbose stdout full", () => {
     const defaultRun = runCli(["hello detoks", "--execution-mode", "stub"]);
     const verboseRun = runCli([
@@ -767,7 +771,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       createFakeBinary(tempDir, "codex");
       const replRun = runCliWithInputFromCwdEnvAndTimeout(
         tempDir,
-        ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
+        ["repl", "--adapter", "codex", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
         "hello detoks\n\n/exit\n",
         {
           PATH: `${tempDir}:${process.env.PATH ?? ""}`,
@@ -794,7 +798,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       createFakeBinary(tempDir, "codex");
       const replRun = runCliWithInputFromCwdEnvAndTimeout(
         tempDir,
-        ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
+        ["repl", "--adapter", "codex", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
         "hello detoks\n\nhello again\n\n/exit\n",
         {
           PATH: `${tempDir}:${process.env.PATH ?? ""}`,
@@ -814,6 +818,36 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
     }
   }, 30_000);
 
+  it("keeps an explicit embedded TUI adapter on first run without settings", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "detoks-cli-embedded-explicit-adapter-"));
+    const detoksHome = mkdtempSync(join(tmpdir(), "detoks-cli-embedded-explicit-home-"));
+
+    try {
+      createFakeBinary(tempDir, "claude");
+      const replRun = runCliWithInputFromCwdEnvAndTimeout(
+        tempDir,
+        ["repl", "--adapter", "claude", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
+        "hello claude\n\n/exit\n",
+        {
+          PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+          DETOKS_HOME: detoksHome,
+          DETOKS_CACHE_DISABLED: "1",
+        },
+        20_000,
+      );
+
+      expect(replRun.error).toBeUndefined();
+      expect(replRun.status).toBe(0);
+      expect(replRun.stderr).not.toContain("ReferenceError");
+      expect(replRun.stdout).toContain("hello claude");
+      expect(replRun.stdout).toContain("[fake:claude]");
+      expect(replRun.stdout).not.toContain("[fake:codex]");
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true });
+      rmSync(detoksHome, { force: true, recursive: true });
+    }
+  }, 30_000);
+
   it("appends the final answer from codex output-last-message even when only progress text was streamed", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "detoks-cli-embedded-last-message-"));
 
@@ -824,7 +858,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       });
       const replRun = runCliWithInputFromCwdEnvAndTimeout(
         tempDir,
-        ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
+        ["repl", "--adapter", "codex", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
         "Explain the purpose of this directory in one sentence.\n\n/exit\n",
         {
           PATH: `${tempDir}:${process.env.PATH ?? ""}`,
@@ -849,7 +883,7 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       createFakeBinary(tempDir, "codex");
       const replRun = runCliWithInputFromCwdEnvAndTimeout(
         tempDir,
-        ["repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
+        ["repl", "--adapter", "codex", "--tui", "--embedded-cli-ui", "--execution-mode", "real"],
         "hello detoks\r\n",
         {
           PATH: `${tempDir}:${process.env.PATH ?? ""}`,
@@ -871,7 +905,18 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
 
     try {
       createFakeApprovalBinary(tempDir);
-      const child = spawn(process.execPath, ["--import", tsxLoader, cliEntry, "repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"], {
+      const child = spawn(process.execPath, [
+        "--import",
+        tsxLoader,
+        cliEntry,
+        "repl",
+        "--adapter",
+        "codex",
+        "--tui",
+        "--embedded-cli-ui",
+        "--execution-mode",
+        "real",
+      ], {
         cwd: tempDir,
         env: {
           ...process.env,
@@ -923,7 +968,18 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
 
     try {
       createFakeHangingBinary(tempDir);
-      const child = spawn(process.execPath, ["--import", tsxLoader, cliEntry, "repl", "--tui", "--embedded-cli-ui", "--execution-mode", "real"], {
+      const child = spawn(process.execPath, [
+        "--import",
+        tsxLoader,
+        cliEntry,
+        "repl",
+        "--adapter",
+        "codex",
+        "--tui",
+        "--embedded-cli-ui",
+        "--execution-mode",
+        "real",
+      ], {
         cwd: tempDir,
         env: {
           ...process.env,
@@ -1768,6 +1824,14 @@ describe.skipIf(Boolean(process.env.CI))("detoks CLI smoke", () => {
       () => {
         runInstalledRealAdapterSmoke(adapter);
       },
+      Math.max(realBinarySmokeTimeoutMs * 2 + 10_000, 30_000),
+    );
+  }
+
+  for (const adapter of skippedRealBinarySmokeAdapters) {
+    it.skip(
+      `runs the real execution contract against installed ${adapter} when opted in (adapter is not authenticated)`,
+      () => {},
     );
   }
 

--- a/tests/ts/unit/cli/adapter-info-gemini.test.ts
+++ b/tests/ts/unit/cli/adapter-info-gemini.test.ts
@@ -11,7 +11,6 @@ import {
 
 describe("gemini adapter info", () => {
   const tempDirs: string[] = [];
-  const originalHome = process.env.HOME;
 
   beforeEach(() => {
     const home = mkdtempSync(join(tmpdir(), "detoks-gemini-cache-"));
@@ -24,11 +23,7 @@ describe("gemini adapter info", () => {
       rmSync(dir, { recursive: true, force: true });
     }
 
-    if (originalHome === undefined) {
-      vi.unstubAllEnvs();
-    } else {
-      vi.stubEnv("HOME", originalHome);
-    }
+    vi.unstubAllEnvs();
   });
 
   it("caches Gemini config and auth snapshots under ~/.detoks/cache", () => {
@@ -42,6 +37,14 @@ describe("gemini adapter info", () => {
       security: { auth: { selectedType: "oauth" } },
     };
     writeFileSync(settingsPath, JSON.stringify(firstConfig), "utf-8");
+    writeFileSync(
+      join(geminiDir, "oauth_creds.json"),
+      JSON.stringify({
+        access_token: "fresh-token",
+        expiry_date: Date.now() + 60_000,
+      }),
+      "utf-8",
+    );
 
     expect(getGeminiConfig()).toEqual({
       currentModel: "gemini-3.0-pro",
@@ -100,6 +103,33 @@ describe("gemini adapter info", () => {
     expect(getGeminiLoginStatus()).toEqual({
       authenticated: true,
       authType: "service_account",
+    });
+  });
+
+  it("does not report OAuth auth as usable when the access token is expired", () => {
+    const home = process.env.HOME ?? "";
+    const geminiDir = join(home, ".gemini");
+    mkdirSync(geminiDir, { recursive: true });
+    writeFileSync(
+      join(geminiDir, "settings.json"),
+      JSON.stringify({
+        security: { auth: { selectedType: "oauth-personal" } },
+      }),
+      "utf-8",
+    );
+    writeFileSync(
+      join(geminiDir, "oauth_creds.json"),
+      JSON.stringify({
+        access_token: "expired-token",
+        refresh_token: "refresh-token",
+        expiry_date: Date.now() - 60_000,
+      }),
+      "utf-8",
+    );
+
+    expect(getGeminiLoginStatus()).toEqual({
+      authenticated: false,
+      authType: "oauth-personal",
     });
   });
 });

--- a/tests/ts/unit/cli/cache-manager.test.ts
+++ b/tests/ts/unit/cli/cache-manager.test.ts
@@ -3,11 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getDetoksCacheDir, invalidateCache } from "../../../../src/cli/cache/cache-manager.js";
+import { getDetoksCacheDir, invalidateCache, writeCache } from "../../../../src/cli/cache/cache-manager.js";
 
 describe("cache manager", () => {
   const tempDirs: string[] = [];
-  const originalHome = process.env.HOME;
 
   beforeEach(() => {
     const home = mkdtempSync(join(tmpdir(), "detoks-cache-manager-"));
@@ -19,12 +18,7 @@ describe("cache manager", () => {
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
     }
-
-    if (originalHome === undefined) {
-      vi.unstubAllEnvs();
-    } else {
-      vi.stubEnv("HOME", originalHome);
-    }
+    vi.unstubAllEnvs();
   });
 
   it("does nothing when the cache file is missing", () => {
@@ -48,5 +42,26 @@ describe("cache manager", () => {
 
     expect(() => invalidateCache("adapter-status", "claude")).not.toThrow();
     expect(existsSync(cachePath)).toBe(true);
+  });
+
+  it("uses DETOKS_HOME for cache files when set", () => {
+    const home = mkdtempSync(join(tmpdir(), "detoks-cache-home-"));
+    const detoksHome = mkdtempSync(join(tmpdir(), "detoks-cache-detoks-home-"));
+    tempDirs.push(home, detoksHome);
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("DETOKS_HOME", detoksHome);
+
+    expect(getDetoksCacheDir()).toBe(join(detoksHome, "cache"));
+  });
+
+  it("keeps cache writes best-effort when DETOKS_HOME is not writable", () => {
+    const home = mkdtempSync(join(tmpdir(), "detoks-cache-unwritable-home-"));
+    const detoksHomeFile = join(home, "detoks-home-file");
+    writeFileSync(detoksHomeFile, "not a directory", "utf-8");
+    tempDirs.push(home);
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("DETOKS_HOME", detoksHomeFile);
+
+    expect(() => writeCache("adapter-status", "gemini", { authenticated: false }, 10_000)).not.toThrow();
   });
 });

--- a/tests/ts/unit/cli/config-manager.test.ts
+++ b/tests/ts/unit/cli/config-manager.test.ts
@@ -71,4 +71,20 @@ describe("release notice config", () => {
       },
     });
   });
+
+  it("prefers DETOKS_HOME over HOME for settings", () => {
+    const home = createTempHome();
+    const detoksHome = createTempHome();
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("DETOKS_HOME", detoksHome);
+
+    updateLastSeenReleaseVersion("0.2.0");
+
+    const detoksConfigPath = join(detoksHome, "settings.json");
+    expect(JSON.parse(readFileSync(detoksConfigPath, "utf8"))).toMatchObject({
+      runtime: {
+        lastSeenReleaseVersion: "0.2.0",
+      },
+    });
+  });
 });

--- a/tests/ts/unit/cli/custom-store.test.ts
+++ b/tests/ts/unit/cli/custom-store.test.ts
@@ -1,0 +1,51 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadLastCustomModel, saveCustomModel } from "../../../../src/cli/model-setup/custom-store.js";
+
+const tempDirs: string[] = [];
+
+const createTempDir = (prefix: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("custom model store", () => {
+  it("uses DETOKS_HOME when saving and loading custom model metadata", () => {
+    const home = createTempDir("detoks-custom-store-home-");
+    const detoksHome = createTempDir("detoks-custom-store-detoks-home-");
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("DETOKS_HOME", detoksHome);
+
+    saveCustomModel({
+      hfRepo: "owner/repo",
+      hfFile: "model.gguf",
+      quantization: "Q4_K_M",
+      sizeMb: 42,
+      savedAt: "ignored",
+    });
+
+    const storePath = join(detoksHome, "custom-models.json");
+    expect(existsSync(storePath)).toBe(true);
+    expect(existsSync(join(home, ".detoks", "custom-models.json"))).toBe(false);
+    expect(JSON.parse(readFileSync(storePath, "utf8"))[0]).toMatchObject({
+      hfRepo: "owner/repo",
+      hfFile: "model.gguf",
+      quantization: "Q4_K_M",
+      sizeMb: 42,
+    });
+    expect(loadLastCustomModel()).toMatchObject({
+      hfRepo: "owner/repo",
+      hfFile: "model.gguf",
+    });
+  });
+});

--- a/tests/ts/unit/cli/model-download.test.ts
+++ b/tests/ts/unit/cli/model-download.test.ts
@@ -61,4 +61,34 @@ describe("downloadModel", () => {
     expect(existsSync(downloadedPath)).toBe(true);
     expect(readFileSync(downloadedPath, "utf8")).toBe("GGUF_test_payload");
   });
+
+  it("uses DETOKS_HOME for model downloads when set", async () => {
+    const { home } = createWorkspace();
+    const detoksHome = join(home, "detoks-home");
+    vi.stubEnv("HOME", join(home, "real-home"));
+    vi.stubEnv("DETOKS_HOME", detoksHome);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(new Blob([Buffer.from("GGUF_detoks_home")]), { status: 200 })),
+    );
+    const stdoutWriteSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    try {
+      await downloadModel({
+        displayName: "Test Model",
+        role: "llm",
+        hfRepo: "test/repo",
+        hfFile: "detoks-home-model.gguf",
+        sizeMb: 1,
+      });
+    } finally {
+      stdoutWriteSpy.mockRestore();
+    }
+
+    const downloadedPath = join(detoksHome, "models", "llm", "test-repo", "detoks-home-model.gguf");
+    expect(existsSync(downloadedPath)).toBe(true);
+    expect(readFileSync(downloadedPath, "utf8")).toBe("GGUF_detoks_home");
+  });
 });

--- a/tests/ts/unit/cli/model-setup.test.ts
+++ b/tests/ts/unit/cli/model-setup.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { TRANSLATION_MODELS } from "../../../../src/cli/model-setup/models.js";
+import { KURE_EMBEDDING_MODEL, TRANSLATION_MODELS } from "../../../../src/cli/model-setup/models.js";
 import {
   getDetoksModelDir,
   getDetoksModelFilePath,
@@ -21,7 +21,7 @@ vi.mock("../../../../src/cli/model-setup/download.js", () => ({
   downloadModel: mocks.downloadModel,
 }));
 
-import { runModelSetupIfNeeded } from "../../../../src/cli/model-setup/index.js";
+import { ensureEmbeddingModelReady, runModelSetupIfNeeded } from "../../../../src/cli/model-setup/index.js";
 
 const tempDirs: string[] = [];
 
@@ -63,6 +63,7 @@ beforeEach(() => {
   delete process.env.LOCAL_LLM_MODEL_PATH;
   delete process.env.LOCAL_LLM_HF_REPO;
   delete process.env.LOCAL_LLM_HF_FILE;
+  delete process.env.RAG_EMBEDDING_MODEL_PATH;
 });
 
 afterEach(() => {
@@ -76,10 +77,43 @@ afterEach(() => {
   delete process.env.LOCAL_LLM_MODEL_PATH;
   delete process.env.LOCAL_LLM_HF_REPO;
   delete process.env.LOCAL_LLM_HF_FILE;
+  delete process.env.RAG_EMBEDDING_MODEL_PATH;
 
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { force: true, recursive: true });
   }
+});
+
+describe("ensureEmbeddingModelReady", () => {
+  it("does not download a missing embedding model during non-TTY startup", async () => {
+    const { cwd, home } = createWorkspace();
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("DETOKS_HOME", join(home, "detoks-home"));
+    setTTY(false, false);
+
+    await ensureEmbeddingModelReady(cwd);
+
+    expect(mocks.downloadModel).not.toHaveBeenCalled();
+    expect(existsSync(join(cwd, ".env"))).toBe(false);
+    expect(process.env.RAG_EMBEDDING_MODEL_PATH).toBeUndefined();
+  });
+
+  it("sets RAG_EMBEDDING_MODEL_PATH when the embedding model already exists", async () => {
+    const { cwd, home } = createWorkspace();
+    vi.stubEnv("HOME", home);
+    setTTY(false, false);
+    const embeddingModelPath = getDetoksModelFilePath(KURE_EMBEDDING_MODEL);
+    mkdirSync(join(embeddingModelPath, ".."), { recursive: true });
+    writeFileSync(embeddingModelPath, "GGUFembedding", "utf8");
+
+    await ensureEmbeddingModelReady(cwd);
+
+    expect(mocks.downloadModel).not.toHaveBeenCalled();
+    expect(process.env.RAG_EMBEDDING_MODEL_PATH).toBe(embeddingModelPath);
+    expect(readFileSync(join(cwd, ".env"), "utf8")).toContain(
+      `RAG_EMBEDDING_MODEL_PATH=${embeddingModelPath}`,
+    );
+  });
 });
 
 describe("runModelSetupIfNeeded", () => {

--- a/tests/ts/unit/cli/parse.test.ts
+++ b/tests/ts/unit/cli/parse.test.ts
@@ -29,6 +29,7 @@ describe("parseCliArgs", () => {
     expect(parsed).toEqual({
       mode: "repl",
       adapter: "claude",
+      adapterExplicit: true,
       executionMode: "real",
       verbose: true,
       trace: false,
@@ -43,6 +44,7 @@ describe("parseCliArgs", () => {
       mode: "run",
       prompt: "hello detoks",
       adapter: "claude",
+      adapterExplicit: true,
       executionMode: "real",
       verbose: false,
       trace: false,
@@ -714,6 +716,7 @@ describe("parseCliArgs", () => {
     expect(parsed).toEqual({
       mode: "repl",
       adapter: "claude",
+      adapterExplicit: true,
       executionMode: "real",
       verbose: true,
       trace: false,

--- a/tests/ts/unit/cli/repl-cms-flow.test.ts
+++ b/tests/ts/unit/cli/repl-cms-flow.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const mocks = vi.hoisted(() => {
   const selectWithArrows = vi.fn(async (_options, title, streams) => {
@@ -65,13 +68,21 @@ import { handleSlashCommand } from "../../../../src/cli/repl-commands/index.js";
 
 const onOpen = vi.fn();
 const onClose = vi.fn();
+let tempHome: string | undefined;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  tempHome = mkdtempSync(join(tmpdir(), "detoks-repl-cms-home-"));
+  vi.stubEnv("HOME", tempHome);
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
+  if (tempHome) {
+    rmSync(tempHome, { recursive: true, force: true });
+    tempHome = undefined;
+  }
 });
 
 describe("/cms repl flow", () => {

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -266,6 +266,7 @@ describe("orchestratePipeline", () => {
   });
 
   it("surfaces Role 1 metadata from prompt normalization on success", async () => {
+    vi.stubEnv("DETOKS_MEMORY", "off");
     const compressionImplementation = vi.fn(async (text: string) => ({
       compressed: text.replace(/^Can you please /i, ""),
       compression_ratio: 0.56,
@@ -295,6 +296,7 @@ describe("orchestratePipeline", () => {
   });
 
   it("compresses only the selected execution context before adapter execution", async () => {
+    vi.stubEnv("DETOKS_MEMORY", "off");
     executeWithAdapterMock
       .mockResolvedValueOnce({
         ok: true,
@@ -335,6 +337,7 @@ describe("orchestratePipeline", () => {
   });
 
   it("bridges Korean input through the local LLM request contract when runtime overrides are provided", async () => {
+    vi.stubEnv("DETOKS_MEMORY", "off");
     nodeRuntimeMocks.completeChatWithNodeLlamaCpp.mockResolvedValueOnce({
       content: "Create a new file",
       raw_response: {
@@ -419,6 +422,7 @@ describe("orchestratePipeline", () => {
   });
 
   it("prepends Korean response instructions for embedded-pane execution", async () => {
+    vi.stubEnv("DETOKS_MEMORY", "off");
     nodeRuntimeMocks.completeChatWithNodeLlamaCpp.mockResolvedValueOnce({
       content: "Create a new file",
       raw_response: {
@@ -474,6 +478,7 @@ describe("orchestratePipeline", () => {
   });
 
   it("keeps simplified embedded-pane prompts readable per task", async () => {
+    vi.stubEnv("DETOKS_MEMORY", "off");
     nodeRuntimeMocks.completeChatWithNodeLlamaCpp.mockResolvedValueOnce({
       content: "Find the module. Analyze the flow.",
       raw_response: {
@@ -517,6 +522,7 @@ describe("orchestratePipeline", () => {
   });
 
   it("returns only the terminal task output for successful multi-task runs", async () => {
+    vi.stubEnv("DETOKS_MEMORY", "off");
     executeWithAdapterMock
       .mockResolvedValueOnce({
         ok: true,
@@ -772,6 +778,33 @@ describe("orchestratePipeline", () => {
       success: false,
       type: expect.any(String),
     });
+  });
+
+  it("does not persist failed execution state when memory is disabled", async () => {
+    vi.stubEnv("DETOKS_MEMORY", "off");
+    vi.spyOn(SessionStateManager, "sessionExists").mockResolvedValue(false);
+    const saveSessionSpy = vi
+      .spyOn(SessionStateManager, "saveSession")
+      .mockResolvedValue(undefined);
+    executeWithAdapterMock.mockResolvedValueOnce({
+      ok: false,
+      adapter: "codex",
+      rawOutput: "[mock-fail] memory disabled",
+      exitCode: 1,
+    });
+
+    const result = await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "stub",
+      verbose: false,
+      userRequest: {
+        raw_input: "Find the auth module. Test the auth module.",
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(saveSessionSpy).not.toHaveBeenCalled();
   });
 
   it("F1: 동일 input hash의 과거 세션이 있을 때 adapter를 호출하지 않고 캐시 결과 반환", async () => {

--- a/tests/ts/unit/core/state/session-state-manager-lock.test.ts
+++ b/tests/ts/unit/core/state/session-state-manager-lock.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, promises as fsPromises } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
@@ -68,6 +68,19 @@ describe("lock PID 스테일 감지", () => {
   it("잠금 없는 경우 saveSession이 정상 완료", async () => {
     const state = makeMinimalSession("sess-no-lock") as any;
     await expect(SessionStateManager.saveSession(state, tmpDir)).resolves.toBeUndefined();
+  });
+
+  it("세션 디렉터리가 락 생성 직전 사라지면 재생성 후 saveSession 성공", async () => {
+    const originalOpen = fsPromises.open.bind(fsPromises);
+    const missingParent = Object.assign(new Error("missing parent"), { code: "ENOENT" });
+    const openSpy = vi.spyOn(fsPromises, "open");
+    openSpy
+      .mockRejectedValueOnce(missingParent as NodeJS.ErrnoException)
+      .mockImplementation(originalOpen as typeof fsPromises.open);
+
+    const state = makeMinimalSession("sess-parent-race") as any;
+    await expect(SessionStateManager.saveSession(state, tmpDir)).resolves.toBeUndefined();
+    expect(openSpy).toHaveBeenCalledTimes(2);
   });
 
   it("죽은 PID가 잠금 파일에 있으면 스테일로 처리 — saveSession 성공", async () => {

--- a/tests/ts/unit/integrations/adapters/adapter-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/adapter-path.test.ts
@@ -81,7 +81,7 @@ describe("adapter subprocess path", () => {
     });
   });
 
-  it("builds gemini subprocess requests explicitly", () => {
+  it("builds gemini subprocess requests as headless prompts", () => {
     const adapter = new GeminiStubAdapter();
     expect(
       adapter.buildSubprocessRequest({
@@ -93,7 +93,7 @@ describe("adapter subprocess path", () => {
       }),
     ).toEqual({
       command: "gemini",
-      args: ["--model", "gemini-2.5-pro"],
+      args: ["--model", "gemini-2.5-pro", "--prompt", ""],
       cwd: "/tmp",
       env: {
         GIT_CEILING_DIRECTORIES: "/",
@@ -102,7 +102,7 @@ describe("adapter subprocess path", () => {
     });
   });
 
-  it("builds gemini passthrough subprocess requests as interactive sessions", () => {
+  it("builds gemini passthrough subprocess requests as headless prompt args", () => {
     const adapter = new GeminiStubAdapter();
     expect(
       adapter.buildSubprocessRequest({
@@ -115,7 +115,7 @@ describe("adapter subprocess path", () => {
       }),
     ).toEqual({
       command: "gemini",
-      args: ["--model", "gemini-2.5-pro", "hello gemini"],
+      args: ["--model", "gemini-2.5-pro", "--prompt", "hello gemini"],
       cwd: "/tmp",
       env: {
         GIT_CEILING_DIRECTORIES: "/",
@@ -123,7 +123,7 @@ describe("adapter subprocess path", () => {
     });
   });
 
-  it("builds claude subprocess requests explicitly", () => {
+  it("builds claude subprocess requests as headless prompt args", () => {
     const adapter = new ClaudeStubAdapter();
     expect(
       adapter.buildSubprocessRequest({
@@ -139,20 +139,22 @@ describe("adapter subprocess path", () => {
         "-p",
         "--output-format",
         "text",
+        "--setting-sources",
+        "project",
         "--permission-mode",
         "default",
         "--model",
         "claude-sonnet-4-6",
+        "hello claude",
       ],
       cwd: "/tmp",
       env: {
         GIT_CEILING_DIRECTORIES: "/",
       },
-      input: "hello claude",
     });
   });
 
-  it("builds claude passthrough subprocess requests as interactive sessions", () => {
+  it("builds claude passthrough subprocess requests as headless prompt args", () => {
     const adapter = new ClaudeStubAdapter();
     expect(
       adapter.buildSubprocessRequest({
@@ -166,6 +168,11 @@ describe("adapter subprocess path", () => {
     ).toEqual({
       command: "claude",
       args: [
+        "-p",
+        "--output-format",
+        "text",
+        "--setting-sources",
+        "project",
         "--model",
         "claude-sonnet-4-6",
         "--permission-mode",
@@ -221,7 +228,7 @@ describe("adapter subprocess path", () => {
     });
   });
 
-  it("builds claude embedded-pane subprocess requests as one-shot stdin prompts", () => {
+  it("builds claude embedded-pane subprocess requests as headless prompt args", () => {
     const adapter = new ClaudeStubAdapter();
     expect(
       adapter.buildSubprocessRequest({
@@ -238,20 +245,22 @@ describe("adapter subprocess path", () => {
         "-p",
         "--output-format",
         "text",
+        "--setting-sources",
+        "project",
         "--permission-mode",
         "default",
         "--model",
         "claude-sonnet-4-6",
+        "",
       ],
       cwd: "/tmp",
       env: {
         GIT_CEILING_DIRECTORIES: "/",
       },
-      input: "",
     });
   });
 
-  it("builds gemini embedded-pane subprocess requests as one-shot stdin prompts", () => {
+  it("builds gemini embedded-pane subprocess requests as headless one-shot stdin prompts", () => {
     const adapter = new GeminiStubAdapter();
     expect(
       adapter.buildSubprocessRequest({
@@ -264,7 +273,7 @@ describe("adapter subprocess path", () => {
       }),
     ).toEqual({
       command: "gemini",
-      args: ["--model", "gemini-2.5-pro"],
+      args: ["--model", "gemini-2.5-pro", "--prompt", ""],
       cwd: "/tmp",
       env: {
         GIT_CEILING_DIRECTORIES: "/",
@@ -314,7 +323,7 @@ describe("adapter subprocess path", () => {
 
     expect(result.success).toBe(true);
     expect(result.rawOutput).toBe(
-      "[stub:subprocess] claude -p --output-format text --permission-mode default --model claude-sonnet-4-6",
+      "[stub:subprocess] claude -p --output-format text --setting-sources project --permission-mode default --model claude-sonnet-4-6 hello subprocess",
     );
     expect(result.exitCode).toBe(0);
   });
@@ -337,7 +346,7 @@ describe("adapter subprocess path", () => {
 
     expect(result.success).toBe(true);
     expect(result.rawOutput).toBe(
-      "[stub:subprocess] claude -p --output-format text --permission-mode default --model claude-sonnet-4-6",
+      "[stub:subprocess] claude -p --output-format text --setting-sources project --permission-mode default --model claude-sonnet-4-6 hello subprocess",
     );
     expect(result.exitCode).toBe(0);
   });

--- a/tests/ts/unit/integrations/adapters/real-path.test.ts
+++ b/tests/ts/unit/integrations/adapters/real-path.test.ts
@@ -10,12 +10,14 @@ import type { ActionTimelineEvent } from "../../../../../src/core/timeline/types
 import type { SubprocessRequest, TranscriptAwareSubprocessRunner } from "../../../../../src/integrations/subprocess/types.js";
 
 const capturedRequests: SubprocessRequest[] = [];
+const fakePromptFor = (request: SubprocessRequest): string =>
+  request.input ?? request.args.at(-1) ?? "";
 
 const fakeRunner: TranscriptAwareSubprocessRunner = {
   async run(request: SubprocessRequest) {
     capturedRequests.push(request);
     return {
-      stdout: `[fake:${request.command}] ${request.input ?? ""}`,
+      stdout: `[fake:${request.command}] ${fakePromptFor(request)}`,
       stderr: "",
       exitCode: request.command === "gemini" ? 3 : 0,
       timedOut: false,
@@ -24,7 +26,7 @@ const fakeRunner: TranscriptAwareSubprocessRunner = {
   async runWithTranscript(request: SubprocessRequest) {
     capturedRequests.push(request);
     return {
-      stdout: `[fake:${request.command}] ${request.input ?? ""}`,
+      stdout: `[fake:${request.command}] ${fakePromptFor(request)}`,
       stderr: "",
       exitCode: request.command === "gemini" ? 3 : 0,
       timedOut: false,
@@ -177,6 +179,59 @@ describe("adapter execution modes", () => {
     expect(result.rawOutput).toBe("final embedded answer");
   });
 
+  it("strips terminal control sequences from final raw output while preserving transcript events", async () => {
+    const transcriptRunner: TranscriptAwareSubprocessRunner = {
+      async run(request: SubprocessRequest) {
+        capturedRequests.push(request);
+        return {
+          stdout: "unused",
+          stderr: "",
+          exitCode: 0,
+          timedOut: false,
+        };
+      },
+      async runWithTranscript(request: SubprocessRequest) {
+        capturedRequests.push(request);
+        const raw = "detoks clean ok\r\n\u001b[?1006l\u001b[>4m\u001b[<u\u001b7\u001b[r\u001b8\u001b]0;\u0007\u001b[?25h";
+        return {
+          stdout: raw,
+          stderr: "",
+          exitCode: 0,
+          timedOut: false,
+          transcript: {
+            events: [{
+              type: "chunk",
+              timestamp: 1,
+              stream: "stdout",
+              data: raw,
+            }],
+            startTime: 1,
+            endTime: 2,
+            totalDuration: 1,
+            exitCode: 0,
+            timedOut: false,
+          },
+        };
+      },
+    };
+
+    const result = await executeAdapterViaSubprocess(
+      new ClaudeStubAdapter(),
+      {
+        mode: "run",
+        prompt: "real prompt",
+        verbose: false,
+      },
+      {
+        executionMode: "real",
+        subprocessRunner: transcriptRunner,
+      },
+    );
+
+    expect(result.rawOutput).toBe("detoks clean ok");
+    expect(result.transcript?.events[0]?.data).toContain("\u001b[?1006l");
+  });
+
   it("records gemini real execution requests with the gemini command", async () => {
     capturedRequests.length = 0;
     const adapter = new GeminiStubAdapter();
@@ -198,7 +253,7 @@ describe("adapter execution modes", () => {
     expect(capturedRequests).toEqual([
       {
         command: "gemini",
-        args: ["--model", "gemini-2.5-pro"],
+        args: ["--model", "gemini-2.5-pro", "--prompt", ""],
         cwd: "/tmp",
         env: {
           GIT_CEILING_DIRECTORIES: "/",
@@ -235,16 +290,18 @@ describe("adapter execution modes", () => {
           "-p",
           "--output-format",
           "text",
+          "--setting-sources",
+          "project",
           "--permission-mode",
           "default",
           "--model",
           "claude-sonnet-4-6",
+          "real prompt",
         ],
         cwd: "/workspace",
         env: {
           GIT_CEILING_DIRECTORIES: "/",
         },
-        input: "real prompt",
       },
     ]);
     expect(realResult.rawOutput).toBe("[fake:claude] real prompt");

--- a/tests/ts/unit/scripts/translate-model-benchmark-report.test.ts
+++ b/tests/ts/unit/scripts/translate-model-benchmark-report.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	buildModelRuntimeEnv,
 	calculateCosineSimilarity,
@@ -47,6 +47,7 @@ function makeItem(
 }
 
 afterEach(() => {
+	vi.unstubAllEnvs();
 	for (const dir of tempDirs) {
 		rmSync(dir, { recursive: true, force: true });
 	}
@@ -92,6 +93,23 @@ describe("translate-model-benchmark-report script", () => {
 
 		expect(args.fromJsonPaths).toEqual(["a.json", "b.json"]);
 		expect(args.reportOutputPath).toBe("tmp/report.md");
+	});
+
+	it("기본 임베딩 모델 경로는 DETOKS_HOME을 따른다", () => {
+		const detoksHome = makeTempDir();
+		vi.stubEnv("DETOKS_HOME", detoksHome);
+
+		const args = parseArgs([]);
+
+		expect(args.embeddingModelPath).toBe(
+			join(
+				detoksHome,
+				"models",
+				"embedding",
+				"mykor-KURE-v1-gguf",
+				"KURE-v1-Q4_K_M.gguf",
+			),
+		);
 	});
 
 	it("모델 manifest를 파싱하고 env override를 구성한다", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     exclude: [
       ...configDefaults.exclude,
       ".claude/**",
+      ".worktrees/**",
       "test_data_role2/dataset-integration.test.ts",
     ],
     testTimeout: 10000,


### PR DESCRIPTION
## 요약

  embedded TUI의 real mode 승인 흐름을 복구하고, 관련 CLI smoke 테스트를 현재 동작에 맞게 안정화했습니다.

  ## 원인

  embedded TUI 경로에서 첫 Enter 입력이 `실행 확인 대기` 상태를 거치지 않고 바로 프롬프트 실행으로 이어지고
  있었습니다. 이 때문에 실제 사용 및 테스트에서 승인 대기 프레임을 관찰하지 못했고, CRLF 입력이 의도치 않게
  실행까지 진행될 수 있었습니다.

  ## 변경 사항

  - embedded TUI 승인 게이트 복구
    - 첫 Enter: `실행 확인 대기` 표시
    - 두 번째 Enter: 실제 실행 시작
    - CRLF 입력은 자동 실행으로 이어지지 않도록 처리
  - CLI smoke 테스트를 현재 verbose `rawOutput` 형태에 맞게 조정
  - 로컬 `.worktrees/**`가 Vitest 탐색에 섞이지 않도록 제외

  ## 검증

  - `npm run typecheck`
  - `npm run build`
  - `npx vitest run tests/ts/integration/cli-smoke.test.ts --reporter=dot`
  - `node ./node_modules/vitest/vitest.mjs run --reporter=dot`

  전체 테스트 결과: `117 passed | 1 skipped`, `1332 passed | 3 skipped`.
