### PR TITLE
refactor: split adapter CLI reference helpers

### DIFF
--- a/src/cli/repl-commands/adapter-cli-reference.ts
+++ b/src/cli/repl-commands/adapter-cli-reference.ts
@@ -1,0 +1,93 @@
+import type { Adapter } from "../../core/pipeline/types.js";
+import { colors } from "../colors.js";
+
+export interface AdapterLoginCommandSpec {
+  command: string;
+  args: string[];
+}
+
+interface AdapterCliReferenceSection {
+  title: string;
+  commands: string[];
+  note?: string;
+}
+
+export const getAdapterLoginCommandSpec = (
+  adapter: Adapter,
+): AdapterLoginCommandSpec => {
+  if (adapter === "codex") {
+    return { command: "codex", args: ["login"] };
+  }
+
+  if (adapter === "gemini") {
+    return { command: "gemini", args: [] };
+  }
+
+  return { command: "claude", args: ["auth", "login"] };
+};
+
+export const getLoginHint = (adapter: Adapter): string => {
+  const spec = getAdapterLoginCommandSpec(adapter);
+  return [spec.command, ...spec.args].join(" ").trim();
+};
+
+export const getLogoutHint = (adapter: Adapter): string =>
+  adapter === "claude" ? "claude auth logout" : `${adapter} logout`;
+
+const getAdapterCliReferenceSections = (): AdapterCliReferenceSection[] => [
+  {
+    title: "Codex CLI",
+    commands: [
+      "codex login",
+      "codex login status",
+      "codex debug models",
+      "codex /goal <objective>",
+      "codex /goal pause | resume | clear",
+      "codex logout",
+    ],
+    note: "로그인 / 상태 / 모델 조회 / 목표 관리(/goal)는 Codex 원본 CLI에서 처리합니다.",
+  },
+  {
+    title: "Gemini CLI",
+    commands: ["gemini"],
+    note: "인증 진입은 gemini로 하고, 모델 선택은 detoks /gms가 맡습니다.",
+  },
+  {
+    title: "Claude Code",
+    commands: [
+      "claude auth login",
+      "claude auth status --json",
+      "claude --model <model>",
+      "claude auth logout",
+    ],
+    note: "Claude는 auth 후 detoks /claude-models가 모델 선택을 맡고, 실행 시 --model로 전달됩니다.",
+  },
+];
+
+export const formatAdapterCliReference = (): string => {
+  const lines: string[] = [
+    "",
+    `${colors.title("외부 adapter CLI 참고")}`,
+    "",
+  ];
+
+  for (const section of getAdapterCliReferenceSections()) {
+    lines.push(`  ${colors.boldText(section.title)}`);
+    for (const command of section.commands) {
+      lines.push(`    ${colors.muted(command)}`);
+    }
+    if (section.note) {
+      lines.push(`    ${colors.muted(section.note)}`);
+    }
+    lines.push("");
+  }
+
+  lines.push(
+    colors.muted(
+      "  detoks 명령은 REPL 안에서, adapter CLI 원본 명령은 외부 터미널에서 사용하세요.",
+    ),
+  );
+  lines.push("");
+
+  return `${lines.join("\n")}\n`;
+};

--- a/src/cli/repl-commands/index.ts
+++ b/src/cli/repl-commands/index.ts
@@ -47,6 +47,13 @@ import {
 import { loadLastCustomModel, saveCustomModel } from "../model-setup/custom-store.js";
 import { parseHfRepoInput, listGgufFiles, HfRepoError } from "../model-setup/hf-repo.js";
 import { promptLine } from "../interactive/prompt-line.js";
+import {
+  formatAdapterCliReference,
+  getAdapterLoginCommandSpec,
+  getLoginHint,
+  getLogoutHint,
+} from "./adapter-cli-reference.js";
+export { formatAdapterCliReference, getAdapterLoginCommandSpec } from "./adapter-cli-reference.js";
 
 export interface SlashCommand {
   name: string;
@@ -209,92 +216,6 @@ export const isSlashCommand = (
   adapter: Adapter,
 ): boolean => {
   return input.startsWith("/") && getSlashCommand(input, adapter) !== null;
-};
-
-export const getAdapterLoginCommandSpec = (
-  adapter: Adapter,
-): { command: string; args: string[] } => {
-  if (adapter === "codex") {
-    return { command: "codex", args: ["login"] };
-  }
-
-  if (adapter === "gemini") {
-    return { command: "gemini", args: [] };
-  }
-
-  return { command: "claude", args: ["auth", "login"] };
-};
-
-const getLoginHint = (adapter: Adapter): string => {
-  const spec = getAdapterLoginCommandSpec(adapter);
-  return [spec.command, ...spec.args].join(" ").trim();
-};
-
-const getLogoutHint = (adapter: Adapter): string =>
-  adapter === "claude" ? "claude auth logout" : `${adapter} logout`;
-
-interface AdapterCliReferenceSection {
-  title: string;
-  commands: string[];
-  note?: string;
-}
-
-const getAdapterCliReferenceSections = (): AdapterCliReferenceSection[] => [
-  {
-    title: "Codex CLI",
-    commands: [
-      "codex login",
-      "codex login status",
-      "codex debug models",
-      "codex /goal <objective>",
-      "codex /goal pause | resume | clear",
-      "codex logout",
-    ],
-    note: "로그인 / 상태 / 모델 조회 / 목표 관리(/goal)는 Codex 원본 CLI에서 처리합니다.",
-  },
-  {
-    title: "Gemini CLI",
-    commands: ["gemini"],
-    note: "인증 진입은 gemini로 하고, 모델 선택은 detoks /gms가 맡습니다.",
-  },
-  {
-    title: "Claude Code",
-    commands: [
-      "claude auth login",
-      "claude auth status --json",
-      "claude --model <model>",
-      "claude auth logout",
-    ],
-    note: "Claude는 auth 후 detoks /claude-models가 모델 선택을 맡고, 실행 시 --model로 전달됩니다.",
-  },
-];
-
-export const formatAdapterCliReference = (): string => {
-  const lines: string[] = [
-    "",
-    `${colors.title("외부 adapter CLI 참고")}`,
-    "",
-  ];
-
-  for (const section of getAdapterCliReferenceSections()) {
-    lines.push(`  ${colors.boldText(section.title)}`);
-    for (const command of section.commands) {
-      lines.push(`    ${colors.muted(command)}`);
-    }
-    if (section.note) {
-      lines.push(`    ${colors.muted(section.note)}`);
-    }
-    lines.push("");
-  }
-
-  lines.push(
-    colors.muted(
-      "  detoks 명령은 REPL 안에서, adapter CLI 원본 명령은 외부 터미널에서 사용하세요.",
-    ),
-  );
-  lines.push("");
-
-  return `${lines.join("\n")}\n`;
 };
 
 const buildSlashCommandMenuOptions = (

--- a/tests/ts/unit/cli/repl-commands/adapter-cli-reference.test.ts
+++ b/tests/ts/unit/cli/repl-commands/adapter-cli-reference.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatAdapterCliReference,
+  getAdapterLoginCommandSpec,
+  getLoginHint,
+  getLogoutHint,
+} from "../../../../../src/cli/repl-commands/adapter-cli-reference.js";
+
+describe("adapter CLI reference helpers", () => {
+  it("maps adapters to login and logout hints", () => {
+    expect(getAdapterLoginCommandSpec("codex")).toEqual({
+      command: "codex",
+      args: ["login"],
+    });
+    expect(getAdapterLoginCommandSpec("gemini")).toEqual({
+      command: "gemini",
+      args: [],
+    });
+    expect(getAdapterLoginCommandSpec("claude")).toEqual({
+      command: "claude",
+      args: ["auth", "login"],
+    });
+
+    expect(getLoginHint("codex")).toBe("codex login");
+    expect(getLoginHint("gemini")).toBe("gemini");
+    expect(getLoginHint("claude")).toBe("claude auth login");
+
+    expect(getLogoutHint("codex")).toBe("codex logout");
+    expect(getLogoutHint("gemini")).toBe("gemini logout");
+    expect(getLogoutHint("claude")).toBe("claude auth logout");
+  });
+
+  it("formats the external adapter CLI reference", () => {
+    const reference = formatAdapterCliReference();
+
+    expect(reference).toContain("외부 adapter CLI 참고");
+    expect(reference).toContain("Codex CLI");
+    expect(reference).toContain("codex debug models");
+    expect(reference).toContain("Gemini CLI");
+    expect(reference).toContain("gemini");
+    expect(reference).toContain("Claude Code");
+    expect(reference).toContain("claude auth status --json");
+    expect(reference).toContain("detoks 명령은 REPL 안에서");
+  });
+});


### PR DESCRIPTION
## 개요

REPL slash command 본체에서 외부 adapter CLI 참고/로그인 힌트 로직을 별도 모듈로 분리했습니다. 명령 동작은 유지하면서 command handling 파일의 책임 범위를 줄였습니다.

## 변경 사항

- `getAdapterLoginCommandSpec`, login/logout hint, adapter CLI reference formatter를 `adapter-cli-reference.ts`로 분리
- 기존 `repl-commands/index.ts` export 호환 유지
- 분리된 helper에 대한 단위 테스트 추가

## 검증

- `npx vitest run tests/ts/unit/cli/repl-commands/adapter-cli-reference.test.ts tests/ts/unit/cli/repl.test.ts tests/ts/unit/cli/repl-adapter-auth.test.ts --reporter=verbose`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check`

## 참고

- `dev` 기준 독립 브랜치입니다.
- `.worktrees/` untracked 파일은 unrelated라 건드리지 않았습니다.