### PR TITLE
refactor: split TUI helper modules

### DIFF
--- a/src/cli/tui/index.ts
+++ b/src/cli/tui/index.ts
@@ -1,4 +1,3 @@
-import { execSync } from "node:child_process";
 import { stdout, stdin } from "node:process";
 import { StringDecoder } from "node:string_decoder";
 import type { CliArgs } from "../types.js";
@@ -94,7 +93,6 @@ import { buildActionTimeline } from "../../core/timeline/action-timeline.js";
 import { readRole1ModelName, loadRole1RuntimeConfig } from "../../core/prompt/config.js";
 import { ensureLocalLlmRuntime } from "../../core/llm-client/local-runtime.js";
 import { onLlamaBuildPhase } from "../../core/llm-client/llama-build-events.js";
-import type { TokenReductionSnapshot } from "../../core/utils/tokenMetrics.js";
 import { statusColor } from "./design/tokens.js";
 import { formatError } from "../format.js";
 import {
@@ -107,6 +105,12 @@ import {
 import { loadAndApplyConfig } from "../config/loader.js";
 import type { PipelineProgressEvent } from "../../core/pipeline/types.js";
 import type { PtySessionController } from "../../integrations/subprocess/types.js";
+import {
+  formatCacheHitBadge,
+  formatTokenSavingsBadge,
+  resolveFooterBranchLabel,
+  truncateToDisplayWidth,
+} from "./run-view-helpers.js";
 
 interface TuiRunOptions {
   adapter: CliArgs["adapter"];
@@ -141,53 +145,6 @@ interface StickyPromptState {
   prompt: string;
   status: RunBlockStatus;
 }
-
-const truncateToDisplayWidth = (text: string, width: number): string => {
-  if (width <= 0) {
-    return "";
-  }
-
-  const [firstLine = ""] = wrapTextToDisplayWidth(text, width);
-  return firstLine;
-};
-
-const formatTokenSavingsBadge = (reduction?: TokenReductionSnapshot | null): string | undefined => {
-  if (!reduction) {
-    return undefined;
-  }
-
-  const percent = Math.max(0, Math.round(reduction.savedPercent));
-  return `tok -${percent}%`;
-};
-
-const formatCacheHitBadge = (cacheHit: import("../../core/pipeline/types.js").CacheHitInfo): string => {
-  const ageDays = Math.round(cacheHit.cacheAge / (24 * 60 * 60 * 1000));
-  const ageLabel = ageDays === 0 ? "오늘" : `${ageDays}일 전`;
-  const kindLabel = cacheHit.kind === "session" ? "세션" : "task";
-  return `cache hit(${kindLabel} · ${ageLabel})`;
-};
-
-const resolveFooterBranchLabel = (cwd: string): string | undefined => {
-  try {
-    const branch = execSync("git symbolic-ref --short HEAD", {
-      cwd,
-      stdio: ["ignore", "pipe", "ignore"],
-      encoding: "utf8",
-    }).trim();
-    return branch.length > 0 ? branch : undefined;
-  } catch {}
-
-  try {
-    const detachedHead = execSync("git rev-parse --short HEAD", {
-      cwd,
-      stdio: ["ignore", "pipe", "ignore"],
-      encoding: "utf8",
-    }).trim();
-    return detachedHead.length > 0 ? `detached@${detachedHead}` : undefined;
-  } catch {
-    return undefined;
-  }
-};
 
 export const runTuiRepl = async (options: TuiRunOptions): Promise<void> => {
   const screen = createScreenManager(stdout, stdin);

--- a/src/cli/tui/panels/embedded-terminal-activity.ts
+++ b/src/cli/tui/panels/embedded-terminal-activity.ts
@@ -1,0 +1,98 @@
+export type EmbeddedActivityKind = "file" | "read" | "edit" | "search" | "tool" | "test" | "git" | "command";
+
+export interface EmbeddedActivitySnapshot {
+  kind: EmbeddedActivityKind;
+  label: string;
+  detail: string;
+  status: "running" | "completed" | "failed";
+}
+
+const extractShellPayload = (commandLine: string): string => {
+  const trimmed = commandLine.trim();
+  const shellMatch = trimmed.match(/\s-lc\s+(?:"((?:\\.|[^"\\])*)"|'([^']*)'|(\S.*?))(?:\s+in\s+\/.*)?$/);
+  if (shellMatch) {
+    return (shellMatch[1] ?? shellMatch[2] ?? shellMatch[3] ?? trimmed)
+      .replace(/\\"/g, "\"")
+      .replace(/\\'/g, "'")
+      .trim();
+  }
+
+  return trimmed.replace(/\s+in\s+\/.*$/, "").trim();
+};
+
+export const extractCommandName = (commandLine: string): string => {
+  const target = extractShellPayload(commandLine);
+  const firstToken = target.split(/\s+/)[0] ?? target;
+  const basename = firstToken.split("/").pop() ?? firstToken;
+  return basename.length > 0 ? basename : "command";
+};
+
+const extractPathCandidate = (commandLine: string): string | null => {
+  const payload = extractShellPayload(commandLine);
+  const pathMatches = payload.match(/(?:~\/|\/|\.\.?\/)[^\s"'`]+/g);
+  const likelyPath = [...payload.split(/\s+/).filter(Boolean)].reverse().find((token) =>
+    /[./]/.test(token) && /\.(?:[cm]?[jt]sx?|json|md|yml|yaml|toml|lock|txt|css|html|py|rs|go|java|swift)$/i.test(token),
+  );
+  if (pathMatches !== null && pathMatches.length > 0) {
+    const lastPathMatch = (pathMatches[pathMatches.length - 1] ?? "").replace(/[;:,]+$/, "");
+    if (likelyPath !== undefined && likelyPath.length > lastPathMatch.length) {
+      return likelyPath;
+    }
+    return lastPathMatch.length > 0 ? lastPathMatch : likelyPath ?? null;
+  }
+
+  return likelyPath?.replace(/[;:,]+$/, "") ?? null;
+};
+
+const extractSearchQuery = (commandLine: string): string | null => {
+  const payload = extractShellPayload(commandLine);
+  const quoted = payload.match(/\b(?:rg|grep)\b(?:\s+-\S+)*\s+(?:"([^"]+)"|'([^']+)')/i);
+  if (quoted) {
+    return quoted[1] ?? quoted[2] ?? null;
+  }
+
+  const tokens = payload.split(/\s+/).filter(Boolean);
+  const commandIndex = tokens.findIndex((token) => /^(rg|grep)$/i.test(token.split("/").pop() ?? token));
+  if (commandIndex >= 0) {
+    return tokens.slice(commandIndex + 1).find((token) => !token.startsWith("-"))?.replace(/[;:,]+$/, "") ?? null;
+  }
+
+  return null;
+};
+
+export const describeCommandActivity = (commandLine: string): Omit<EmbeddedActivitySnapshot, "status"> => {
+  const payload = extractShellPayload(commandLine);
+  const commandName = extractCommandName(commandLine);
+  const path = extractPathCandidate(commandLine);
+
+  if (/\b(sed|cat|less|head|tail)\b/i.test(payload) && path !== null) {
+    return { kind: "file", label: "파일 읽기", detail: path };
+  }
+
+  if (/\b(rg|grep|find)\b/i.test(payload)) {
+    const query = extractSearchQuery(commandLine);
+    return { kind: "search", label: "검색", detail: query ?? payload };
+  }
+
+  if (/\b(git)\b/i.test(payload)) {
+    return { kind: "git", label: "Git", detail: payload };
+  }
+
+  if (/\b(npm|npx|pnpm|yarn|node)\b/i.test(payload) && /\b(test|vitest|tsc|build)\b/i.test(payload)) {
+    return { kind: "test", label: "검증", detail: payload };
+  }
+
+  return { kind: "command", label: "명령 실행", detail: commandName };
+};
+
+export const statusFromCommandStatusLine = (statusLine: string | null): EmbeddedActivitySnapshot["status"] => {
+  if (statusLine === null) {
+    return "running";
+  }
+
+  if (/^succeeded in/i.test(statusLine)) {
+    return "completed";
+  }
+
+  return "failed";
+};

--- a/src/cli/tui/panels/embedded-terminal.ts
+++ b/src/cli/tui/panels/embedded-terminal.ts
@@ -16,6 +16,14 @@ import {
 import type { CodexStructuredLine } from "./codex-json.js";
 import type { TerminalCell, TerminalCellStyle, TerminalColor } from "../terminal-emulator.js";
 import { TerminalEmulatorBuffer, getCharacterDisplayWidth } from "../terminal-emulator.js";
+import {
+  describeCommandActivity,
+  extractCommandName,
+  statusFromCommandStatusLine,
+  type EmbeddedActivityKind,
+  type EmbeddedActivitySnapshot,
+} from "./embedded-terminal-activity.js";
+export type { EmbeddedActivityKind, EmbeddedActivitySnapshot } from "./embedded-terminal-activity.js";
 
 // Larger than the terminal-emulator default (200) to retain full LLM session output.
 const EMBEDDED_PANE_SCROLLBACK_LIMIT = 500;
@@ -234,15 +242,6 @@ interface RenderedRowInfo {
   globalRow: number;
 }
 
-export type EmbeddedActivityKind = "file" | "read" | "edit" | "search" | "tool" | "test" | "git" | "command";
-
-export interface EmbeddedActivitySnapshot {
-  kind: EmbeddedActivityKind;
-  label: string;
-  detail: string;
-  status: "running" | "completed" | "failed";
-}
-
 export interface EmbeddedInteractionState {
   kind: "none" | "approval";
   label: string;
@@ -305,96 +304,6 @@ const classifyNarrativeActivityTitle = (
     return { kind: "bash", icon: glyph.execDone, style: statusColor.header };
   }
   return null;
-};
-
-const extractCommandName = (commandLine: string): string => {
-  const target = extractShellPayload(commandLine);
-  const firstToken = target.split(/\s+/)[0] ?? target;
-  const basename = firstToken.split("/").pop() ?? firstToken;
-  return basename.length > 0 ? basename : "command";
-};
-
-const extractShellPayload = (commandLine: string): string => {
-  const trimmed = commandLine.trim();
-  const shellMatch = trimmed.match(/\s-lc\s+(?:"((?:\\.|[^"\\])*)"|'([^']*)'|(\S.*?))(?:\s+in\s+\/.*)?$/);
-  if (shellMatch) {
-    return (shellMatch[1] ?? shellMatch[2] ?? shellMatch[3] ?? trimmed)
-      .replace(/\\"/g, "\"")
-      .replace(/\\'/g, "'")
-      .trim();
-  }
-
-  return trimmed.replace(/\s+in\s+\/.*$/, "").trim();
-};
-
-const extractPathCandidate = (commandLine: string): string | null => {
-  const payload = extractShellPayload(commandLine);
-  const pathMatches = payload.match(/(?:~\/|\/|\.\.?\/)[^\s"'`]+/g);
-  const likelyPath = [...payload.split(/\s+/).filter(Boolean)].reverse().find((token) =>
-    /[./]/.test(token) && /\.(?:[cm]?[jt]sx?|json|md|yml|yaml|toml|lock|txt|css|html|py|rs|go|java|swift)$/i.test(token),
-  );
-  if (pathMatches !== null && pathMatches.length > 0) {
-    const lastPathMatch = (pathMatches[pathMatches.length - 1] ?? "").replace(/[;:,]+$/, "");
-    if (likelyPath !== undefined && likelyPath.length > lastPathMatch.length) {
-      return likelyPath;
-    }
-    return lastPathMatch.length > 0 ? lastPathMatch : likelyPath ?? null;
-  }
-
-  return likelyPath?.replace(/[;:,]+$/, "") ?? null;
-};
-
-const extractSearchQuery = (commandLine: string): string | null => {
-  const payload = extractShellPayload(commandLine);
-  const quoted = payload.match(/\b(?:rg|grep)\b(?:\s+-\S+)*\s+(?:"([^"]+)"|'([^']+)')/i);
-  if (quoted) {
-    return quoted[1] ?? quoted[2] ?? null;
-  }
-
-  const tokens = payload.split(/\s+/).filter(Boolean);
-  const commandIndex = tokens.findIndex((token) => /^(rg|grep)$/i.test(token.split("/").pop() ?? token));
-  if (commandIndex >= 0) {
-    return tokens.slice(commandIndex + 1).find((token) => !token.startsWith("-"))?.replace(/[;:,]+$/, "") ?? null;
-  }
-
-  return null;
-};
-
-const describeCommandActivity = (commandLine: string): Omit<EmbeddedActivitySnapshot, "status"> => {
-  const payload = extractShellPayload(commandLine);
-  const commandName = extractCommandName(commandLine);
-  const path = extractPathCandidate(commandLine);
-
-  if (/\b(sed|cat|less|head|tail)\b/i.test(payload) && path !== null) {
-    return { kind: "file", label: "파일 읽기", detail: path };
-  }
-
-  if (/\b(rg|grep|find)\b/i.test(payload)) {
-    const query = extractSearchQuery(commandLine);
-    return { kind: "search", label: "검색", detail: query ?? payload };
-  }
-
-  if (/\b(git)\b/i.test(payload)) {
-    return { kind: "git", label: "Git", detail: payload };
-  }
-
-  if (/\b(npm|npx|pnpm|yarn|node)\b/i.test(payload) && /\b(test|vitest|tsc|build)\b/i.test(payload)) {
-    return { kind: "test", label: "검증", detail: payload };
-  }
-
-  return { kind: "command", label: "명령 실행", detail: commandName };
-};
-
-const statusFromCommandStatusLine = (statusLine: string | null): EmbeddedActivitySnapshot["status"] => {
-  if (statusLine === null) {
-    return "running";
-  }
-
-  if (/^succeeded in/i.test(statusLine)) {
-    return "completed";
-  }
-
-  return "failed";
 };
 
 const summarizeCommandActivity = (

--- a/src/cli/tui/run-view-helpers.ts
+++ b/src/cli/tui/run-view-helpers.ts
@@ -1,0 +1,51 @@
+import { execSync } from "node:child_process";
+import type { CacheHitInfo } from "../../core/pipeline/types.js";
+import type { TokenReductionSnapshot } from "../../core/utils/tokenMetrics.js";
+import { wrapTextToDisplayWidth } from "./renderer.js";
+
+export const truncateToDisplayWidth = (text: string, width: number): string => {
+  if (width <= 0) {
+    return "";
+  }
+
+  const [firstLine = ""] = wrapTextToDisplayWidth(text, width);
+  return firstLine;
+};
+
+export const formatTokenSavingsBadge = (reduction?: TokenReductionSnapshot | null): string | undefined => {
+  if (!reduction) {
+    return undefined;
+  }
+
+  const percent = Math.max(0, Math.round(reduction.savedPercent));
+  return `tok -${percent}%`;
+};
+
+export const formatCacheHitBadge = (cacheHit: CacheHitInfo): string => {
+  const ageDays = Math.round(cacheHit.cacheAge / (24 * 60 * 60 * 1000));
+  const ageLabel = ageDays === 0 ? "오늘" : `${ageDays}일 전`;
+  const kindLabel = cacheHit.kind === "session" ? "세션" : "task";
+  return `cache hit(${kindLabel} · ${ageLabel})`;
+};
+
+export const resolveFooterBranchLabel = (cwd: string): string | undefined => {
+  try {
+    const branch = execSync("git symbolic-ref --short HEAD", {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim();
+    return branch.length > 0 ? branch : undefined;
+  } catch {}
+
+  try {
+    const detachedHead = execSync("git rev-parse --short HEAD", {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim();
+    return detachedHead.length > 0 ? `detached@${detachedHead}` : undefined;
+  } catch {
+    return undefined;
+  }
+};

--- a/tests/ts/unit/cli/tui/panels/embedded-terminal-activity.test.ts
+++ b/tests/ts/unit/cli/tui/panels/embedded-terminal-activity.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeCommandActivity,
+  statusFromCommandStatusLine,
+} from "../../../../../../src/cli/tui/panels/embedded-terminal-activity.js";
+
+describe("embedded terminal activity helpers", () => {
+  it("classifies common shell commands", () => {
+    expect(describeCommandActivity(`/bin/zsh -lc "sed -n '1,20p' src/index.ts"`)).toMatchObject({
+      kind: "file",
+      label: "파일 읽기",
+      detail: "src/index.ts",
+    });
+
+    expect(describeCommandActivity(`/bin/zsh -lc "rg -n \\"ProjectMemory\\" src tests"`)).toMatchObject({
+      kind: "search",
+      label: "검색",
+      detail: "ProjectMemory",
+    });
+
+    expect(describeCommandActivity("git status --short")).toMatchObject({
+      kind: "git",
+      label: "Git",
+    });
+
+    expect(describeCommandActivity("npm test")).toMatchObject({
+      kind: "test",
+      label: "검증",
+    });
+  });
+
+  it("maps command status lines to activity status", () => {
+    expect(statusFromCommandStatusLine(null)).toBe("running");
+    expect(statusFromCommandStatusLine("succeeded in 10ms")).toBe("completed");
+    expect(statusFromCommandStatusLine("failed in 10ms")).toBe("failed");
+  });
+});

--- a/tests/ts/unit/cli/tui/run-view-helpers.test.ts
+++ b/tests/ts/unit/cli/tui/run-view-helpers.test.ts
@@ -1,0 +1,51 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  formatCacheHitBadge,
+  formatTokenSavingsBadge,
+  resolveFooterBranchLabel,
+  truncateToDisplayWidth,
+} from "../../../../../src/cli/tui/run-view-helpers.js";
+
+describe("TUI run view helpers", () => {
+  it("truncates text using display-width wrapping", () => {
+    expect(truncateToDisplayWidth("abcdef", 3)).toBe("abc");
+    expect(truncateToDisplayWidth("한글abc", 4)).toBe("한글");
+    expect(truncateToDisplayWidth("abc", 0)).toBe("");
+  });
+
+  it("formats token and cache badges", () => {
+    expect(formatTokenSavingsBadge({
+      originalTokens: 100,
+      optimizedTokens: 75,
+      savedTokens: 25,
+      savedPercent: 24.6,
+    })).toBe("tok -25%");
+
+    expect(formatCacheHitBadge({
+      kind: "session",
+      sourceSessionId: "s1",
+      cacheAge: 0,
+      tokensSaved: 12,
+    })).toBe("cache hit(세션 · 오늘)");
+
+    expect(formatCacheHitBadge({
+      kind: "task",
+      sourceSessionId: "s1",
+      sourceTaskId: "t1",
+      cacheAge: 2 * 24 * 60 * 60 * 1000,
+      tokensSaved: 12,
+    })).toBe("cache hit(task · 2일 전)");
+  });
+
+  it("returns undefined outside a git repository", () => {
+    const dir = mkdtempSync(join(tmpdir(), "detoks-tui-helper-"));
+    try {
+      expect(resolveFooterBranchLabel(dir)).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 개요

TUI REPL의 대형 파일에서 순수 helper 로직을 분리해 책임 범위를 줄이고, 기존 동작은 유지했습니다.

## 변경 사항

- `src/cli/tui/index.ts`의 run view helper를 `run-view-helpers.ts`로 분리
- embedded terminal의 command activity 분류 로직을 `embedded-terminal-activity.ts`로 분리
- 분리된 helper에 대한 단위 테스트 추가
- 기존 embedded terminal 렌더링/상호작용 동작은 변경하지 않음

## 검증

- `npx vitest run tests/ts/unit/cli/tui/run-view-helpers.test.ts tests/ts/unit/cli/tui/panels/embedded-terminal-activity.test.ts tests/ts/unit/cli/tui/panels/embedded-terminal.test.ts tests/ts/unit/cli/tui/embedded-terminal.test.ts --reporter=verbose`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check`

## 참고

- 로컬 `dev`를 `origin/dev`로 fast-forward 동기화한 뒤 생성한 브랜치입니다.
- `.worktrees/` untracked 파일은 unrelated라 건드리지 않았습니다.