### PR TITLE
refactor: split pipeline RAG display helpers

### DIFF
--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -64,6 +64,7 @@ import type {
 } from "./types.js";
 import { createActionTimelineEvent } from "../timeline/types.js";
 import type { ActionTimelineEvent } from "../timeline/types.js";
+import { extractRagMeta, toRagDisplayItem } from "./rag-display.js";
 
 const ADAPTER_MODEL_MAP: Record<string, string> = {
   claude: 'claude-3.5-sonnet',
@@ -293,47 +294,6 @@ function namespaceTaskGraphForTurn(
         depends_on: dependsOn,
       };
     }),
-  };
-}
-
-// RAG 메타데이터: Task 객체에서 task_results에 보존할 필드만 추출
-function extractRagMeta(task?: { title?: string; input_hash?: string; depends_on?: string[] }) {
-  if (!task) return {};
-  return {
-    ...(task.title !== undefined ? { title: task.title } : {}),
-    ...(task.input_hash !== undefined ? { input_hash: task.input_hash } : {}),
-    ...(task.depends_on !== undefined ? { depends_on: task.depends_on } : {}),
-  };
-}
-
-function normalizeRagPreview(content: string, maxLength = 80): string {
-  const normalized = content.replace(/\s+/g, " ").trim();
-  if (normalized.length <= maxLength) {
-    return normalized;
-  }
-  return `${normalized.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
-}
-
-function toRagDisplaySourceType(kind: RagSnippet["kind"]): RagContextDisplayItem["sourceType"] {
-  if (kind === "prompt") return "previous_request";
-  if (kind === "output") return "previous_output";
-  return "previous_task";
-}
-
-function toRagRelevance(distance: number): RagContextDisplayItem["relevance"] {
-  if (distance <= 0.35) return "high";
-  if (distance <= 0.65) return "medium";
-  return "low";
-}
-
-function toRagDisplayItem(snippet: RagSnippet): RagContextDisplayItem {
-  return {
-    sourceType: toRagDisplaySourceType(snippet.kind),
-    sessionId: snippet.session_id,
-    ...(snippet.task_id ? { taskId: snippet.task_id } : {}),
-    preview: normalizeRagPreview(snippet.content),
-    relevance: toRagRelevance(snippet.distance),
-    injected: false,
   };
 }
 

--- a/src/core/pipeline/rag-display.ts
+++ b/src/core/pipeline/rag-display.ts
@@ -1,0 +1,46 @@
+import type { RagSnippet } from "../rag/rag-context-loader.js";
+import type { RagContextDisplayItem } from "./types.js";
+
+export interface RagMetaSource {
+  title?: string;
+  input_hash?: string;
+  depends_on?: string[];
+}
+
+export const extractRagMeta = (task?: RagMetaSource): RagMetaSource => {
+  if (!task) return {};
+  return {
+    ...(task.title !== undefined ? { title: task.title } : {}),
+    ...(task.input_hash !== undefined ? { input_hash: task.input_hash } : {}),
+    ...(task.depends_on !== undefined ? { depends_on: task.depends_on } : {}),
+  };
+};
+
+export const normalizeRagPreview = (content: string, maxLength = 80): string => {
+  const normalized = content.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+};
+
+export const toRagDisplaySourceType = (kind: RagSnippet["kind"]): RagContextDisplayItem["sourceType"] => {
+  if (kind === "prompt") return "previous_request";
+  if (kind === "output") return "previous_output";
+  return "previous_task";
+};
+
+export const toRagRelevance = (distance: number): RagContextDisplayItem["relevance"] => {
+  if (distance <= 0.35) return "high";
+  if (distance <= 0.65) return "medium";
+  return "low";
+};
+
+export const toRagDisplayItem = (snippet: RagSnippet): RagContextDisplayItem => ({
+  sourceType: toRagDisplaySourceType(snippet.kind),
+  sessionId: snippet.session_id,
+  ...(snippet.task_id ? { taskId: snippet.task_id } : {}),
+  preview: normalizeRagPreview(snippet.content),
+  relevance: toRagRelevance(snippet.distance),
+  injected: false,
+});

--- a/tests/ts/unit/core/pipeline/rag-display.test.ts
+++ b/tests/ts/unit/core/pipeline/rag-display.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractRagMeta,
+  normalizeRagPreview,
+  toRagDisplayItem,
+  toRagDisplaySourceType,
+  toRagRelevance,
+} from "../../../../../src/core/pipeline/rag-display.js";
+
+describe("pipeline RAG display helpers", () => {
+  it("extracts only task metadata persisted for RAG", () => {
+    expect(extractRagMeta({
+      title: "Read docs",
+      input_hash: "abc",
+      depends_on: ["t1"],
+    })).toEqual({
+      title: "Read docs",
+      input_hash: "abc",
+      depends_on: ["t1"],
+    });
+
+    expect(extractRagMeta()).toEqual({});
+  });
+
+  it("normalizes previews and maps source/relevance labels", () => {
+    expect(normalizeRagPreview("  one\n two\tthree  ")).toBe("one two three");
+    expect(normalizeRagPreview("abcdefghijklmnopqrstuvwxyz", 10)).toBe("abcdefg...");
+
+    expect(toRagDisplaySourceType("prompt")).toBe("previous_request");
+    expect(toRagDisplaySourceType("output")).toBe("previous_output");
+    expect(toRagDisplaySourceType("task")).toBe("previous_task");
+
+    expect(toRagRelevance(0.35)).toBe("high");
+    expect(toRagRelevance(0.65)).toBe("medium");
+    expect(toRagRelevance(0.66)).toBe("low");
+  });
+
+  it("converts a snippet to a display item", () => {
+    expect(toRagDisplayItem({
+      id: "r1",
+      distance: 0.2,
+      kind: "task",
+      session_id: "s1",
+      task_id: "t1",
+      content: "previous task output",
+    })).toEqual({
+      sourceType: "previous_task",
+      sessionId: "s1",
+      taskId: "t1",
+      preview: "previous task output",
+      relevance: "high",
+      injected: false,
+    });
+  });
+});


### PR DESCRIPTION
## 개요

Pipeline orchestrator의 RAG 표시/메타데이터 helper를 별도 모듈로 분리해 orchestrator 책임 범위를 줄였습니다. 동작 변경 없이 기존 RAG context display item 변환과 task result 메타 보존 로직을 유지합니다.

## 변경 사항

- `extractRagMeta`, RAG preview/source/relevance/display item 변환 helper를 `src/core/pipeline/rag-display.ts`로 분리
- 분리된 helper에 대한 단위 테스트 추가
- `orchestrator.ts`는 helper import만 사용하도록 축소

## 검증

- `npx vitest run tests/ts/unit/core/pipeline/rag-display.test.ts tests/ts/unit/core/pipeline/orchestrator.test.ts tests/ts/unit/core/pipeline/orchestrator-rag-cache.test.ts --reporter=verbose`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check`

## 참고

- `dev` 기준 독립 브랜치입니다.
- `.worktrees/` untracked 파일은 unrelated라 건드리지 않았습니다.