### PR TITLE
chore: prepare release 0.2.0

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,4 +1,4 @@
-name: Auto Release and Publish
+name: GitHub Release and Publish
 
 on:
   push:
@@ -7,10 +7,10 @@ on:
 permissions:
   contents: write
   id-token: write
-  pull-requests: write
+
 jobs:
   release:
-    name: Auto Release
+    name: Release and auto-bump
     runs-on: ubuntu-latest
 
     steps:
@@ -23,89 +23,107 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24.15.0
+          registry-url: https://registry.npmjs.org
           cache: npm
 
       - name: Install dependencies
         run: npm ci
 
+      - name: Resolve release version
+        id: version
+        run: |
+          set -euo pipefail
+
+          bump_patch() {
+            local current="$1"
+            local major minor patch
+            IFS='.' read -r major minor patch <<< "$current"
+
+            patch=$((patch + 1))
+            if [ "$patch" -ge 10 ]; then
+              patch=0
+              minor=$((minor + 1))
+            fi
+            if [ "$minor" -ge 10 ]; then
+              minor=0
+              major=$((major + 1))
+            fi
+
+            echo "$major.$minor.$patch"
+          }
+
+          CURRENT="$(node -p "require('./package.json').version")"
+          LOCK_VERSION="$(node -p "require('./package-lock.json').version")"
+          LOCK_ROOT_VERSION="$(node -p "require('./package-lock.json').packages[''].version")"
+          if [ "$CURRENT" != "$LOCK_VERSION" ] || [ "$CURRENT" != "$LOCK_ROOT_VERSION" ]; then
+            echo "package.json and package-lock.json versions differ: package=$CURRENT lock=$LOCK_VERSION root=$LOCK_ROOT_VERSION"
+            exit 1
+          fi
+
+          git fetch --tags --force
+
+          SHOULD_BUMP=false
+          RELEASE_VERSION="$CURRENT"
+          if git rev-parse "v$CURRENT" >/dev/null 2>&1; then
+            SHOULD_BUMP=true
+            RELEASE_VERSION="$(bump_patch "$CURRENT")"
+            if git rev-parse "v$RELEASE_VERSION" >/dev/null 2>&1; then
+              echo "Next tag v$RELEASE_VERSION already exists."
+              exit 1
+            fi
+          fi
+
+          echo "Current package version: $CURRENT"
+          echo "Release version: $RELEASE_VERSION"
+          echo "should_bump=$SHOULD_BUMP" >> "$GITHUB_OUTPUT"
+          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update package version for subsequent main releases
+        if: steps.version.outputs.should_bump == 'true'
+        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+
+      - name: Validate package versions
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          LOCK_VERSION="$(node -p "require('./package-lock.json').version")"
+          LOCK_ROOT_VERSION="$(node -p "require('./package-lock.json').packages[''].version")"
+          if [ "$VERSION" != "${{ steps.version.outputs.version }}" ] ||
+             [ "$VERSION" != "$LOCK_VERSION" ] ||
+             [ "$VERSION" != "$LOCK_ROOT_VERSION" ]; then
+            echo "Invalid release versions: expected=${{ steps.version.outputs.version }} package=$VERSION lock=$LOCK_VERSION root=$LOCK_ROOT_VERSION"
+            exit 1
+          fi
+
       - name: Type check
         run: npm run typecheck
-
-      - name: Build
-        run: npm run build
 
       - name: Run tests
         run: npm test
 
-      - name: Get current version
-        id: current_version
-        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
-
-      - name: Calculate next version
-        id: next_version
-        run: |
-          CURRENT="${{ steps.current_version.outputs.version }}"
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
-
-          # Patch 버전 증가
-          PATCH=$((PATCH + 1))
-
-          # Patch가 10 이상이면 Minor 증가, Patch는 0
-          if [ $PATCH -ge 10 ]; then
-            PATCH=0
-            MINOR=$((MINOR + 1))
-          fi
-
-          # Minor가 10 이상이면 Major 증가, Minor는 0
-          if [ $MINOR -ge 10 ]; then
-            MINOR=0
-            MAJOR=$((MAJOR + 1))
-          fi
-
-          NEXT_VERSION="$MAJOR.$MINOR.$PATCH"
-          echo "version=$NEXT_VERSION" >> $GITHUB_OUTPUT
-          echo "Current: $CURRENT → Next: $NEXT_VERSION"
-
-      - name: Update package.json version
-        run: |
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
-            pkg.version = '${{ steps.next_version.outputs.version }}';
-            fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-
-      - name: Verify build with new version
+      - name: Build
         run: npm run build
 
-      - name: Commit and tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit version bump
+        if: steps.version.outputs.should_bump == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json
-          git commit -m "chore: release v${{ steps.next_version.outputs.version }}"
-          git tag "v${{ steps.next_version.outputs.version }}"
-          git push origin main
-          git push origin "v${{ steps.next_version.outputs.version }}"
-
-      - name: Setup npm registry
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.15.0
-          registry-url: https://registry.npmjs.org
-          cache: npm
+          git add package.json package-lock.json
+          git commit -m "chore: release ${{ steps.version.outputs.tag }}"
+          git push origin HEAD:main
 
       - name: Publish to npm
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Create Release
+      - name: Create GitHub release
         run: |
-          gh release create "v${{ steps.next_version.outputs.version }}" \
-            --title "Release v${{ steps.next_version.outputs.version }}" \
+          RELEASE_SHA="$(git rev-parse HEAD)"
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --target "$RELEASE_SHA" \
+            --title "Release ${{ steps.version.outputs.tag }}" \
             --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,3 +36,5 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@
 
 ## 🔔 업데이트 안내
 
-`claude` 어댑터가 포함된 새 버전을 사용하려면, 설치된 detoks를 최신 릴리스로 업데이트하세요.
+`0.2.0` 릴리스는 기존 `main`의 `0.1.2` 대비 로컬 LLM 런타임과 RAG/TUI 흐름이 크게 바뀝니다.
+기존 detoks 설정 파일이 있는 사용자는 새 버전 실행 시 CLI에서 업데이트 안내를 1회 확인할 수 있습니다.
+
+주요 변경점:
+
+- 로컬 LLM 실행이 `node-llama-cpp` Node.js 네이티브 바인딩 기반으로 변경되었습니다.
+- 별도 `llama-server` 실행이나 Python 런타임 없이 GGUF 모델을 Node.js 프로세스 안에서 로드합니다.
+- RAG 의미 검색, Cross-Session Cache, TUI/embedded PTY 흐름이 강화되었습니다.
 
 - 전역 설치: `npm install -g @sorlros/detoks@latest`
 - 전역 업데이트: `npm update -g @sorlros/detoks`
@@ -30,6 +37,7 @@ detoks는 `codex`, `gemini`, `claude` 같은 LLM CLI 앞단에서 동작하는 *
 - adapter / subprocess 경계 분리: `codex` / `gemini` / `claude`
 - `stub` / `real` 실행 모드
 - 세션 저장 및 재개 기반 워크플로우 (checkpoint 지원)
+- **로컬 LLM 런타임**: `node-llama-cpp` Node.js 네이티브 바인딩으로 GGUF 모델을 in-process 로드
 - **RAG 시스템**: 세션 간 컨텍스트 재사용, 의미 검색, 실패 패턴 인식
 - **캐시 시스템**: Cross-Session Cache, 해시 기반 유효성 검사, `/cache` REPL 명령
 - **TUI 모드** (전체 화면):
@@ -45,6 +53,7 @@ detoks는 `codex`, `gemini`, `claude` 같은 LLM CLI 앞단에서 동작하는 *
 - Node.js `>=24.15.0 <26`
 - `codex`, `gemini`, 또는 `claude` CLI: 해당 adapter를 사용할 때
 - 로컬 모델 추론 사용 시: `node-llama-cpp`에서 로드 가능한 GGUF 모델
+- 로컬 LLM 실행은 Node.js 프로세스 안에서 처리되며, 별도 `llama-server` 실행이나 Python 런타임이 필요하지 않습니다.
 
 자세한 버전 기준은 [STACK_VERSIONS.md](./docs/STACK_VERSIONS.md)와 [LLAMA_CPP_SERVER_SPEC.md](./docs/LLAMA_CPP_SERVER_SPEC.md)를 참고하세요.
 
@@ -136,18 +145,45 @@ TUI 키보드 단축키:
 |------|------|--------|
 | `DETOKS_THEME` | TUI 테마: `dark` / `light` / `colorblind` | `dark` |
 | `DETOKS_NERD_FONT` | Nerd Font 아이콘 활성화 (`1` = on) | `0` |
+| `LOCAL_LLM_RUNTIME_PROVIDER` | 로컬 LLM 런타임 provider. 현재 `node-llama-cpp`만 지원 | `node-llama-cpp` |
+| `LOCAL_LLM_MODEL_NAME` | 로컬 LLM 모델 이름 | `unsloth/Qwen3.5-4B-GGUF` |
+| `LOCAL_LLM_MODEL_PATH` | 직접 지정한 GGUF 모델 파일 경로 | 없음 |
+| `LOCAL_LLM_MODEL_DIR` | GGUF 모델 캐시 디렉터리 | `~/.detoks/models/llm/<repo>` |
+| `LOCAL_LLM_HF_REPO` | Hugging Face GGUF repo와 quantization | `unsloth/Qwen3.5-4B-GGUF:Q4_K_M` |
+| `LOCAL_LLM_HF_FILE` | 로드할 GGUF 파일명 | `Qwen3.5-4B-Q4_K_M.gguf` |
+| `LOCAL_LLM_CONTEXT_SIZE` | 로컬 LLM context size | `4096` |
+| `LOCAL_LLM_MAX_TOKENS` | 로컬 LLM 기본 생성 토큰 수 | `512` |
+| `RAG_ENABLED` | RAG 비활성화 플래그 (`0` = off) | 모델 존재 시 on |
+| `RAG_EMBEDDING_MODEL_PATH` | RAG 임베딩 GGUF 모델 경로 | `~/.detoks/models/embedding/mykor-KURE-v1-gguf/KURE-v1-Q4_K_M.gguf` |
+| `DETOKS_CACHE_DISABLED` | Cross-session cache 비활성화 (`1` = off) | `0` |
 
 ## detoks가 해주는 일
 
 1. 입력을 작업 단위로 정리
 2. task graph와 의존성을 구성
 3. 현재 실행에 필요한 context만 주입 (RAG 의미 검색으로 세션 간 재사용)
-4. adapter / subprocess boundary를 통해 실행
+4. adapter / subprocess boundary 또는 `node-llama-cpp` in-process 런타임을 통해 실행
 5. 결과를 세션에 저장해 다음 실행에서 재사용 (캐시 + 패턴 학습)
 
 ## 변경 이력
 
-### 개발 버전 (dev — 다음 릴리스 예정)
+### 0.2.0 (main 병합 예정)
+
+**이전 main(0.1.2) 대비 핵심 변화**
+- 패키지 버전이 `0.1.2`에서 `0.2.0`으로 올라갑니다.
+- 로컬 LLM 실행 경로가 외부 `llama.cpp` / `llama-server` 프로세스 중심에서 `node-llama-cpp` Node.js 네이티브 바인딩 기반 in-process 런타임으로 변경되었습니다.
+- 로컬 모델 추론에 Python 런타임 또는 Python helper 스크립트를 사용하지 않습니다.
+- `LOCAL_LLM_RUNTIME_PROVIDER`는 현재 `node-llama-cpp`만 허용하며, GGUF 모델은 `LOCAL_LLM_MODEL_PATH` 또는 `LOCAL_LLM_MODEL_DIR` + `LOCAL_LLM_HF_FILE` 기준으로 로드합니다.
+- `node-llama-cpp`, `better-sqlite3`, `sqlite-vec`, `node-pty`가 런타임 의존성으로 추가되어 로컬 GGUF 추론, RAG 벡터 검색, embedded TUI/PTY 흐름을 지원합니다.
+- `add:py` 계열 Python 의존성 관리 스크립트가 제거되고, Node.js/TypeScript 중심의 build·test·packaging 흐름으로 정리되었습니다.
+- `main` push 이후 GitHub Release 및 npm publish가 연동되도록 릴리즈 자동화가 업데이트되었습니다.
+
+**로컬 LLM 런타임**
+- `node-llama-cpp`로 GGUF 모델을 Node.js 프로세스 안에서 직접 로드
+- 외부 OpenAI-compatible HTTP `llama-server` fallback 미지원
+- 기본 모델: `unsloth/Qwen3.5-4B-GGUF` / `Qwen3.5-4B-Q4_K_M.gguf`
+- 모델 선택 UI에서 내장 GGUF 모델 또는 사용자 지정 Hugging Face GGUF 파일 선택 가능
+- KURE-v1 GGUF 임베딩 모델 기반 RAG 인덱싱 지원
 
 **TUI 대폭 개선**
 - 테마 시스템: `dark` / `light` / `colorblind` 내장 팔레트 + `DETOKS_THEME` 환경 변수
@@ -187,7 +223,7 @@ TUI 키보드 단축키:
 - `claude` 어댑터 추가 (`codex`, `gemini`에 이어 세 번째 공식 어댑터)
 - task type 세션 결과 영속 (재시작 후에도 task 분류 유지)
 - codex reasoning flow 개선
-- node-llama-cpp 기반 로컬 모델 실행 (GGUF)
+- 초기 로컬 `llama-server` 연동 기반 Role 1 번역 파이프라인
 - TUI 기반 구축: embedded PTY, 실시간 스트리밍, 한글 IME 입력 처리
 - 세션 checkpoint 저장 및 재개 (list / continue / fork / restore)
 - Role 1 번역 파이프라인 + Guardrails 출력 검증
@@ -198,16 +234,12 @@ TUI 키보드 단축키:
 - [PIPELINE.md](./docs/PIPELINE.md)
 - [PROJECT_STRUCTURE.md](./docs/PROJECT_STRUCTURE.md)
 - [STACK_VERSIONS.md](./docs/STACK_VERSIONS.md)
+- [LLAMA_CPP_SERVER_SPEC.md](./docs/LLAMA_CPP_SERVER_SPEC.md)
 - [DEPENDENCY_WORKFLOW.md](./docs/DEPENDENCY_WORKFLOW.md)
 - [TESTING_GUIDE.md](./docs/TESTING_GUIDE.md)
 - [ROLES.md](./docs/ROLES.md)
 - [ENGINEERING_GUIDELINES.md](./docs/ENGINEERING_GUIDELINES.md)
 - [SCHEMAS.md](./docs/SCHEMAS.md)
-
-## Windows 사용
-
-Windows native 실행은 지원하지 않으며, WSL Ubuntu에서 실행합니다.
-자세한 설치/실행 절차는 [README.ko.md](./README.ko.md) 및 [LLAMA_CPP_SERVER_SPEC.md](./docs/LLAMA_CPP_SERVER_SPEC.md)를 참고하세요.
 
 ## Authors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sorlros/detoks",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sorlros/detoks",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "better-sqlite3": "^12.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sorlros/detoks",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "private": false,
   "type": "module",
   "bin": {

--- a/src/cli/runtime-notice.ts
+++ b/src/cli/runtime-notice.ts
@@ -17,6 +17,13 @@ export interface RuntimeNoticeDependencies {
   log?: (message: string) => void;
 }
 
+const RELEASE_NOTICE_LINES = [
+  "주요 변경점:",
+  "- 로컬 LLM 실행이 node-llama-cpp Node.js 네이티브 바인딩 기반으로 변경되었습니다.",
+  "- 별도 llama-server 실행이나 Python 런타임 없이 GGUF 모델을 in-process로 로드합니다.",
+  "- RAG 의미 검색, Cross-Session Cache, TUI/embedded PTY 흐름이 강화되었습니다.",
+];
+
 const PACKAGE_JSON_CANDIDATES = [
   join(dirname(fileURLToPath(import.meta.url)), "../../package.json"),
   join(dirname(fileURLToPath(import.meta.url)), "../../../package.json"),
@@ -69,7 +76,8 @@ export const maybeShowRuntimeUpdateNotice = (
   log(
     [
       "",
-      `detoks ${packageMetadata.version}에 Claude adapter가 포함된 새 버전이 배포되었습니다.`,
+      `detoks ${packageMetadata.version} 업데이트 안내`,
+      ...RELEASE_NOTICE_LINES,
       `업데이트: npm install -g ${packageMetadata.name}@latest`,
     ].join("\n"),
   );

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,1 @@
-export const DETOKS_VERSION = "0.1.2";
+export const DETOKS_VERSION = "0.2.0";

--- a/tests/ts/unit/cli/runtime-notice.test.ts
+++ b/tests/ts/unit/cli/runtime-notice.test.ts
@@ -37,7 +37,9 @@ describe("maybeShowRuntimeUpdateNotice", () => {
     });
 
     expect(logs).toHaveLength(1);
-    expect(logs[0]).toContain("Claude adapter가 포함된 새 버전");
+    expect(logs[0]).toContain("detoks 0.1.0 업데이트 안내");
+    expect(logs[0]).toContain("node-llama-cpp Node.js 네이티브 바인딩");
+    expect(logs[0]).toContain("llama-server 실행이나 Python 런타임 없이");
     expect(logs[0]).toContain("npm install -g detoks@latest");
     expect(seenVersion).toBe("0.1.0");
   });


### PR DESCRIPTION
## 개요

  detoks 릴리즈 준비를 위해 패키지 버전을 `0.2.0`으로 명시하고, `main` 브랜치 push 이후 GitHub Release 및 npm
  publish가 연동되도록 릴리즈 워크플로우를 정리했습니다.

  ## 변경 사항

  - `package.json`, `package-lock.json` 버전을 `0.2.0`으로 업데이트
  - `main` 브랜치 push 시 릴리즈 버전을 해석하는 자동 릴리즈 워크플로우 개선
    - 현재 `package.json` 버전의 태그가 없으면 해당 버전으로 릴리즈
    - 이미 태그가 존재하면 다음 patch 버전으로 자동 증가
    - patch가 10 이상이면 minor 증가, minor가 10 이상이면 major 증가
  - 자동 버전 증가 시 `package.json`과 `package-lock.json`을 함께 갱신하도록 수정
  - 릴리즈 전 검증 순서 정리
    - 버전 일치 검증
    - typecheck
    - test
    - build
  - npm publish 단계에 `NODE_AUTH_TOKEN` 설정 추가
  - GitHub Release 생성 시 실제 릴리즈 대상 SHA를 명시하도록 수정

  ## 변경 파일

  - `.github/workflows/auto-release.yml`
  - `.github/workflows/publish.yml`
  - `package.json`
  - `package-lock.json`

  ## 검증

  - `npm test` 통과
  - `npm run typecheck` 통과
  - `npm run build` 통과
  - `npm pack --dry-run` 통과
  - `git diff --check` 통과

  ## 참고

  이 PR은 현재 `dev` 기준 코드에 릴리즈 준비 변경만 추가합니다.
  병합 후 `main`으로 반영되면 `v0.2.0` GitHub Release 및 npm publish 연동을 진행할 수 있습니다.

  현재 브랜치 기준 변경량은 4 files changed, 83 insertions(+), 63 deletions(-) 입니다.
