### PR TITLE
fix: cache/session safety 보강

### DIFF
--- a/src/core/cache/cache-validator.ts
+++ b/src/core/cache/cache-validator.ts
@@ -18,7 +18,13 @@ export function isSessionCacheValid(
   session: SessionState,
   opts: CacheValidationOpts = {},
 ): CacheValidity {
-  const { project_id, recencyDays = CACHE_TTL_DAYS, expected_adapter, expected_git_head } = opts;
+  const {
+    project_id,
+    recencyDays = CACHE_TTL_DAYS,
+    expected_adapter,
+    expected_adapter_model,
+    expected_git_head,
+  } = opts;
 
   if (project_id && session.shared_context.project_id !== project_id) return "skip";
 
@@ -35,6 +41,13 @@ export function isSessionCacheValid(
   // 구 세션(stamp 필드 없음)은 adapter/git_head 필드 자체가 없으므로 비교 없이 통과
   const ctx = session.shared_context as Record<string, unknown>;
   if (expected_adapter && ctx.adapter && ctx.adapter !== expected_adapter) return "advise";
+  if (
+    expected_adapter_model !== undefined &&
+    ctx.adapter_model !== undefined &&
+    ctx.adapter_model !== expected_adapter_model
+  ) {
+    return "advise";
+  }
   if (expected_git_head && ctx.git_head && ctx.git_head !== expected_git_head) return "advise";
 
   return "auto";
@@ -42,11 +55,20 @@ export function isSessionCacheValid(
 
 export function deriveAdviseReasons(
   ctx: Record<string, unknown>,
-  opts: Pick<CacheValidationOpts, "expected_adapter" | "expected_git_head">,
+  opts: Pick<CacheValidationOpts, "expected_adapter" | "expected_adapter_model" | "expected_git_head">,
 ): string[] {
   const reasons: string[] = [];
   if (opts.expected_adapter && ctx.adapter && ctx.adapter !== opts.expected_adapter) {
     reasons.push(`adapter 불일치: 저장 ${String(ctx.adapter)} → 현재 ${opts.expected_adapter}`);
+  }
+  if (
+    opts.expected_adapter_model !== undefined &&
+    ctx.adapter_model !== undefined &&
+    ctx.adapter_model !== opts.expected_adapter_model
+  ) {
+    reasons.push(
+      `adapter model 불일치: 저장 ${String(ctx.adapter_model)} → 현재 ${opts.expected_adapter_model}`,
+    );
   }
   if (opts.expected_git_head && ctx.git_head && ctx.git_head !== opts.expected_git_head) {
     const stored = String(ctx.git_head).slice(0, 7);
@@ -60,7 +82,7 @@ export function isTaskCacheValid(
   taskResult: Record<string, unknown>,
   opts: CacheValidationOpts = {},
 ): CacheValidity {
-  const { recencyDays = CACHE_TTL_DAYS, expected_adapter, expected_git_head } = opts;
+  const { recencyDays = CACHE_TTL_DAYS, expected_adapter, expected_adapter_model, expected_git_head } = opts;
 
   if (taskResult.success !== true) return "skip";
 
@@ -71,6 +93,13 @@ export function isTaskCacheValid(
 
   // 구 세션(stamp 필드 없음)은 비교 없이 통과
   if (expected_adapter && taskResult.adapter && taskResult.adapter !== expected_adapter) return "advise";
+  if (
+    expected_adapter_model !== undefined &&
+    taskResult.adapter_model !== undefined &&
+    taskResult.adapter_model !== expected_adapter_model
+  ) {
+    return "advise";
+  }
   if (expected_git_head && taskResult.git_head && taskResult.git_head !== expected_git_head) return "advise";
 
   return "auto";

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -371,6 +371,14 @@ function markTaskCompleted(
   };
 }
 
+function markTaskRunning(state: SessionState, taskId: string): SessionState {
+  return {
+    ...state,
+    current_task_id: taskId,
+    updated_at: new Date().toISOString(),
+  };
+}
+
 function markTaskFailed(
   state: SessionState,
   taskId: string,
@@ -733,6 +741,7 @@ export const orchestratePipeline = async (
     request.projectInfo?.projectId ??
     computeProjectId(request.userRequest.cwd ?? process.cwd());
   const gitHead = resolveGitHead(request.userRequest.cwd ?? process.cwd());
+  const adapterModel = request.env?.ADAPTER_MODEL ?? process.env.ADAPTER_MODEL ?? "";
 
   // ── F1: Cross-session input_hash cache bypass ────────────────────────────
   // stub 모드는 테스트/개발용이므로 캐시 우회 대상에서 제외
@@ -751,6 +760,7 @@ export const orchestratePipeline = async (
       ? isSessionCacheValid(cachedSession, {
           project_id: projectId,
           expected_adapter: request.adapter,
+          expected_adapter_model: adapterModel,
           ...(gitHead ? { expected_git_head: gitHead } : {}),
         })
       : "skip";
@@ -799,6 +809,7 @@ export const orchestratePipeline = async (
       const adviseCtx = cachedSession!.shared_context as Record<string, unknown>;
       const adviseReasons = deriveAdviseReasons(adviseCtx, {
         expected_adapter: request.adapter,
+        expected_adapter_model: adapterModel,
         ...(gitHead ? { expected_git_head: gitHead } : {}),
       });
       await emitActionTimelineWithLogging(
@@ -949,7 +960,6 @@ export const orchestratePipeline = async (
   PipelineTracer.startStage("TaskGraphBuilder");
   const compiledSentences = TaskSentenceSplitter.split(role2PromptInput.compiled_prompt);
   const rawGraph = TaskGraphProcessor.process(compiledSentences);
-  const adapterModel = request.env?.ADAPTER_MODEL ?? process.env.ADAPTER_MODEL ?? "";
   let graph = {
     ...rawGraph,
     tasks: rawGraph.tasks.map((task) => ({
@@ -1382,6 +1392,7 @@ export const orchestratePipeline = async (
           const f2Validity = cachedTask
             ? isTaskCacheValid(cachedTask.taskResult, {
                 expected_adapter: request.adapter,
+                expected_adapter_model: adapterModel,
                 ...(gitHead ? { expected_git_head: gitHead } : {}),
               })
             : "skip";
@@ -1411,6 +1422,7 @@ export const orchestratePipeline = async (
           if (f2Validity === "advise") {
             const f2AdviseReasons = deriveAdviseReasons(cachedTask!.taskResult, {
               expected_adapter: request.adapter,
+              expected_adapter_model: adapterModel,
               ...(gitHead ? { expected_git_head: gitHead } : {}),
             });
             await emitActionTimelineWithLogging(
@@ -1432,7 +1444,10 @@ export const orchestratePipeline = async (
           }
         }
 
-        // (4) ExecutionContext 생성
+        // (4) Running checkpoint — hard crash 후 F3 resume hint가 현재 task를 찾을 수 있게 저장
+        await saveSessionIfEnabled(markTaskRunning(stageBaseState, task.id));
+
+        // (5) ExecutionContext 생성
         await emitProgressWithLogging({
           stage: "Context Optimizer", status: "start", taskId: task.id,
           message: `Context Optimizer(${task.id}) 시작`,
@@ -1462,7 +1477,7 @@ export const orchestratePipeline = async (
           data: { tokensBeforeCompression, contextTokens, contextCompressionRepairActions: contextCompression.repairActions, compressedTaskIds, keptTaskIds },
         });
 
-        // (5) Budget Gate — stage 시작 시점 스냅샷 기준으로 결정
+        // (6) Budget Gate — stage 시작 시점 스냅샷 기준으로 결정
         const responseLanguageInstruction = compiledPrompt.language !== "en" ? "Respond entirely in Korean.\n\n" : "";
         const taskSnippets = perTaskSnippets.get(task.id) ?? [];
         const ragContextRaw = formatRagSnippetsForPrompt(taskSnippets);
@@ -1494,7 +1509,7 @@ export const orchestratePipeline = async (
           }
         }
 
-        // (6) LLM 실행
+        // (7) LLM 실행
         // embedded-pane: codex exec은 단순 작업 설명만 기대 — 구조화된 템플릿은 모델을 혼란시킴.
         // 다른 모드: 번역된 원본 명령 + RAG 컨텍스트 + 태스크 정보 포함.
         let prompt: string;

--- a/tests/ts/unit/core/cache/cache-validator.test.ts
+++ b/tests/ts/unit/core/cache/cache-validator.test.ts
@@ -63,6 +63,29 @@ describe("isSessionCacheValid", () => {
     expect(isSessionCacheValid(session, { expected_adapter: "claude" })).toBe("auto");
   });
 
+  it("adapter model 불일치 시 advise (stamp 있는 세션)", () => {
+    const session = makeSession({
+      shared_context: {
+        session_id: "s1",
+        project_id: "git-abc123",
+        adapter: "codex",
+        adapter_model: "old-model",
+      },
+    });
+    expect(isSessionCacheValid(session, { expected_adapter_model: "new-model" })).toBe("advise");
+  });
+
+  it("현재 adapter model이 기본값이어도 저장된 명시 model과 다르면 advise", () => {
+    const session = makeSession({
+      shared_context: {
+        session_id: "s1",
+        project_id: "git-abc123",
+        adapter_model: "old-explicit-model",
+      },
+    });
+    expect(isSessionCacheValid(session, { expected_adapter_model: "" })).toBe("advise");
+  });
+
   it("stamp 없는 구 세션은 adapter 불일치여도 auto (후방 호환)", () => {
     const session = makeSession(); // adapter stamp 없음
     expect(isSessionCacheValid(session, { expected_adapter: "claude" })).toBe("auto");
@@ -102,6 +125,15 @@ describe("isTaskCacheValid", () => {
 
   it("adapter 일치 시 auto", () => {
     expect(isTaskCacheValid({ success: true, adapter: "claude" }, { expected_adapter: "claude" })).toBe("auto");
+  });
+
+  it("adapter model 불일치 시 advise (stamp 있는 task)", () => {
+    expect(
+      isTaskCacheValid(
+        { success: true, adapter_model: "old-model" },
+        { expected_adapter_model: "new-model" },
+      ),
+    ).toBe("advise");
   });
 
   it("stamp 없는 구 task는 adapter 불일치여도 auto (후방 호환)", () => {

--- a/tests/ts/unit/core/pipeline/orchestrator.test.ts
+++ b/tests/ts/unit/core/pipeline/orchestrator.test.ts
@@ -136,6 +136,29 @@ describe("orchestratePipeline", () => {
     expect(savedState?.shared_context?.raw_input_hash).toBeUndefined();
   });
 
+  it("persists current_task_id before executing a task", async () => {
+    vi.spyOn(SessionStateManager, "sessionExists").mockResolvedValue(false);
+    const saveSessionSpy = vi
+      .spyOn(SessionStateManager, "saveSession")
+      .mockResolvedValue(undefined);
+
+    const result = await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "stub",
+      verbose: false,
+      userRequest: { raw_input: "running checkpoint test" },
+    });
+
+    expect(result.ok).toBe(true);
+    const runningState = saveSessionSpy.mock.calls
+      .map((call) => call[0] as any)
+      .find((state) => state.current_task_id === "t1");
+    expect(runningState).toBeDefined();
+    expect(runningState.completed_task_ids).toEqual([]);
+    expect(runningState.task_results).toEqual({});
+  });
+
   it("passes execution mode through to the executor boundary", async () => {
     vi.stubEnv("DETOKS_MEMORY", "off");
     executeWithAdapterMock.mockImplementationOnce(async (request) => {
@@ -848,6 +871,58 @@ describe("orchestratePipeline", () => {
     expect(result.cacheHit?.sourceSessionId).toBe("cached-session");
     expect(result.rawOutput).toContain("cached output");
     expect(executeWithAdapterMock).not.toHaveBeenCalled();
+  });
+
+  it("F1: adapter_model이 다르면 세션 캐시를 자동 적용하지 않고 새로 실행한다", async () => {
+    vi.stubEnv("RAG_ENABLED", "0");
+    vi.spyOn(SessionStateManager, "sessionExists").mockResolvedValue(false);
+    vi.spyOn(SessionStateManager, "saveSession").mockResolvedValue(undefined);
+    vi.spyOn(SessionStateManager, "findSuccessfulSessionByInputHash").mockResolvedValue({
+      shared_context: {
+        session_id: "cached-session-old-model",
+        raw_input_hash: "willbematched",
+        project_id: "git-test123",
+        adapter: "codex",
+        adapter_model: "old-model",
+        failed_task_ids: [],
+      },
+      task_results: {
+        t1: {
+          task_id: "t1",
+          success: true,
+          raw_output: "old model cached output",
+          summary: "old model cached output",
+        },
+      },
+      current_task_id: null,
+      completed_task_ids: ["t1"],
+      updated_at: new Date().toISOString(),
+    } as any);
+    executeWithAdapterMock.mockResolvedValueOnce({
+      ok: true,
+      adapter: "codex",
+      rawOutput: "fresh output",
+      exitCode: 0,
+    });
+
+    const result = await orchestratePipeline({
+      mode: "run",
+      adapter: "codex",
+      executionMode: "real",
+      verbose: false,
+      env: { ADAPTER_MODEL: "new-model" },
+      projectInfo: { projectId: "git-test123", projectPath: "/test", projectName: "test" },
+      userRequest: { raw_input: "cached prompt" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.cacheHit).toBeUndefined();
+    expect(result.rawOutput).toContain("fresh output");
+    expect(executeWithAdapterMock).toHaveBeenCalledTimes(1);
+    expect(result.actionTimeline?.some((event) =>
+      event.kind === "cache_advise" &&
+      event.details?.some((detail) => detail.includes("adapter model 불일치")),
+    )).toBe(true);
   });
 
   it("F1: 캐시된 multi-task 세션은 terminal task output만 반환한다", async () => {


### PR DESCRIPTION
## 개요

cache/RAG/session 점검에서 확인한 두 가지 안전성 개선점을 적용했습니다. F1 세션 캐시가 adapter model 차이를 무시하지 않도록 보강하고, task 실행 직전 현재 실행 중인 task를 session state에 기록해 crash 이후 resume hint 정확도를 높였습니다.

## 변경 사항

- F1/F2 cache validator에 adapter_model 불일치 검증 추가
- F1 session cache advise 사유에 adapter model mismatch 표시
- task 실행 전 current_task_id running checkpoint 저장
- adapter model cache mismatch 및 running checkpoint 단위 테스트 추가

## 검증

- npx vitest run tests/ts/unit/core/cache/cache-validator.test.ts tests/ts/unit/core/pipeline/orchestrator.test.ts tests/ts/unit/core/pipeline/orchestrator-rag-cache.test.ts tests/ts/unit/core/state/session-state-manager-cache.test.ts tests/ts/unit/core/state/session-state-manager-resume.test.ts --reporter=verbose
- npm run typecheck
- npm test
- npm run build
- git diff --check

## 참고

- dev 기준 독립 브랜치입니다.
- .worktrees/ untracked 파일은 unrelated라 건드리지 않았습니다.
